### PR TITLE
feat: add homebrew publishing script + action

### DIFF
--- a/.github/workflows/homebrew_release.yml
+++ b/.github/workflows/homebrew_release.yml
@@ -1,0 +1,25 @@
+name: Push Release to HomeBrew repository
+
+on:
+  workflow_dispatch:
+
+jobs:
+  push-release-homebrew:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        run: uv python install 3.13
+        shell: bash
+
+      - name: Push Release to HomeBrew repository
+        run: ./scripts/publish-to-homebrew-repo.sh
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_TOKEN }} # PAT with permissions to push to run-llama/homebrew-liteparse

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Dispatch post-publish workflow
+        if: steps.changesets.outputs.published == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'homebrew_release.yml',
+              ref: 'main',
+            })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ LiteParse is a standalone OSS PDF parsing tool focused exclusively on **fast and
 
 #### Option 1: Global Install (Recommended)
 
-Install globally via npm to use the `liteparse` command anywhere:
+Install globally via npm to use the `lit` command anywhere:
 
 ```bash
 npm i -g @llamaindex/liteparse
@@ -40,6 +40,13 @@ Then use it:
 ```bash
 lit parse document.pdf
 lit screenshot document.pdf
+```
+
+For macOS and Linux users, `liteparse` can be also installed via `brew`:
+
+```bash
+brew tap run-llama/liteparse
+brew install llamaindex-liteparse
 ```
 
 #### Option 2: Install from Source

--- a/scripts/publish-to-homebrew-repo.sh
+++ b/scripts/publish-to-homebrew-repo.sh
@@ -3,11 +3,14 @@
 echo "Installing homebrew-npm-noob tool"
 uv tool install --upgrade homebrew-npm-noob
 echo "Setting up repository locally"
-git clone https://github.com/run-llama/homebrew-liteparse
+git clone https://x-access-token:${GITHUB_TOKEN}@github.com/run-llama/homebrew-liteparse
 cd homebrew-liteparse
 mkdir -p Formula/
 echo "Generating HomeBrew Formula"
 noob @llamaindex/liteparse > Formula/llamaindex-liteparse.rb
+echo "Configuring GitHub user"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git config user.name "github-actions[bot]"
 echo "Pushing to GitHub"
 git add .
 git commit -m "Automated HomeBrew Release for liteparse"

--- a/scripts/publish-to-homebrew-repo.sh
+++ b/scripts/publish-to-homebrew-repo.sh
@@ -1,0 +1,17 @@
+#/bin/bash
+
+echo "Installing homebrew-npm-noob tool"
+uv tool install --upgrade homebrew-npm-noob
+echo "Setting up repository locally"
+git clone https://github.com/run-llama/homebrew-liteparse
+cd homebrew-liteparse
+mkdir -p Formula/
+echo "Generating HomeBrew Formula"
+noob @llamaindex/liteparse > Formula/llamaindex-liteparse.rb
+echo "Pushing to GitHub"
+git add .
+git commit -m "Automated HomeBrew Release for liteparse"
+git push -u origin main
+echo "Removing local copy"
+cd ..
+rm -rf homebrew-liteparse


### PR DESCRIPTION
- Add a script (`scripts/publish-to-homebrew-repo.sh`) to update the Homebrew formula for LiteParse in the dedicated repository (`run-llama/homebrew-liteparse`)
- Add a CI action to trigger HomeBrew publishing

