### PR TITLE
support input buffers as escape hatch for URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,32 @@ const result = await parser.parse('document.pdf');
 console.log(result.text);
 ```
 
+#### Buffer / Uint8Array Input
+
+You can pass raw bytes directly instead of a file path. PDF buffers are parsed with **zero disk I/O** — no temp files are written:
+
+```typescript
+import { LiteParse } from '@llamaindex/liteparse';
+import { readFile } from 'fs/promises';
+
+const parser = new LiteParse();
+
+// From a file read
+const pdfBytes = await readFile('document.pdf');
+const result = await parser.parse(pdfBytes);
+
+// From an HTTP response
+const response = await fetch('https://example.com/document.pdf');
+const buffer = Buffer.from(await response.arrayBuffer());
+const result2 = await parser.parse(buffer);
+```
+
+Non-PDF buffers (images, Office documents) are written to a temp directory for format conversion. Screenshots also work with buffer input:
+
+```typescript
+const screenshots = await parser.screenshot(pdfBytes, [1, 2, 3]);
+```
+
 ### CLI Options
 
 #### Parse Command
@@ -227,6 +253,19 @@ lit parse document.pdf --ocr-language fra
 lit parse document.pdf --no-ocr
 ```
 
+By default, Tesseract.js downloads language data from the internet on first use. For offline or air-gapped environments, set the `TESSDATA_PREFIX` environment variable to a directory containing pre-downloaded `.traineddata` files:
+
+```bash
+export TESSDATA_PREFIX=/path/to/tessdata
+lit parse document.pdf --ocr-language eng
+```
+
+You can also pass `tessdataPath` in the library config:
+
+```typescript
+const parser = new LiteParse({ tessdataPath: '/path/to/tessdata' });
+```
+
 ### Optional: HTTP OCR Servers
 
 For higher accuracy or better performance, you can use an HTTP OCR server. We provide ready-to-use example wrappers for popular OCR engines:
@@ -286,6 +325,13 @@ apt-get install imagemagick
 # Windows
 choco install imagemagick.app # might require admin permissions
 ```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `TESSDATA_PREFIX` | Path to a directory containing Tesseract `.traineddata` files. Used for offline/air-gapped environments where Tesseract.js cannot download language data from the internet. |
+| `LITEPARSE_TMPDIR` | Override the temp directory used for format conversion and intermediate files. Defaults to the OS temp directory (`os.tmpdir()`). Useful in containerized or read-only filesystem environments. |
 
 ## Configuration
 

--- a/docs/src/content/docs/liteparse/guides/library-usage.md
+++ b/docs/src/content/docs/liteparse/guides/library-usage.md
@@ -62,9 +62,30 @@ const parser = new LiteParse({
 });
 ```
 
+### Buffer / Uint8Array input
+
+You can pass raw bytes directly instead of a file path. PDF buffers are parsed with **zero disk I/O** — no temp files are written:
+
+```typescript
+import { readFile } from "fs/promises";
+
+const parser = new LiteParse();
+
+// From a file read
+const pdfBytes = await readFile("document.pdf");
+const result = await parser.parse(pdfBytes);
+
+// From an HTTP response
+const response = await fetch("https://example.com/document.pdf");
+const buffer = Buffer.from(await response.arrayBuffer());
+const result2 = await parser.parse(buffer);
+```
+
+Non-PDF buffers (images, Office documents) are written to a temp directory for format conversion. You can control the temp directory with the `LITEPARSE_TMPDIR` environment variable.
+
 ### Screenshots
 
-Generate page images as buffers — useful for sending to LLMs or saving to disk:
+Generate page images as buffers — useful for sending to LLMs or saving to disk. Accepts file paths, `Buffer`, or `Uint8Array`:
 
 ```typescript
 const parser = new LiteParse();
@@ -74,7 +95,18 @@ for (const shot of screenshots) {
   console.log(`Page ${shot.pageNum}: ${shot.width}x${shot.height}`);
   // shot.imageBuffer contains the raw PNG/JPG data
 }
+
+// Also works with buffer input
+const pdfBytes = await readFile("document.pdf");
+const shots = await parser.screenshot(pdfBytes, [1, 2, 3]);
 ```
+
+### Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `TESSDATA_PREFIX` | Path to a directory containing Tesseract `.traineddata` files. For offline/air-gapped environments. Also available as the `tessdataPath` config option. |
+| `LITEPARSE_TMPDIR` | Override the temp directory for format conversion. Defaults to `os.tmpdir()`. |
 
 See the [API reference](/liteparse/api/) for full type details.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@llamaindex/liteparse",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@llamaindex/liteparse",
-      "version": "0.1.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hyzyla/pdfium": "^2.1.9",
         "axios": "^1.7.0",
         "commander": "^12.0.0",
+        "file-type": "^21.3.3",
         "form-data": "^4.0.0",
         "p-limit": "^7.3.0",
         "sharp": "^0.34.5",
@@ -50,6 +51,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/@changesets/apply-release-plan": {
@@ -2090,6 +2100,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2778,7 +2809,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3365,6 +3395,23 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-type": {
+      "version": "21.3.3",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.3.tgz",
+      "integrity": "sha512-pNwbwz8c3aZ+GvbJnIsCnDjKvgCZLHxkFWLEFxU3RMa+Ey++ZSEfisvsWQMcdys6PpxQjWUOIDi1fifXsW3YRg==",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3652,6 +3699,25 @@
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
       "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -4010,7 +4076,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4720,6 +4785,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/strtok3": {
+      "version": "10.3.4",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
+      "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -4828,6 +4908,23 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/tr46": {
@@ -4993,6 +5090,17 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@hyzyla/pdfium": "^2.1.9",
     "axios": "^1.7.0",
     "commander": "^12.0.0",
+    "file-type": "^21.3.3",
     "form-data": "^4.0.0",
     "p-limit": "^7.3.0",
     "sharp": "^0.34.5",

--- a/src/conversion/README.md
+++ b/src/conversion/README.md
@@ -29,19 +29,31 @@ LiteParse's core parsing works on PDFs. This module extends support to 50+ forma
 
 **Key Functions:**
 
-`convertToPdf(filePath)` - Main entry point
+`convertToPdf(filePath)` - Main entry point for file path input
 - Returns `ConversionResult` with `pdfPath` and `originalExtension`
 - Returns `ConversionPassthrough` with `content` for text-based formats (e.g. .txt, .csv)
 - Returns `ConversionError` with `message` and `code` on failure
 - If already PDF, returns path unchanged
 
+`convertBufferToPdf(data)` - Entry point for buffer input
+- Detects format from magic bytes, writes to temp file, then delegates to `convertToPdf`
+- Used when `LiteParse.parse()` receives a non-PDF `Buffer` or `Uint8Array`
+
 `cleanupConversionFiles(pdfPath)` - Removes temp files after parsing
-- Only deletes files in system temp directory
+- Only deletes files in the configured temp directory (`LITEPARSE_TMPDIR` or OS default)
 - Called by `LiteParse.parse()` after processing
+
+`getTmpDir()` - Returns the temp directory for LiteParse operations
+- Respects the `LITEPARSE_TMPDIR` environment variable
+- Falls back to `os.tmpdir()`
 
 `guessFileExtension(filePath)` - Detects format from extension or magic bytes
 - Checks file extension first
 - Falls back to magic byte detection (PDF, PNG, JPEG, ZIP-based)
+
+`guessExtensionFromBuffer(data)` - Detects format from raw bytes using magic bytes
+- Supports PDF, PNG, JPEG, TIFF (both endians), and ZIP-based formats
+- Used by `convertBufferToPdf` to determine the temp file extension
 
 **Design Decisions:**
 
@@ -49,7 +61,7 @@ LiteParse's core parsing works on PDFs. This module extends support to 50+ forma
 
 2. **Subprocess-based**: Conversion runs as separate process to isolate crashes and memory issues.
 
-3. **Temporary file management**: Converted PDFs go to system temp directory, cleaned up after parsing.
+3. **Temporary file management**: Converted PDFs go to the configured temp directory (`LITEPARSE_TMPDIR` env var or OS default), cleaned up after parsing.
 
 4. **Timeout handling**: 2 minutes for LibreOffice, 1 minute for ImageMagick.
 

--- a/src/conversion/convertToPdf.test.ts
+++ b/src/conversion/convertToPdf.test.ts
@@ -1,3 +1,4 @@
+import os from "os";
 import { vi, describe, it, expect, afterEach } from "vitest";
 import { EventEmitter } from "events";
 
@@ -6,10 +7,22 @@ vi.mock("file-type", () => ({
   fileTypeFromFile: (...args: unknown[]) => mockFileTypeFromFile(...args),
   fileTypeFromBuffer: vi.fn(async (data: Buffer | Uint8Array) => {
     // Replicate enough detection to validate the wrapper
-    if (data.length >= 4 && data[0] === 0x25 && data[1] === 0x50 && data[2] === 0x44 && data[3] === 0x46) {
+    if (
+      data.length >= 4 &&
+      data[0] === 0x25 &&
+      data[1] === 0x50 &&
+      data[2] === 0x44 &&
+      data[3] === 0x46
+    ) {
       return { ext: "pdf", mime: "application/pdf" };
     }
-    if (data.length >= 8 && data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47) {
+    if (
+      data.length >= 8 &&
+      data[0] === 0x89 &&
+      data[1] === 0x50 &&
+      data[2] === 0x4e &&
+      data[3] === 0x47
+    ) {
       return { ext: "png", mime: "image/png" };
     }
     if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
@@ -316,7 +329,6 @@ describe("test getTmpDir", () => {
 
   it("falls back to os.tmpdir() when LITEPARSE_TMPDIR is not set", () => {
     delete process.env.LITEPARSE_TMPDIR;
-    const os = require("os");
     expect(getTmpDir()).toBe(os.tmpdir());
   });
 });

--- a/src/conversion/convertToPdf.test.ts
+++ b/src/conversion/convertToPdf.test.ts
@@ -1,10 +1,33 @@
 import { vi, describe, it, expect, afterEach } from "vitest";
 import { EventEmitter } from "events";
 
-const mockFd = {
-  read: vi.fn(),
-  close: vi.fn(),
-};
+const mockFileTypeFromFile = vi.fn();
+vi.mock("file-type", () => ({
+  fileTypeFromFile: (...args: unknown[]) => mockFileTypeFromFile(...args),
+  fileTypeFromBuffer: vi.fn(async (data: Buffer | Uint8Array) => {
+    // Replicate enough detection to validate the wrapper
+    if (data.length >= 4 && data[0] === 0x25 && data[1] === 0x50 && data[2] === 0x44 && data[3] === 0x46) {
+      return { ext: "pdf", mime: "application/pdf" };
+    }
+    if (data.length >= 8 && data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47) {
+      return { ext: "png", mime: "image/png" };
+    }
+    if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
+      return { ext: "jpg", mime: "image/jpeg" };
+    }
+    if (
+      data.length >= 4 &&
+      ((data[0] === 0x49 && data[1] === 0x49 && data[2] === 0x2a && data[3] === 0x00) ||
+        (data[0] === 0x4d && data[1] === 0x4d && data[2] === 0x00 && data[3] === 0x2a))
+    ) {
+      return { ext: "tif", mime: "image/tiff" };
+    }
+    if (data.length >= 4 && data[0] === 0x50 && data[1] === 0x4b) {
+      return { ext: "zip", mime: "application/zip" };
+    }
+    return undefined;
+  }),
+}));
 
 const mockProc = {
   stdout: new EventEmitter(),
@@ -22,9 +45,6 @@ vi.mock("fs", async () => {
   return {
     ...actual,
     promises: {
-      open: vi.fn(async () => {
-        return mockFd;
-      }),
       access: vi.fn(async (path: string, _mode?: number) => {
         console.log(path);
         const toErrorPath = [
@@ -62,20 +82,19 @@ import {
 } from "./convertToPdf";
 
 describe("test guessFileExtension", () => {
-  it("detects PDF", async () => {
-    mockFd.read.mockImplementation((buffer: Buffer) => {
-      Buffer.from("%PDF").copy(buffer);
-    });
-
+  it("detects PDF via file-type", async () => {
+    mockFileTypeFromFile.mockResolvedValue({ ext: "pdf", mime: "application/pdf" });
     expect(await guessFileExtension("/some/file")).toBe(".pdf");
   });
 
-  it("detects PNG", async () => {
-    mockFd.read.mockImplementation((buffer: Buffer) => {
-      Buffer.from([0x89, 0x50, 0x4e, 0x47]).copy(buffer);
-    });
-
+  it("detects PNG via file-type", async () => {
+    mockFileTypeFromFile.mockResolvedValue({ ext: "png", mime: "image/png" });
     expect(await guessFileExtension("/some/file")).toBe(".png");
+  });
+
+  it("defaults to .pdf when file-type returns undefined", async () => {
+    mockFileTypeFromFile.mockResolvedValue(undefined);
+    expect(await guessFileExtension("/some/file")).toBe(".pdf");
   });
 
   it("returns extension directly if present", async () => {
@@ -238,44 +257,44 @@ describe("test convertToPdf", () => {
 });
 
 describe("test guessExtensionFromBuffer", () => {
-  it("detects PDF from magic bytes", () => {
+  it("detects PDF from magic bytes", async () => {
     const pdfBytes = Buffer.from("%PDF-1.4 some content");
-    expect(guessExtensionFromBuffer(pdfBytes)).toBe(".pdf");
+    expect(await guessExtensionFromBuffer(pdfBytes)).toBe(".pdf");
   });
 
-  it("detects PNG from magic bytes", () => {
+  it("detects PNG from magic bytes", async () => {
     const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-    expect(guessExtensionFromBuffer(pngBytes)).toBe(".png");
+    expect(await guessExtensionFromBuffer(pngBytes)).toBe(".png");
   });
 
-  it("detects JPEG from magic bytes", () => {
+  it("detects JPEG from magic bytes", async () => {
     const jpegBytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
-    expect(guessExtensionFromBuffer(jpegBytes)).toBe(".jpg");
+    expect(await guessExtensionFromBuffer(jpegBytes)).toBe(".jpg");
   });
 
-  it("detects TIFF (little-endian) from magic bytes", () => {
+  it("detects TIFF (little-endian) from magic bytes", async () => {
     const tiffBytes = Buffer.from([0x49, 0x49, 0x2a, 0x00]);
-    expect(guessExtensionFromBuffer(tiffBytes)).toBe(".tiff");
+    expect(await guessExtensionFromBuffer(tiffBytes)).toBe(".tif");
   });
 
-  it("detects TIFF (big-endian) from magic bytes", () => {
+  it("detects TIFF (big-endian) from magic bytes", async () => {
     const tiffBytes = Buffer.from([0x4d, 0x4d, 0x00, 0x2a]);
-    expect(guessExtensionFromBuffer(tiffBytes)).toBe(".tiff");
+    expect(await guessExtensionFromBuffer(tiffBytes)).toBe(".tif");
   });
 
-  it("detects ZIP-based formats from magic bytes", () => {
+  it("detects ZIP-based formats from magic bytes", async () => {
     const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
-    expect(guessExtensionFromBuffer(zipBytes)).toBe(".docx");
+    expect(await guessExtensionFromBuffer(zipBytes)).toBe(".zip");
   });
 
-  it("defaults to .pdf for unknown bytes", () => {
+  it("defaults to .pdf for unknown bytes", async () => {
     const unknownBytes = Buffer.from([0x00, 0x01, 0x02, 0x03]);
-    expect(guessExtensionFromBuffer(unknownBytes)).toBe(".pdf");
+    expect(await guessExtensionFromBuffer(unknownBytes)).toBe(".pdf");
   });
 
-  it("works with Uint8Array input", () => {
+  it("works with Uint8Array input", async () => {
     const pdfBytes = new Uint8Array(Buffer.from("%PDF-1.7"));
-    expect(guessExtensionFromBuffer(pdfBytes)).toBe(".pdf");
+    expect(await guessExtensionFromBuffer(pdfBytes)).toBe(".pdf");
   });
 });
 

--- a/src/conversion/convertToPdf.test.ts
+++ b/src/conversion/convertToPdf.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect } from "vitest";
+import { vi, describe, it, expect, afterEach } from "vitest";
 import { EventEmitter } from "events";
 
 const mockFd = {
@@ -52,11 +52,13 @@ vi.mock("fs", async () => {
 
 import {
   guessFileExtension,
+  guessExtensionFromBuffer,
   findImageMagickCommand,
   findLibreOfficeCommand,
   convertOfficeDocument,
   convertImageToPdf,
   convertToPdf,
+  getTmpDir,
 } from "./convertToPdf";
 
 describe("test guessFileExtension", () => {
@@ -232,5 +234,70 @@ describe("test convertToPdf", () => {
     expect(result).toStrictEqual({
       content: "hello world",
     });
+  });
+});
+
+describe("test guessExtensionFromBuffer", () => {
+  it("detects PDF from magic bytes", () => {
+    const pdfBytes = Buffer.from("%PDF-1.4 some content");
+    expect(guessExtensionFromBuffer(pdfBytes)).toBe(".pdf");
+  });
+
+  it("detects PNG from magic bytes", () => {
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    expect(guessExtensionFromBuffer(pngBytes)).toBe(".png");
+  });
+
+  it("detects JPEG from magic bytes", () => {
+    const jpegBytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    expect(guessExtensionFromBuffer(jpegBytes)).toBe(".jpg");
+  });
+
+  it("detects TIFF (little-endian) from magic bytes", () => {
+    const tiffBytes = Buffer.from([0x49, 0x49, 0x2a, 0x00]);
+    expect(guessExtensionFromBuffer(tiffBytes)).toBe(".tiff");
+  });
+
+  it("detects TIFF (big-endian) from magic bytes", () => {
+    const tiffBytes = Buffer.from([0x4d, 0x4d, 0x00, 0x2a]);
+    expect(guessExtensionFromBuffer(tiffBytes)).toBe(".tiff");
+  });
+
+  it("detects ZIP-based formats from magic bytes", () => {
+    const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+    expect(guessExtensionFromBuffer(zipBytes)).toBe(".docx");
+  });
+
+  it("defaults to .pdf for unknown bytes", () => {
+    const unknownBytes = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+    expect(guessExtensionFromBuffer(unknownBytes)).toBe(".pdf");
+  });
+
+  it("works with Uint8Array input", () => {
+    const pdfBytes = new Uint8Array(Buffer.from("%PDF-1.7"));
+    expect(guessExtensionFromBuffer(pdfBytes)).toBe(".pdf");
+  });
+});
+
+describe("test getTmpDir", () => {
+  const originalEnv = process.env.LITEPARSE_TMPDIR;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.LITEPARSE_TMPDIR;
+    } else {
+      process.env.LITEPARSE_TMPDIR = originalEnv;
+    }
+  });
+
+  it("returns LITEPARSE_TMPDIR when set", () => {
+    process.env.LITEPARSE_TMPDIR = "/custom/tmp";
+    expect(getTmpDir()).toBe("/custom/tmp");
+  });
+
+  it("falls back to os.tmpdir() when LITEPARSE_TMPDIR is not set", () => {
+    delete process.env.LITEPARSE_TMPDIR;
+    const os = require("os");
+    expect(getTmpDir()).toBe(os.tmpdir());
   });
 });

--- a/src/conversion/convertToPdf.ts
+++ b/src/conversion/convertToPdf.ts
@@ -2,6 +2,7 @@ import { promises as fs, constants as fsConstants } from "fs";
 import { spawn } from "child_process";
 import path from "path";
 import os from "os";
+import { fileTypeFromFile, fileTypeFromBuffer } from "file-type";
 
 /**
  * Returns the temp directory for LiteParse operations.
@@ -75,7 +76,8 @@ export const imageExtensions = [
 export const htmlExtensions = [".htm", ".html", ".xhtml"];
 
 /**
- * Guess file extension from file content
+ * Guess file extension from file content using file-type magic byte detection.
+ * Returns the path's own extension if present, otherwise inspects file bytes.
  */
 export async function guessFileExtension(filePath: string): Promise<string> {
   const ext = path.extname(filePath).toLowerCase();
@@ -83,34 +85,12 @@ export async function guessFileExtension(filePath: string): Promise<string> {
     return ext;
   }
 
-  // Read first few bytes to detect file type
-  const buffer = Buffer.alloc(16);
-  const fd = await fs.open(filePath, "r");
-  await fd.read(buffer, 0, 16, 0);
-  await fd.close();
-
-  // PDF: %PDF
-  if (buffer.toString("utf-8", 0, 4) === "%PDF") {
-    return ".pdf";
+  const result = await fileTypeFromFile(filePath);
+  if (result) {
+    return `.${result.ext}`;
   }
 
-  // PNG: 89 50 4E 47
-  if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) {
-    return ".png";
-  }
-
-  // JPEG: FF D8 FF
-  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
-    return ".jpg";
-  }
-
-  // ZIP-based formats (docx, xlsx, etc): PK
-  if (buffer[0] === 0x50 && buffer[1] === 0x4b) {
-    // Could be docx, xlsx, pptx, odt, etc.
-    return ".docx"; // Default to docx for now
-  }
-
-  return ext || ".pdf";
+  return ".pdf"; // Default assumption for extensionless files
 }
 
 /**
@@ -424,32 +404,12 @@ export async function cleanupConversionFiles(pdfPath: string): Promise<void> {
 }
 
 /**
- * Guess file extension from raw bytes using magic-byte detection.
+ * Guess file extension from raw bytes using file-type magic byte detection.
  */
-export function guessExtensionFromBuffer(data: Buffer | Uint8Array): string {
-  // PDF: %PDF
-  if (data.length >= 4 && data[0] === 0x25 && data[1] === 0x50 && data[2] === 0x44 && data[3] === 0x46) {
-    return ".pdf";
-  }
-  // PNG: 89 50 4E 47
-  if (data.length >= 4 && data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47) {
-    return ".png";
-  }
-  // JPEG: FF D8 FF
-  if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
-    return ".jpg";
-  }
-  // TIFF: 49 49 2A 00 (little-endian) or 4D 4D 00 2A (big-endian)
-  if (
-    data.length >= 4 &&
-    ((data[0] === 0x49 && data[1] === 0x49 && data[2] === 0x2a && data[3] === 0x00) ||
-      (data[0] === 0x4d && data[1] === 0x4d && data[2] === 0x00 && data[3] === 0x2a))
-  ) {
-    return ".tiff";
-  }
-  // ZIP-based formats (docx, xlsx, pptx, etc.): PK
-  if (data.length >= 2 && data[0] === 0x50 && data[1] === 0x4b) {
-    return ".docx";
+export async function guessExtensionFromBuffer(data: Buffer | Uint8Array): Promise<string> {
+  const result = await fileTypeFromBuffer(data);
+  if (result) {
+    return `.${result.ext}`;
   }
   return ".pdf"; // Default assumption
 }
@@ -461,7 +421,7 @@ export function guessExtensionFromBuffer(data: Buffer | Uint8Array): string {
 export async function convertBufferToPdf(
   data: Buffer | Uint8Array
 ): Promise<ConversionResult | ConversionPassthrough | ConversionError> {
-  const ext = guessExtensionFromBuffer(data);
+  const ext = await guessExtensionFromBuffer(data);
 
   // Write buffer to temp file with detected extension
   const tmpDir = await fs.mkdtemp(path.join(getTmpDir(), "liteparse-"));

--- a/src/conversion/convertToPdf.ts
+++ b/src/conversion/convertToPdf.ts
@@ -3,6 +3,14 @@ import { spawn } from "child_process";
 import path from "path";
 import os from "os";
 
+/**
+ * Returns the temp directory for LiteParse operations.
+ * Respects the `LITEPARSE_TMPDIR` environment variable, falling back to the OS default.
+ */
+export function getTmpDir(): string {
+  return process.env.LITEPARSE_TMPDIR || os.tmpdir();
+}
+
 export interface ConversionResult {
   pdfPath: string;
   originalExtension: string;
@@ -368,7 +376,7 @@ export async function convertToPdf(
     }
 
     // Create temp directory for output
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "liteparse-"));
+    const tmpDir = await fs.mkdtemp(path.join(getTmpDir(), "liteparse-"));
 
     // Convert based on file type
     let pdfPath: string;
@@ -406,11 +414,59 @@ export async function convertToPdf(
 export async function cleanupConversionFiles(pdfPath: string): Promise<void> {
   try {
     // Only delete if in temp directory
-    if (pdfPath.includes(os.tmpdir())) {
+    if (pdfPath.includes(getTmpDir())) {
       const dir = path.dirname(pdfPath);
       await fs.rm(dir, { recursive: true, force: true });
     }
   } catch {
     // Ignore cleanup errors
   }
+}
+
+/**
+ * Guess file extension from raw bytes using magic-byte detection.
+ */
+export function guessExtensionFromBuffer(data: Buffer | Uint8Array): string {
+  // PDF: %PDF
+  if (data.length >= 4 && data[0] === 0x25 && data[1] === 0x50 && data[2] === 0x44 && data[3] === 0x46) {
+    return ".pdf";
+  }
+  // PNG: 89 50 4E 47
+  if (data.length >= 4 && data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47) {
+    return ".png";
+  }
+  // JPEG: FF D8 FF
+  if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
+    return ".jpg";
+  }
+  // TIFF: 49 49 2A 00 (little-endian) or 4D 4D 00 2A (big-endian)
+  if (
+    data.length >= 4 &&
+    ((data[0] === 0x49 && data[1] === 0x49 && data[2] === 0x2a && data[3] === 0x00) ||
+      (data[0] === 0x4d && data[1] === 0x4d && data[2] === 0x00 && data[3] === 0x2a))
+  ) {
+    return ".tiff";
+  }
+  // ZIP-based formats (docx, xlsx, pptx, etc.): PK
+  if (data.length >= 2 && data[0] === 0x50 && data[1] === 0x4b) {
+    return ".docx";
+  }
+  return ".pdf"; // Default assumption
+}
+
+/**
+ * Convert a raw byte buffer to PDF by writing to a temp file and converting.
+ * For PDF buffers, callers should skip this and pass data directly to the PDF engine.
+ */
+export async function convertBufferToPdf(
+  data: Buffer | Uint8Array
+): Promise<ConversionResult | ConversionPassthrough | ConversionError> {
+  const ext = guessExtensionFromBuffer(data);
+
+  // Write buffer to temp file with detected extension
+  const tmpDir = await fs.mkdtemp(path.join(getTmpDir(), "liteparse-"));
+  const tmpPath = path.join(tmpDir, `input${ext}`);
+  await fs.writeFile(tmpPath, data);
+
+  return convertToPdf(tmpPath);
 }

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -14,15 +14,15 @@ The core module contains the main orchestrator class, configuration management, 
 - Handles format conversion for non-PDF inputs
 
 **Public Methods:**
-- `parse(filePath, quiet?)` - Main entry point for document parsing
-- `screenshot(filePath, pageNumbers?, quiet?)` - Generate page screenshots
+- `parse(input, quiet?)` - Main entry point for document parsing. Accepts a file path (`string`), `Buffer`, or `Uint8Array`.
+- `screenshot(input, pageNumbers?, quiet?)` - Generate page screenshots. Accepts the same input types as `parse()`.
 - `getConfig()` - Returns current configuration
 
 **Pipeline Flow (in `parse()`):**
-1. Convert to PDF if needed (via `convertToPdf`)
+1. **Input routing**: File paths go through `convertToPdf`; PDF buffers go directly to the engine (zero disk I/O); non-PDF buffers are written to temp for conversion via `convertBufferToPdf`
 2. Load PDF document with PDF engine
 3. Extract pages
-4. Run OCR on text-sparse pages/embedded images
+4. Run OCR on text-sparse pages/embedded images (passes image buffers directly to OCR engines — no temp files)
 5. Project pages to grid (spatial text reconstruction)
 6. Build bounding boxes (if enabled)
 7. Format output (JSON or text)
@@ -41,6 +41,7 @@ The core module contains the main orchestrator class, configuration management, 
 
 **Configuration Types:**
 - `LiteParseConfig` - All configuration options
+- `LiteParseInput` - Accepted input types: `string | Buffer | Uint8Array`
 - `OutputFormat` - 'json' | 'text'
 
 **Data Types:**

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -1,5 +1,11 @@
 import pLimit from "p-limit";
-import { LiteParseConfig, LiteParseInput, ParseResult, ScreenshotResult, TextItem } from "./types.js";
+import {
+  LiteParseConfig,
+  LiteParseInput,
+  ParseResult,
+  ScreenshotResult,
+  TextItem,
+} from "./types.js";
 import { mergeConfig } from "./config.js";
 import { PdfEngine, PdfDocument, PageData } from "../engines/pdf/interface.js";
 import { PdfJsEngine } from "../engines/pdf/pdfjs.js";
@@ -250,7 +256,11 @@ export class LiteParse {
         }
 
         log(`Rendering page ${pageNum}...`);
-        const imageBuffer = await renderer.renderPageToBuffer(rendererInput, pageNum, this.config.dpi);
+        const imageBuffer = await renderer.renderPageToBuffer(
+          rendererInput,
+          pageNum,
+          this.config.dpi
+        );
 
         // Get page dimensions
         const pageData = await this.pdfEngine.extractPage(doc, pageNum);

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -123,7 +123,7 @@ export class LiteParse {
       doc = await this.pdfEngine.loadDocument(pdfPath);
     } else {
       log(`Processing buffer input (${input.byteLength} bytes)`);
-      const ext = guessExtensionFromBuffer(input);
+      const ext = await guessExtensionFromBuffer(input);
 
       if (ext === ".pdf") {
         // Zero-disk path: pass bytes directly to the PDF engine

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -1,5 +1,5 @@
 import pLimit from "p-limit";
-import { LiteParseConfig, ParseResult, ScreenshotResult, TextItem } from "./types.js";
+import { LiteParseConfig, LiteParseInput, ParseResult, ScreenshotResult, TextItem } from "./types.js";
 import { mergeConfig } from "./config.js";
 import { PdfEngine, PdfDocument, PageData } from "../engines/pdf/interface.js";
 import { PdfJsEngine } from "../engines/pdf/pdfjs.js";
@@ -10,7 +10,12 @@ import { HttpOcrEngine } from "../engines/ocr/http-simple.js";
 import { projectPagesToGrid } from "../processing/grid.js";
 import { buildBoundingBoxes } from "../processing/bbox.js";
 import { formatJSON } from "../output/json.js";
-import { convertToPdf, cleanupConversionFiles } from "../conversion/convertToPdf.js";
+import {
+  convertToPdf,
+  convertBufferToPdf,
+  cleanupConversionFiles,
+  guessExtensionFromBuffer,
+} from "../conversion/convertToPdf.js";
 import { cleanOcrTableArtifacts } from "../processing/textUtils.js";
 
 /**
@@ -78,44 +83,72 @@ export class LiteParse {
    * Supports PDFs natively. Non-PDF formats (DOCX, XLSX, images, etc.) are automatically
    * converted to PDF before parsing if the required system tools are installed.
    *
-   * @param filePath - Path to the document file.
+   * @param input - A file path, `Buffer`, or `Uint8Array` containing document bytes.
+   *   When given raw bytes, PDF data is parsed directly with zero disk I/O.
+   *   Non-PDF bytes are written to a temp file for format conversion.
    * @param quiet - If `true`, suppresses progress logging to stderr.
    * @returns Parsed document data including text, per-page info, and optional JSON.
    *
    * @throws Error if the file cannot be found, converted, or parsed.
    */
-  async parse(filePath: string, quiet = false): Promise<ParseResult> {
+  async parse(input: LiteParseInput, quiet = false): Promise<ParseResult> {
     const log = (msg: string) => {
       if (!quiet) console.error(msg); // Progress goes to stderr
     };
 
-    log(`Processing file: ${filePath}`);
-    const conversionResult = await convertToPdf(filePath);
+    let doc: PdfDocument;
+    let needsCleanup = false;
+    let cleanupPath: string | undefined;
 
-    if ("code" in conversionResult) {
-      // Conversion error
-      throw new Error(`Conversion failed: ${conversionResult.message}`);
+    if (typeof input === "string") {
+      log(`Processing file: ${input}`);
+      const conversionResult = await convertToPdf(input);
+
+      if ("code" in conversionResult) {
+        throw new Error(`Conversion failed: ${conversionResult.message}`);
+      }
+
+      if ("content" in conversionResult) {
+        log(`File is a text-based format. Returning content directly.`);
+        return { pages: [], text: conversionResult.content };
+      }
+
+      const pdfPath = conversionResult.pdfPath;
+      needsCleanup = pdfPath !== input;
+      if (needsCleanup) {
+        cleanupPath = pdfPath;
+        log(`Converted ${conversionResult.originalExtension} to PDF`);
+      }
+
+      doc = await this.pdfEngine.loadDocument(pdfPath);
+    } else {
+      log(`Processing buffer input (${input.byteLength} bytes)`);
+      const ext = guessExtensionFromBuffer(input);
+
+      if (ext === ".pdf") {
+        // Zero-disk path: pass bytes directly to the PDF engine
+        const data = input instanceof Uint8Array ? input : new Uint8Array(input);
+        doc = await this.pdfEngine.loadDocument(data);
+      } else {
+        // Non-PDF buffer: write to temp file for conversion
+        const conversionResult = await convertBufferToPdf(input);
+
+        if ("code" in conversionResult) {
+          throw new Error(`Conversion failed: ${conversionResult.message}`);
+        }
+
+        if ("content" in conversionResult) {
+          log(`Buffer is a text-based format. Returning content directly.`);
+          return { pages: [], text: conversionResult.content };
+        }
+
+        needsCleanup = true;
+        cleanupPath = conversionResult.pdfPath;
+        log(`Converted ${conversionResult.originalExtension} buffer to PDF`);
+        doc = await this.pdfEngine.loadDocument(conversionResult.pdfPath);
+      }
     }
 
-    // Return early for text-based passthrough formats
-    if ("content" in conversionResult) {
-      log(`File is a text-based format. Returning content directly.`);
-      return {
-        pages: [],
-        text: conversionResult.content,
-      };
-    }
-
-    // Convert to PDF if needed
-    const pdfPath = conversionResult.pdfPath;
-    const needsCleanup = pdfPath !== filePath;
-
-    if (needsCleanup) {
-      log(`Converted ${conversionResult.originalExtension} to PDF`);
-    }
-
-    // Load PDF document
-    const doc = await this.pdfEngine.loadDocument(pdfPath);
     log(`Loaded PDF with ${doc.numPages} pages`);
 
     // Extract pages
@@ -152,8 +185,8 @@ export class LiteParse {
     }
 
     // Cleanup temporary conversion files
-    if (needsCleanup) {
-      await cleanupConversionFiles(pdfPath);
+    if (needsCleanup && cleanupPath) {
+      await cleanupConversionFiles(cleanupPath);
     }
 
     const result: ParseResult = {
@@ -180,13 +213,13 @@ export class LiteParse {
    * Uses PDFium for high-quality rendering. Each page is returned as a
    * {@link ScreenshotResult} with the raw image buffer and dimensions.
    *
-   * @param filePath - Path to the PDF file.
+   * @param input - A file path, `Buffer`, or `Uint8Array` containing PDF bytes.
    * @param pageNumbers - 1-indexed page numbers to screenshot. If omitted, all pages are rendered.
    * @param quiet - If `true`, suppresses progress logging to stderr.
    * @returns Array of screenshot results, one per rendered page.
    */
   async screenshot(
-    filePath: string,
+    input: LiteParseInput,
     pageNumbers?: number[],
     quiet = false
   ): Promise<ScreenshotResult[]> {
@@ -194,11 +227,14 @@ export class LiteParse {
       if (!quiet) console.error(msg); // Progress goes to stderr
     };
 
-    log(`Generating screenshots for: ${filePath}`);
+    log(`Generating screenshots for: ${typeof input === "string" ? input : "<buffer>"}`);
 
     // Load PDF document to get page count and dimensions
-    const doc = await this.pdfEngine.loadDocument(filePath);
+    const doc = await this.pdfEngine.loadDocument(input as string | Uint8Array);
     const totalPages = doc.numPages;
+
+    // Determine the input to pass to the renderer (file path or buffer)
+    const rendererInput: string | Buffer | Uint8Array = typeof input === "string" ? input : input;
 
     const results: ScreenshotResult[] = [];
     const pages = pageNumbers || Array.from({ length: totalPages }, (_, i) => i + 1);
@@ -214,7 +250,7 @@ export class LiteParse {
         }
 
         log(`Rendering page ${pageNum}...`);
-        const imageBuffer = await renderer.renderPageToBuffer(filePath, pageNum, this.config.dpi);
+        const imageBuffer = await renderer.renderPageToBuffer(rendererInput, pageNum, this.config.dpi);
 
         // Get page dimensions
         const pageData = await this.pdfEngine.extractPage(doc, pageNum);
@@ -278,20 +314,12 @@ export class LiteParse {
     }
 
     try {
-      // Render page as image
+      // Render page as image buffer
       const imageBuffer = await this.pdfEngine.renderPageImage(doc, page.pageNum, this.config.dpi);
 
-      // Save temporary image file
-      const fs = await import("fs/promises");
-      const path = await import("path");
-      const os = await import("os");
-      const tmpDir = os.tmpdir();
-      const tmpImagePath = path.join(tmpDir, `page_${page.pageNum}_ocr.png`);
-      await fs.writeFile(tmpImagePath, imageBuffer);
-
-      // Run OCR
+      // Run OCR directly on the buffer (no temp file needed)
       log(`  OCR on page ${page.pageNum}...`);
-      const ocrResults = await this.ocrEngine.recognize(tmpImagePath, {
+      const ocrResults = await this.ocrEngine.recognize(imageBuffer, {
         language: this.config.ocrLanguage,
         correctRotation: true,
       });
@@ -384,9 +412,6 @@ export class LiteParse {
         page.textItems.push(...ocrTextItems);
         log(`  Found ${ocrTextItems.length} text items from OCR on page ${page.pageNum}`);
       }
-
-      // Clean up temp file
-      await fs.unlink(tmpImagePath).catch(() => {});
     } catch (error) {
       log(`  OCR failed for page ${page.pageNum}: ${error}`);
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -7,6 +7,15 @@
 export type OutputFormat = "json" | "text";
 
 /**
+ * Accepted input types for {@link LiteParse.parse} and {@link LiteParse.screenshot}.
+ *
+ * - `string` — A file path to a document on disk.
+ * - `Buffer | Uint8Array` — Raw file bytes (PDF bytes go straight to the parser with zero disk I/O;
+ *   non-PDF bytes are written to a temp file for format conversion).
+ */
+export type LiteParseInput = string | Buffer | Uint8Array;
+
+/**
  * Configuration options for the {@link LiteParse} parser.
  *
  * All fields have sensible defaults. Pass a `Partial<LiteParseConfig>` to the

--- a/src/engines/ocr/README.md
+++ b/src/engines/ocr/README.md
@@ -10,8 +10,8 @@ OCR engines for extracting text from images.
 ```typescript
 interface OcrEngine {
   name: string;
-  recognize(imagePath: string, options: OcrOptions): Promise<OcrResult[]>;
-  recognizeBatch(imagePaths: string[], options: OcrOptions): Promise<OcrResult[][]>;
+  recognize(image: string | Buffer, options: OcrOptions): Promise<OcrResult[]>;
+  recognizeBatch(images: (string | Buffer)[], options: OcrOptions): Promise<OcrResult[][]>;
 }
 
 interface OcrOptions {
@@ -35,9 +35,11 @@ This is the default OCR engine when no `ocrServerUrl` is configured.
 
 **Key Features:**
 - Worker-based processing (runs in background thread)
+- Accepts file paths or `Buffer` input directly (no temp files needed)
 - Language caching (reuses worker for same language)
 - Automatic language code normalization (e.g., `en` → `eng`)
 - Low-confidence filtering (removes results < 30%)
+- Supports offline usage via `TESSDATA_PREFIX` env var or `tessdataPath` config for pre-downloaded `.traineddata` files
 
 **Language Normalization:**
 Maps common ISO 639-1 codes to Tesseract's 3-letter codes:
@@ -47,8 +49,8 @@ Maps common ISO 639-1 codes to Tesseract's 3-letter codes:
 
 **Lifecycle:**
 - `initialize(language)` - Create/recreate worker for language
-- `recognize(imagePath, options)` - OCR single image
-- `recognizeBatch(imagePaths, options)` - OCR multiple images sequentially
+- `recognize(image, options)` - OCR single image (accepts file path or Buffer)
+- `recognizeBatch(images, options)` - OCR multiple images sequentially
 - `terminate()` - Clean up worker (called by LiteParse after parsing)
 
 **Design Decisions:**

--- a/src/engines/ocr/http-simple.ts
+++ b/src/engines/ocr/http-simple.ts
@@ -27,11 +27,15 @@ export class HttpOcrEngine implements OcrEngine {
     this.serverUrl = serverUrl;
   }
 
-  async recognize(imagePath: string, options: OcrOptions): Promise<OcrResult[]> {
+  async recognize(image: string | Buffer, options: OcrOptions): Promise<OcrResult[]> {
     try {
       // Prepare request
       const formData = new FormData();
-      formData.append("file", fs.createReadStream(imagePath));
+      if (typeof image === "string") {
+        formData.append("file", fs.createReadStream(image));
+      } else {
+        formData.append("file", image, { filename: "image.png", contentType: "image/png" });
+      }
 
       const language = Array.isArray(options.language) ? options.language[0] : options.language;
       formData.append("language", language);
@@ -56,23 +60,24 @@ export class HttpOcrEngine implements OcrEngine {
         confidence: item.confidence,
       }));
     } catch (error) {
+      const label = typeof image === "string" ? image : "<buffer>";
       if (axios.isAxiosError(error)) {
         console.error(
-          `OCR HTTP error for ${imagePath}:`,
+          `OCR HTTP error for ${label}:`,
           error.response?.status,
           error.response?.data?.error || error.message
         );
       } else {
-        console.error(`OCR error for ${imagePath}:`, error);
+        console.error(`OCR error for ${label}:`, error);
       }
       return [];
     }
   }
 
-  async recognizeBatch(imagePaths: string[], options: OcrOptions): Promise<OcrResult[][]> {
+  async recognizeBatch(images: (string | Buffer)[], options: OcrOptions): Promise<OcrResult[][]> {
     const results: OcrResult[][] = [];
-    for (const imagePath of imagePaths) {
-      const result = await this.recognize(imagePath, options);
+    for (const image of images) {
+      const result = await this.recognize(image, options);
       results.push(result);
     }
     return results;

--- a/src/engines/ocr/interface.ts
+++ b/src/engines/ocr/interface.ts
@@ -1,7 +1,7 @@
 export interface OcrEngine {
   name: string;
-  recognize(imagePath: string, options: OcrOptions): Promise<OcrResult[]>;
-  recognizeBatch(imagePaths: string[], options: OcrOptions): Promise<OcrResult[][]>;
+  recognize(image: string | Buffer, options: OcrOptions): Promise<OcrResult[]>;
+  recognizeBatch(images: (string | Buffer)[], options: OcrOptions): Promise<OcrResult[][]>;
 }
 
 export interface OcrOptions {

--- a/src/engines/ocr/tesseract.ts
+++ b/src/engines/ocr/tesseract.ts
@@ -94,7 +94,7 @@ export class TesseractEngine implements OcrEngine {
     this.currentLanguage = language;
   }
 
-  async recognize(imagePath: string, options: OcrOptions): Promise<OcrResult[]> {
+  async recognize(image: string | Buffer, options: OcrOptions): Promise<OcrResult[]> {
     // Handle language - tesseract.js uses language codes like 'eng', 'fra', 'deu'
     const language = this.normalizeLanguage(
       Array.isArray(options.language) ? options.language[0] : options.language
@@ -109,10 +109,11 @@ export class TesseractEngine implements OcrEngine {
 
     try {
       // Recognize text from image using scheduler
+      // tesseract.js accepts string (path/URL) or Buffer/Uint8Array
       // In tesseract.js v6+, we need to enable blocks output to get word-level data
       const {
         data: { blocks },
-      } = await this.scheduler.addJob("recognize", imagePath, {}, { blocks: true });
+      } = await this.scheduler.addJob("recognize", image, {}, { blocks: true });
 
       // Extract words from hierarchical blocks structure: blocks → paragraphs → lines → words
       const results: OcrResult[] = [];
@@ -138,12 +139,13 @@ export class TesseractEngine implements OcrEngine {
       // Filter out low confidence results (below 30%)
       return results.filter((r) => r.confidence > 0.3);
     } catch (error) {
-      console.error(`\nTesseract OCR error for ${imagePath}:`, error);
+      const label = typeof image === "string" ? image : "<buffer>";
+      console.error(`\nTesseract OCR error for ${label}:`, error);
       return [];
     }
   }
 
-  async recognizeBatch(imagePaths: string[], options: OcrOptions): Promise<OcrResult[][]> {
+  async recognizeBatch(images: (string | Buffer)[], options: OcrOptions): Promise<OcrResult[][]> {
     // Handle language
     const language = this.normalizeLanguage(
       Array.isArray(options.language) ? options.language[0] : options.language
@@ -157,7 +159,7 @@ export class TesseractEngine implements OcrEngine {
     }
 
     // Process all images in parallel - scheduler handles distribution
-    const jobs = imagePaths.map((imagePath) => this.recognize(imagePath, options));
+    const jobs = images.map((image) => this.recognize(image, options));
 
     return Promise.all(jobs);
   }

--- a/src/engines/pdf/README.md
+++ b/src/engines/pdf/README.md
@@ -11,13 +11,15 @@ PDF parsing engines for loading documents and extracting content.
 ```typescript
 interface PdfEngine {
   name: string;
-  loadDocument(filePath: string): Promise<PdfDocument>;
+  loadDocument(input: string | Uint8Array): Promise<PdfDocument>;
   extractPage(doc: PdfDocument, pageNum: number): Promise<PageData>;
   extractAllPages(doc, maxPages?, targetPages?): Promise<PageData[]>;
   renderPageImage(doc, pageNum, dpi): Promise<Buffer>;
   close(doc: PdfDocument): Promise<void>;
 }
 ```
+
+`loadDocument` accepts either a file path or raw PDF bytes as a `Uint8Array`. When given bytes, the document is loaded with zero disk I/O.
 
 **Key Data Types:**
 - `PdfDocument` - Loaded document with `numPages`, `data` (Uint8Array), `metadata`
@@ -69,9 +71,9 @@ When garbled text is detected:
 This allows targeted OCR replacement of only the corrupted text while preserving high-quality PDF text extraction elsewhere.
 
 **Design Decisions:**
-- **Stores PDF path**: Needed for PDFium rendering (pdfjs.ts:95)
-- **Filters off-page items**: Removes text with negative coords or beyond page bounds (pdfjs.ts:191-198)
-- **Zero-size filtering**: Skips text items with 0 width/height (pdfjs.ts:125)
+- **Stores PDF path and data**: Keeps both the file path (when available) and the raw `Uint8Array` data for PDFium rendering. Buffer input skips file reads entirely.
+- **Filters off-page items**: Removes text with negative coords or beyond page bounds
+- **Zero-size filtering**: Skips text items with 0 width/height
 
 ---
 
@@ -88,7 +90,7 @@ Used for generating page images for OCR and the `screenshot` command. Provides b
 
 **Methods:**
 - `init()` - Initialize PDFium library (called automatically)
-- `renderPageToBuffer(pdfPath, pageNumber, dpi)` - Render page to PNG buffer
+- `renderPageToBuffer(pdfInput, pageNumber, dpi)` - Render page to PNG buffer. Accepts a file path (`string`), `Buffer`, or `Uint8Array`.
 - `close()` - Cleanup PDFium resources
 
 **Design Decision:**

--- a/src/engines/pdf/interface.ts
+++ b/src/engines/pdf/interface.ts
@@ -2,7 +2,7 @@ import { TextItem } from "../../core/types.js";
 
 export interface PdfEngine {
   name: string;
-  loadDocument(filePath: string): Promise<PdfDocument>;
+  loadDocument(input: string | Uint8Array): Promise<PdfDocument>;
   extractPage(doc: PdfDocument, pageNum: number): Promise<PageData>;
   extractAllPages(doc: PdfDocument, maxPages?: number, targetPages?: string): Promise<PageData[]>;
   renderPageImage(doc: PdfDocument, pageNum: number, dpi: number): Promise<Buffer>;

--- a/src/engines/pdf/pdfium-renderer.ts
+++ b/src/engines/pdf/pdfium-renderer.ts
@@ -27,9 +27,8 @@ export class PdfiumRenderer {
     }
 
     // Accept file path or raw bytes
-    const pdfBuffer = typeof pdfInput === "string"
-      ? await fs.readFile(pdfInput)
-      : Buffer.from(pdfInput);
+    const pdfBuffer =
+      typeof pdfInput === "string" ? await fs.readFile(pdfInput) : Buffer.from(pdfInput);
 
     // Load document
     const document = await this.pdfium.loadDocument(pdfBuffer);

--- a/src/engines/pdf/pdfium-renderer.ts
+++ b/src/engines/pdf/pdfium-renderer.ts
@@ -16,7 +16,7 @@ export class PdfiumRenderer {
   }
 
   async renderPageToBuffer(
-    pdfPath: string,
+    pdfInput: string | Buffer | Uint8Array,
     pageNumber: number,
     dpi: number = 150
   ): Promise<Buffer> {
@@ -26,8 +26,10 @@ export class PdfiumRenderer {
       throw new Error("PDFium not initialized");
     }
 
-    // Read PDF file
-    const pdfBuffer = await fs.readFile(pdfPath);
+    // Accept file path or raw bytes
+    const pdfBuffer = typeof pdfInput === "string"
+      ? await fs.readFile(pdfInput)
+      : Buffer.from(pdfInput);
 
     // Load document
     const document = await this.pdfium.loadDocument(pdfBuffer);

--- a/src/engines/pdf/pdfjs.ts
+++ b/src/engines/pdf/pdfjs.ts
@@ -431,12 +431,21 @@ export class PdfJsEngine implements PdfEngine {
   name = "pdfjs";
   private pdfiumRenderer: PdfiumRenderer | null = null;
   private currentPdfPath: string | null = null;
+  private currentPdfData: Uint8Array | null = null;
 
-  async loadDocument(filePath: string): Promise<PdfDocument> {
-    const data = new Uint8Array(await fs.readFile(filePath));
+  async loadDocument(input: string | Uint8Array): Promise<PdfDocument> {
+    let data: Uint8Array;
+    if (typeof input === "string") {
+      data = new Uint8Array(await fs.readFile(input));
+      this.currentPdfPath = input;
+    } else {
+      // pdf.js requires a plain Uint8Array, not a Buffer subclass
+      data = new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+      this.currentPdfPath = null;
+    }
 
-    // Store path for PDFium rendering
-    this.currentPdfPath = filePath;
+    // Store data for buffer-based rendering
+    this.currentPdfData = data;
 
     const loadingTask = getDocument({
       data,
@@ -616,16 +625,17 @@ export class PdfJsEngine implements PdfEngine {
   }
 
   async renderPageImage(_doc: PdfDocument, pageNum: number, dpi: number): Promise<Buffer> {
-    // Use PDFium for rendering (more robust with inline images)
-    if (!this.currentPdfPath) {
-      throw new Error("PDF path not available for rendering");
-    }
-
     if (!this.pdfiumRenderer) {
       this.pdfiumRenderer = new PdfiumRenderer();
     }
 
-    return await this.pdfiumRenderer.renderPageToBuffer(this.currentPdfPath, pageNum, dpi);
+    // Use file path when available, otherwise pass buffer directly
+    const pdfInput = this.currentPdfPath || this.currentPdfData;
+    if (!pdfInput) {
+      throw new Error("No PDF path or data available for rendering");
+    }
+
+    return await this.pdfiumRenderer.renderPageToBuffer(pdfInput, pageNum, dpi);
   }
 
   async close(doc: PdfDocument): Promise<void> {
@@ -640,6 +650,7 @@ export class PdfJsEngine implements PdfEngine {
       this.pdfiumRenderer = null;
     }
     this.currentPdfPath = null;
+    this.currentPdfData = null;
   }
 
   private parseTargetPages(targetPages: string, maxPages: number): number[] {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -15,6 +15,7 @@
 export { LiteParse } from "./core/parser.js";
 export type {
   LiteParseConfig,
+  LiteParseInput,
   OutputFormat,
   ParseResult,
   ParseResultJson,


### PR DESCRIPTION
Adds support and tests for reading from buffers/streams in library usage.

This means users can directly stream data through liteparse without writing to disk

**NOTE:** office/image conversion will require disk access. The folder this writes to is controlled by an env var