### PR TITLE
fix(ocr): normalize PaddleOCR language aliases

### DIFF
--- a/ocr/paddleocr/server.py
+++ b/ocr/paddleocr/server.py
@@ -30,6 +30,20 @@ class PaddleOCRServer:
         )
         self.current_language: str = "en"
 
+    @staticmethod
+    def normalize_language(language: str) -> str:
+        normalized = language.lower()
+        aliases = {
+            "zh": "ch",
+            "zh-cn": "ch",
+            "zh-hans": "ch",
+            "zh-tw": "chinese_cht",
+            "zh-hant": "chinese_cht",
+            "ja": "japan",
+            "ko": "korean",
+        }
+        return aliases.get(normalized, normalized)
+
     def _create_ocr_server(
         self,
     ) -> FastAPI:
@@ -40,7 +54,7 @@ class PaddleOCRServer:
             file: UploadFile = File(...), language: str = Form(default="en")
         ) -> OcrResponse:
             # Get language from request
-            language = language.lower()
+            language = self.normalize_language(language)
 
             try:
                 # Initialize OCR if needed or language changed
@@ -52,7 +66,7 @@ class PaddleOCRServer:
                         use_doc_unwarping=False,
                         use_textline_orientation=True,
                     )
-                    # self.current_language = paddle_lang
+                    self.current_language = language
 
                 # Load image
 

--- a/ocr/paddleocr/test_server.py
+++ b/ocr/paddleocr/test_server.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 from paddleocr import PaddleOCR
 from PIL import Image
 
+import server as paddle_server_module
 from server import PaddleOCRServer
 
 
@@ -71,3 +72,35 @@ def test_server_ocr_endpoint(server: PaddleOCRServer) -> None:
     )
     assert response.status_code == 200
     assert response.json().get("results", []) == mock_ocr.transformed_results
+
+
+def test_server_normalizes_documented_language_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    image = Image.new("RGB", (1, 1), color=(255, 255, 255))
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    buffer.seek(0)
+
+    captured_langs: list[str] = []
+
+    class CapturingPaddleOcr(MockPaddleOcr):
+        def __init__(self, *args, **kwargs) -> None:
+            captured_langs.append(kwargs.get("lang", ""))
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(paddle_server_module, "PaddleOCR", CapturingPaddleOcr)
+
+    server = PaddleOCRServer()
+    app = server._create_ocr_server()
+    client = TestClient(app)
+
+    response = client.post(
+        "/ocr",
+        files={"file": ("test.png", buffer, "image/png")},
+        data={"language": "zh"},
+    )
+
+    assert response.status_code == 200
+    assert captured_langs == ["en", "ch"]
+    assert server.current_language == "ch"


### PR DESCRIPTION
## Problem

The PaddleOCR example server currently lowercases the incoming `language` form value and passes it directly into `PaddleOCR(lang=...)`. LiteParse's own OCR docs and examples advertise aliases like `zh`, `zh-cn`, and `zh-tw`, so requests using those documented values can fail even though the server appears configured correctly.

## What changed

- Added a small language alias normalizer in `ocr/paddleocr/server.py`
- Mapped the documented common aliases to PaddleOCR-friendly values
- Updated the server to persist `current_language` after reinitializing the OCR client
- Added a regression test covering a `zh` request and the cached language state

## Why this fixes it

This keeps the external LiteParse API stable while adapting the incoming language value to the codes PaddleOCR expects internally. That matches the current docs/examples instead of forcing callers to discover backend-specific language names on their own.

## Verification

- `python3 -m py_compile ocr/paddleocr/server.py ocr/paddleocr/test_server.py`
- I also attempted to run `uv run --project ocr/paddleocr pytest test_server.py -q`, but local verification was blocked by repeated `paddlepaddle` download/extraction timeouts in this environment.

Related: #36

## Self-critique

1. The alias map is intentionally small and focused on the documented/common cases; maintainers may prefer an even narrower first pass.
2. This keeps docs-compatible aliases working, but if PaddleOCR's supported names shift upstream, the mapping may need to be revisited.
3. The local test limitation means CI is especially important on this PR, so I'm leaving it as a draft until those checks run.