### PR TITLE
Add TSV parser with header colspan support

### DIFF
--- a/src/processing/README.md
+++ b/src/processing/README.md
@@ -142,6 +142,32 @@ If any character lacks a Unicode equivalent, returns original string unchanged.
 
 ---
 
+### tsvParser.ts
+**TSV parser with table header and colspan support.**
+
+Parses tab-separated values with special markers for table structure.
+
+**Key Functions:**
+
+`parseTsv(tsv)` - Parse TSV string into structured table:
+- Recognizes `[thead]` markers for header rows
+- Auto-extends last non-empty cell to span remaining columns when header row has fewer cells
+- Returns `TsvTable` with rows, cells, and column count
+
+`toTsv(table)` - Convert structured table back to TSV format:
+- Restores `[thead]` markers for header rows
+- Expands colspan cells to trailing empty cells
+
+**Example:**
+```
+[thead]\tYear ended Dec. 31,\t
+[thead](in millions)\t2024\t2023\t2022
+```
+
+The first header row has 3 cells but the table has 4 columns. "Year ended Dec. 31," (the last non-empty cell) gets colspan=3, spanning columns 2-4.
+
+---
+
 ### cleanText.ts
 **Post-processing text cleanup.**
 

--- a/src/processing/tsvParser.test.ts
+++ b/src/processing/tsvParser.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { parseTsv, toTsv } from "./tsvParser.js";
+
+describe("tsvParser", () => {
+  describe("parseTsv", () => {
+    it("should parse basic TSV", () => {
+      const tsv = "A\tB\tC\n1\t2\t3";
+      const table = parseTsv(tsv);
+
+      expect(table.columnCount).toBe(3);
+      expect(table.rows).toHaveLength(2);
+      expect(table.rows[0].cells.map((c) => c.text)).toEqual(["A", "B", "C"]);
+      expect(table.rows[1].cells.map((c) => c.text)).toEqual(["1", "2", "3"]);
+    });
+
+    it("should recognize [thead] marker for header rows", () => {
+      const tsv = "[thead]Header1\tHeader2\n1\t2";
+      const table = parseTsv(tsv);
+
+      expect(table.rows[0].isHeader).toBe(true);
+      expect(table.rows[0].cells[0].text).toBe("Header1");
+      expect(table.rows[1].isHeader).toBe(false);
+    });
+
+    it("should extend last cell as colspan when header row is missing cells", () => {
+      const tsv = `[thead]\tYear ended Dec. 31,\t
+[thead](in millions)\t2024\t2023\t2022
+**Operating activities:**\t\t\t`;
+
+      const table = parseTsv(tsv);
+
+      expect(table.columnCount).toBe(4);
+
+      // First header row - "Year ended Dec. 31," should span columns 2-4 (colspan 3)
+      expect(table.rows[0].isHeader).toBe(true);
+      expect(table.rows[0].cells[1].text).toBe("Year ended Dec. 31,");
+      expect(table.rows[0].cells[1].colspan).toBe(3);
+
+      // Second header row - all cells present, no colspan
+      expect(table.rows[1].isHeader).toBe(true);
+      expect(table.rows[1].cells.every((c) => c.colspan === 1)).toBe(true);
+
+      // Data row - not a header, no colspan extension
+      expect(table.rows[2].isHeader).toBe(false);
+    });
+
+    it("should not extend colspan for non-header rows with fewer cells", () => {
+      const tsv = "A\tB\tC\tD\n1\t2";
+      const table = parseTsv(tsv);
+
+      expect(table.columnCount).toBe(4);
+      expect(table.rows[1].cells[1].colspan).toBe(1);
+    });
+
+    it("should extend last non-empty cell when trailing cells are empty", () => {
+      const tsv = `[thead]A\tB\t\nC\tD\tE\tF`;
+      const table = parseTsv(tsv);
+
+      expect(table.columnCount).toBe(4);
+      // Last non-empty cell "B" should span remaining columns (absorbing empty trailing cell)
+      expect(table.rows[0].cells.length).toBe(2);
+      expect(table.rows[0].cells[1].text).toBe("B");
+      expect(table.rows[0].cells[1].colspan).toBe(3);
+    });
+
+    it("should handle single column tables", () => {
+      const tsv = "[thead]Header\nRow1\nRow2";
+      const table = parseTsv(tsv);
+
+      expect(table.columnCount).toBe(1);
+      expect(table.rows[0].cells[0].colspan).toBe(1);
+    });
+  });
+
+  describe("toTsv", () => {
+    it("should convert table back to TSV", () => {
+      const tsv = "[thead]A\tB\n1\t2";
+      const table = parseTsv(tsv);
+      const result = toTsv(table);
+
+      expect(result).toBe("[thead]A\tB\n1\t2");
+    });
+
+    it("should expand colspan cells to empty trailing cells", () => {
+      const table = {
+        rows: [
+          {
+            isHeader: true,
+            cells: [
+              { text: "", colspan: 1, isHeader: true },
+              { text: "Spans three", colspan: 3, isHeader: true },
+            ],
+          },
+        ],
+        columnCount: 4,
+      };
+
+      const result = toTsv(table);
+      expect(result).toBe("[thead]\tSpans three\t\t");
+    });
+  });
+});

--- a/src/processing/tsvParser.ts
+++ b/src/processing/tsvParser.ts
@@ -1,0 +1,135 @@
+/**
+ * TSV Parser with support for table headers and colspan handling.
+ *
+ * Features:
+ * - Parses tab-separated values
+ * - Recognizes [thead] markers for header rows
+ * - Auto-extends last cell to span remaining columns when row has fewer cells
+ */
+
+export interface TsvCell {
+  text: string;
+  colspan: number;
+  isHeader: boolean;
+}
+
+export interface TsvRow {
+  cells: TsvCell[];
+  isHeader: boolean;
+}
+
+export interface TsvTable {
+  rows: TsvRow[];
+  columnCount: number;
+}
+
+/**
+ * Parse a TSV string into a structured table representation.
+ * If a header row is missing cells, the last cell is treated as a colspan
+ * extending to the end of the table.
+ */
+export function parseTsv(tsv: string): TsvTable {
+  const lines = tsv.split("\n").filter((line) => line.trim() !== "");
+
+  if (lines.length === 0) {
+    return { rows: [], columnCount: 0 };
+  }
+
+  // First pass: parse all rows and determine max column count
+  const rawRows: Array<{ cells: string[]; isHeader: boolean }> = [];
+  let maxColumns = 0;
+
+  for (const line of lines) {
+    const cells = line.split("\t");
+    const isHeader = cells[0]?.startsWith("[thead]") ?? false;
+
+    // Clean the first cell if it has [thead] marker
+    if (isHeader && cells.length > 0) {
+      cells[0] = cells[0].replace(/^\[thead\]/, "").trim();
+    }
+
+    rawRows.push({ cells, isHeader });
+    maxColumns = Math.max(maxColumns, cells.length);
+  }
+
+  // Second pass: build structured rows with colspan handling
+  const rows: TsvRow[] = rawRows.map((rawRow) => {
+    const { cells: rawCells, isHeader } = rawRow;
+
+    // For header rows with fewer cells, find the last non-empty cell index
+    let lastNonEmptyCellIndex = -1;
+    if (isHeader && rawCells.length < maxColumns) {
+      for (let i = rawCells.length - 1; i >= 0; i--) {
+        if (rawCells[i].trim() !== "") {
+          lastNonEmptyCellIndex = i;
+          break;
+        }
+      }
+    }
+
+    const cells: TsvCell[] = [];
+
+    for (let i = 0; i < rawCells.length; i++) {
+      const text = rawCells[i].trim();
+
+      // If this is the last non-empty cell in a header row with fewer cells,
+      // extend it to span remaining columns (absorbing any trailing empty cells)
+      let colspan = 1;
+      if (isHeader && i === lastNonEmptyCellIndex && lastNonEmptyCellIndex !== -1) {
+        colspan = maxColumns - i;
+      }
+
+      // Skip trailing empty cells after a colspan cell in header rows
+      if (isHeader && lastNonEmptyCellIndex !== -1 && i > lastNonEmptyCellIndex) {
+        continue;
+      }
+
+      cells.push({
+        text,
+        colspan,
+        isHeader,
+      });
+    }
+
+    return { cells, isHeader };
+  });
+
+  return { rows, columnCount: maxColumns };
+}
+
+/**
+ * Convert a parsed table back to TSV format.
+ * Colspan cells are represented by trailing empty cells.
+ */
+export function toTsv(table: TsvTable): string {
+  const lines: string[] = [];
+
+  for (const row of table.rows) {
+    const cells: string[] = [];
+
+    for (const cell of row.cells) {
+      // Add header marker to first cell if this is a header row
+      const prefix = row.isHeader && cells.length === 0 ? "[thead]" : "";
+      cells.push(prefix + cell.text);
+
+      // Add empty cells for colspan > 1
+      for (let i = 1; i < cell.colspan; i++) {
+        cells.push("");
+      }
+    }
+
+    lines.push(cells.join("\t"));
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Get the effective column span for a cell at a given position.
+ */
+export function getCellSpan(row: TsvRow, cellIndex: number, columnCount: number): number {
+  const cell = row.cells[cellIndex];
+  if (!cell) return 1;
+
+  return cell.colspan;
+}


### PR DESCRIPTION
When a header row has fewer cells than the max column count, the last non-empty cell is treated as a colspan extending to the end of the table. This handles common financial table patterns where headers span multiple data columns.

https://claude.ai/code/session_01TVspuvZPtdpKm7VPFVf6gG