### PR TITLE
feat: install if not available in python package

### DIFF
--- a/docs/src/content/docs/liteparse/guides/library-usage.md
+++ b/docs/src/content/docs/liteparse/guides/library-usage.md
@@ -120,15 +120,11 @@ The Python package wraps the LiteParse CLI, so the Node.js CLI must be installed
 ### Installation
 
 ```bash
-# 1. Install the CLI (required)
-npm install -g @llamaindex/liteparse
-
-# 2. Install the Python package
 pip install liteparse
 ```
 
 <Aside type="caution">
-  The Python package calls the LiteParse CLI under the hood. Make sure `lit` is available on your PATH before using the Python library.
+  The Python package calls the LiteParse CLI under the hood: while the package can auto-install the CLI executable if not installed, it is recommended to do it separately (`npm install -g @llamaindex/liteparse` or `brew install run-llama/liteparse/llamaindex-liteparse`).
 </Aside>
 
 ### Parsing a document

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -8,7 +8,7 @@ Python wrapper for [LiteParse](https://github.com/run-llama/liteparse) - fast, l
 pip install liteparse
 ```
 
-**Prerequisites:** The LiteParse Node.js CLI must be installed:
+While the python package can auto-install the LiteParse CLI if not installed, it is recommended to do it separately:
 
 ```bash
 npm install -g liteparse

--- a/packages/python/liteparse/parser.py
+++ b/packages/python/liteparse/parser.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import warnings
 from pathlib import Path
 from typing import Any, List, Literal, Optional, Union, cast
 
@@ -24,7 +25,7 @@ from .types import (
 )
 
 
-def _find_cli() -> str:
+def _find_cli(install_if_not_available: bool) -> str:
     """Find the liteparse CLI executable."""
     # Check if liteparse is in PATH
     cli_path = shutil.which("liteparse")
@@ -46,6 +47,24 @@ def _find_cli() -> str:
     for path in possible_paths:
         if os.path.isfile(path):
             return os.path.abspath(path)
+
+    if install_if_not_available:
+        warnings.warn(
+            "liteparse CLI could not be find. Running `npm install -g @llamaindex/liteparse` to install it.",
+            UserWarning,
+        )
+        result = subprocess.run(
+            ["npm", "install", "-g", "@llamaindex/liteparse"],
+        )
+        if result.returncode != 0:
+            raise subprocess.CalledProcessError(
+                result.returncode,
+                ["npm", "install", "-g", "@llamaindex/liteparse"],
+                result.stderr,
+            )
+        cli_path = shutil.which("liteparse")
+        if cli_path:
+            return cli_path
 
     raise CLINotFoundError(
         "liteparse CLI not found. Please install it with: npm i -g @llamaindex/liteparse"
@@ -209,20 +228,24 @@ class LiteParse:
         >>> print(result.text)
     """
 
-    def __init__(self, cli_path: Optional[str] = None):
+    def __init__(
+        self, cli_path: Optional[str] = None, install_if_not_available: bool = True
+    ):
         """
         Initialize LiteParse parser.
 
         Args:
             cli_path: Custom path to liteparse CLI (auto-detected if not provided)
+            install_if_not_available: Install the liteparse CLI from NPM if not available. Defaults to True.
         """
         self._cli_path = cli_path
+        self.install_if_not_available = install_if_not_available
 
     @property
     def cli_path(self) -> str:
         """Get the CLI path, finding it if not already set."""
         if self._cli_path is None:
-            self._cli_path = _find_cli()
+            self._cli_path = _find_cli(self.install_if_not_available)
         return self._cli_path
 
     def _prepare_command(

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "liteparse"
-version = "1.1.0"
+version = "1.2.0"
 description = "Python wrapper for LiteParse - fast, lightweight PDF and document parsing"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Adding auto-installation if LiteParse is not available in python wrapper. Opt-out (installed if not available by default, users can specify not to)

