### PR TITLE
fix: add format conversion to screenshot() for non-PDF inputs

### DIFF
--- a/.changeset/goofy-deserts-hug.md
+++ b/.changeset/goofy-deserts-hug.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/liteparse": patch
+---
+
+Ensure screenshot converts formats when possible

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -255,9 +255,7 @@ export class LiteParse {
       }
 
       if ("content" in conversionResult) {
-        throw new Error(
-          `Cannot screenshot text-based format. Convert to PDF first.`
-        );
+        throw new Error(`Cannot screenshot text-based format. Convert to PDF first.`);
       }
 
       const pdfPath = conversionResult.pdfPath;
@@ -284,9 +282,7 @@ export class LiteParse {
         }
 
         if ("content" in conversionResult) {
-          throw new Error(
-            `Cannot screenshot text-based format. Convert to PDF first.`
-          );
+          throw new Error(`Cannot screenshot text-based format. Convert to PDF first.`);
         }
 
         needsCleanup = true;
@@ -311,11 +307,7 @@ export class LiteParse {
         }
 
         log(`Rendering page ${pageNum}...`);
-        const imageBuffer = await renderer.renderPageToBuffer(
-          pdfInput,
-          pageNum,
-          this.config.dpi
-        );
+        const imageBuffer = await renderer.renderPageToBuffer(pdfInput, pageNum, this.config.dpi);
 
         const pageData = await this.pdfEngine.extractPage(doc, pageNum);
 


### PR DESCRIPTION
## Summary

- Add the same format-conversion pipeline used by `parse()` to `screenshot()`, so non-PDF files (DOCX, XLSX, images, ...) are automatically converted before rendering.
- Throw a clear error for text-based formats (TXT, CSV) that cannot be rendered as page images.
- Clean up temporary conversion files in the existing `finally` block.

## Problem

`screenshot()` accepts `LiteParseInput` (string | Buffer | Uint8Array), the same type as `parse()`, but passes input directly to PDF.js/PDFium with no format detection or conversion. Non-PDF files produce cryptic internal errors like "Invalid PDF structure" instead of being converted or rejected with a helpful message.

## Changes

- **`src/core/parser.ts` , `screenshot()`**:
  - Added format detection and conversion for string paths via `convertToPdf()`
  - Added format detection and conversion for buffers via `guessExtensionFromBuffer()` + `convertBufferToPdf()`
  - Text-based formats (ConversionPassthrough) now throw `"Cannot screenshot text-based format. Convert to PDF first."`
  - Track `needsCleanup`/`cleanupPath` and clean up temp files in the `finally` block
  - Removed unsafe `input as string | Uint8Array` cast in favor of resolved `pdfInput` variable
  - Updated JSDoc to document new format support and error conditions


Closes #85 