### PR TITLE
perf: parallelize HTTP OCR batch requests

### DIFF
--- a/src/engines/ocr/http-simple.ts
+++ b/src/engines/ocr/http-simple.ts
@@ -75,11 +75,6 @@ export class HttpOcrEngine implements OcrEngine {
   }
 
   async recognizeBatch(images: (string | Buffer)[], options: OcrOptions): Promise<OcrResult[][]> {
-    const results: OcrResult[][] = [];
-    for (const image of images) {
-      const result = await this.recognize(image, options);
-      results.push(result);
-    }
-    return results;
+    return Promise.all(images.map((image) => this.recognize(image, options)));
   }
 }


### PR DESCRIPTION
## Summary

- Replace sequential await-in-loop with `Promise.all` in `HttpOcrEngine.recognizeBatch()` to send all HTTP OCR requests concurrently.

## Problem

`recognizeBatch()` in `src/engines/ocr/http-simple.ts` processes images one at a time using `await` in a `for` loop. HTTP OCR servers can handle concurrent requests, so this unnecessarily serializes work. With 10 images at ~500ms each, sequential takes ~5s vs ~500ms in parallel.

The Tesseract engine's `recognizeBatch()` already uses `Promise.all` for parallel processing. The HTTP engine was inconsistent.

## Changes

- **`src/engines/ocr/http-simple.ts`**: Replace sequential loop with `Promise.all(images.map(...))`, matching the Tesseract engine's implementation.

Closes #92