### PR TITLE
fix(conversion): clean up temp dirs for unsupported buffers

### DIFF
--- a/src/conversion/convertToPdf.test.ts
+++ b/src/conversion/convertToPdf.test.ts
@@ -288,6 +288,22 @@ describe("test convertBufferToPdf", () => {
       force: true,
     });
   });
+
+  it("does not mask passthrough content when temp cleanup fails", async () => {
+    const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+
+    const { convertBufferToPdf } = await import("./convertToPdf");
+    const fsModule = await import("fs");
+    vi.mocked(fsModule.promises.rm).mockImplementationOnce(async () => {
+      throw new Error("cleanup failed");
+    });
+
+    const result = await convertBufferToPdf(zipBytes);
+
+    expect(result).toStrictEqual({
+      content: "hello world",
+    });
+  });
 });
 
 describe("test guessExtensionFromBuffer", () => {

--- a/src/conversion/convertToPdf.test.ts
+++ b/src/conversion/convertToPdf.test.ts
@@ -76,6 +76,8 @@ vi.mock("fs", async () => {
       mkdtemp: vi.fn(async () => {
         return "/tmp/test";
       }),
+      rm: vi.fn(async () => {}),
+      writeFile: vi.fn(async () => {}),
       readFile: vi.fn(async () => {
         return "hello world";
       }),
@@ -265,6 +267,25 @@ describe("test convertToPdf", () => {
     const result = await convertToPdf("test.txt");
     expect(result).toStrictEqual({
       content: "hello world",
+    });
+  });
+});
+
+describe("test convertBufferToPdf", () => {
+  it("cleans up the temp directory when an unsupported buffer returns passthrough content", async () => {
+    const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+
+    const { convertBufferToPdf } = await import("./convertToPdf");
+    const fsModule = await import("fs");
+
+    const result = await convertBufferToPdf(zipBytes);
+
+    expect(result).toStrictEqual({
+      content: "hello world",
+    });
+    expect(fsModule.promises.rm).toHaveBeenCalledWith("/tmp/test", {
+      recursive: true,
+      force: true,
     });
   });
 });

--- a/src/conversion/convertToPdf.ts
+++ b/src/conversion/convertToPdf.ts
@@ -443,7 +443,11 @@ export async function convertBufferToPdf(
   const result = await convertToPdf(tmpPath, password);
 
   if ("content" in result || "code" in result) {
-    await fs.rm(tmpDir, { recursive: true, force: true });
+    try {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup: preserve the original passthrough/error result.
+    }
   }
 
   return result;

--- a/src/conversion/convertToPdf.ts
+++ b/src/conversion/convertToPdf.ts
@@ -440,5 +440,11 @@ export async function convertBufferToPdf(
   const tmpPath = path.join(tmpDir, `input${ext}`);
   await fs.writeFile(tmpPath, data);
 
-  return convertToPdf(tmpPath, password);
+  const result = await convertToPdf(tmpPath, password);
+
+  if ("content" in result || "code" in result) {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+
+  return result;
 }


### PR DESCRIPTION
## Problem
`convertBufferToPdf()` writes input bytes to a temporary directory before delegating to `convertToPdf()`. If the delegated conversion returns passthrough content for an unsupported buffer format, that temporary directory is left behind.

## What changed
- cleaned up the temporary directory in `convertBufferToPdf()` when delegated conversion returns passthrough content or an error
- added a conversion test covering an unsupported-but-recognized buffer format returning passthrough content

## Why this fixes it
This keeps the buffer conversion temp directory tied to the lifetime of the attempted conversion instead of only the successful PDF path.

## Verification
- `npm test -- src/conversion/convertToPdf.test.ts`
- `npm run format:check`
- `npm run build`

Fixes #104