### PR TITLE
fix: propagate stderr on JSONDecodeError path in _get_parse_result

### DIFF
--- a/packages/python/liteparse/parser.py
+++ b/packages/python/liteparse/parser.py
@@ -340,7 +340,10 @@ class LiteParse:
             json_data = json.loads(stdout.decode("utf-8"))
             return _parse_json_result(json_data)
         except json.JSONDecodeError as e:
-            raise ParseError(f"Failed to parse CLI output: {e}")
+            raise ParseError(
+                f"Failed to parse CLI output: {e}",
+                stderr=stderr.decode("utf-8"),
+            )
 
     @staticmethod
     def _get_screenshot_result(


### PR DESCRIPTION
## Summary

`_get_parse_result()` has two error paths. The non-zero exit code path (line 335) correctly passes `stderr=stderr.decode("utf-8")` to `ParseError`, but the `JSONDecodeError` path (line 343) does not — the `stderr` parameter is silently dropped.

This means when the Node CLI exits 0 but produces empty or invalid stdout (e.g., LibreOffice silently fails a `.docx` conversion), callers that catch `ParseError` and inspect `exc.stderr` get `None` instead of the actual CLI stderr output, losing critical diagnostic information.

## Fix

Pass `stderr=stderr.decode("utf-8")` on the `JSONDecodeError` path, matching the existing behavior on the non-zero exit path.

## Test

```python
from liteparse import LiteParse
from liteparse.types import ParseError

try:
    LiteParse._get_parse_result(0, b'not json', b'soffice: conversion failed')
except ParseError as e:
    assert e.stderr == 'soffice: conversion failed'  # was None before fix
```