### PR TITLE
feat: add docker image + ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,14 @@ jobs:
 
       - name: Run tests
         run: npm run test
+
+  # test that docker builds
+  build-docker-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build the base Docker image
+        run: docker build .
+      - name: Build the full Docker image
+        run: docker build . -f full.Dockerfile

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,124 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    tags: ["v*.*.*"]
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME_BASE: run-llama/liteparse-base
+  IMAGE_NAME: run-llama/liteparse
+
+jobs:
+  build-and-publish-base-docker-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        with:
+          cosign-release: "v2.2.4"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_BASE }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+
+  build-and-publish-full-docker-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        with:
+          cosign-release: "v2.2.4"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: .
+          file: full.Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Stage 1: Build from source (needs build tools for native addons like sharp, pdfium)
+FROM node:24-trixie AS builder
+
+WORKDIR /build
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts=false
+
+COPY src/ ./src/
+COPY cli/ ./cli/
+COPY tsconfig.json ./
+RUN npm run build
+
+# Stage 2: Minimal runtime image
+FROM node:24-trixie-slim
+
+# sharp and @hyzyla/pdfium ship prebuilt binaries but may need these shared libs at runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libvips42 \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/local/lib/liteparse
+COPY --from=builder /build/package.json ./
+COPY --from=builder /build/dist/ ./dist/
+COPY --from=builder /build/src/vendor/pdfjs ./src/vendor/pdfjs/
+COPY --from=builder /build/node_modules/ ./node_modules/
+
+# Make the CLI executable + globally available via symlinks
+RUN chmod +x /usr/local/lib/liteparse/dist/src/index.js
+RUN ln -s /usr/local/lib/liteparse/dist/src/index.js /usr/local/bin/lit \
+    && ln -s /usr/local/lib/liteparse/dist/src/index.js /usr/local/bin/liteparse
+
+
+CMD ["/bin/sh"]

--- a/full.Dockerfile
+++ b/full.Dockerfile
@@ -1,0 +1,36 @@
+# Stage 1: Build from source (needs build tools for native addons like sharp, pdfium)
+FROM node:24-trixie AS builder
+
+WORKDIR /build
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts=false
+
+COPY src/ ./src/
+COPY cli/ ./cli/
+COPY tsconfig.json ./
+RUN npm run build
+
+# Stage 2: Minimal runtime image
+FROM node:24-trixie-slim
+
+# sharp and @hyzyla/pdfium ship prebuilt binaries but may need these shared libs at runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libvips42 \
+    ca-certificates \
+    libreoffice \
+    imagemagick \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/local/lib/liteparse
+COPY --from=builder /build/package.json ./
+COPY --from=builder /build/dist/ ./dist/
+COPY --from=builder /build/src/vendor/pdfjs ./src/vendor/pdfjs/
+COPY --from=builder /build/node_modules/ ./node_modules/
+
+# Make the CLI executable + globally available via symlinks
+RUN chmod +x /usr/local/lib/liteparse/dist/src/index.js
+RUN ln -s /usr/local/lib/liteparse/dist/src/index.js /usr/local/bin/lit \
+    && ln -s /usr/local/lib/liteparse/dist/src/index.js /usr/local/bin/liteparse
+
+
+CMD ["/bin/sh"]


### PR DESCRIPTION
- Add a base docker image with only LiteParse installed (run-llama/liteparse-base)
- Add a full docker image with LiteParse + ImageMagick + LibreOffice (run-llama/liteparse)
- Add CI workflows to test build in pull requests + build and publish to ghcr.io
