### PR TITLE
[feat] browser support

### DIFF
--- a/.changeset/big-spoons-melt.md
+++ b/.changeset/big-spoons-melt.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/liteparse": patch
+---
+
+Browser support guide

--- a/.github/workflows/browser-compat.yml
+++ b/.github/workflows/browser-compat.yml
@@ -1,0 +1,39 @@
+name: Browser Compatibility
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  browser-bundle:
+    runs-on: ubuntu-latest
+    name: Verify browser bundle builds
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Build browser bundle with Vite
+        run: npx vite build --config scripts/browser-compat/vite.config.ts
+
+      - name: Verify bundle was produced
+        run: |
+          if [ ! -d dist-browser-compat ]; then
+            echo "❌ dist-browser-compat directory not found"
+            exit 1
+          fi
+          JS_FILES=$(find dist-browser-compat -name "*.js" | wc -l)
+          if [ "$JS_FILES" -eq 0 ]; then
+            echo "❌ No JS files in dist-browser-compat"
+            exit 1
+          fi
+          echo "✅ Browser bundle produced ($JS_FILES JS file(s))"
+          du -sh dist-browser-compat/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ pnpm-lock.yaml
 
 # Build output
 dist/
+dist-browser-compat/
 bin/
 sea-prep.blob
 sea-config.json

--- a/README.md
+++ b/README.md
@@ -172,6 +172,82 @@ Non-PDF buffers (images, Office documents) are written to a temp directory for f
 const screenshots = await parser.screenshot(pdfBytes, [1, 2, 3]);
 ```
 
+### Browser Usage
+
+LiteParse's core parsing engine (PDF.js text extraction, grid projection, OCR via Tesseract.js) can run in the browser. Since the library has Node-only dependencies (sharp, fs, child_process), you'll need a bundler like Vite to swap those out with browser stubs.
+
+#### Vite Configuration
+
+The key is a Vite plugin that redirects Node-only source files to browser-safe replacements, plus `resolve.alias` entries that stub out Node built-in modules:
+
+```typescript
+// vite.config.ts
+import { defineConfig, type Plugin } from "vite";
+import { resolve, dirname } from "node:path";
+
+// Node-only files → browser stubs (you write these)
+const FILE_REDIRECTS = [
+  { match: /\/engines\/pdf\/pdfium-renderer(\.js|\.ts)?$/, target: "stubs/pdfium-renderer.ts" },
+  { match: /\/engines\/pdf\/pdfjsImporter(\.js|\.ts)?$/,   target: "stubs/pdfjsImporter.ts" },
+  { match: /\/engines\/ocr\/http-simple(\.js|\.ts)?$/,     target: "stubs/http-simple.ts" },
+  { match: /\/conversion\/convertToPdf(\.js|\.ts)?$/,      target: "stubs/convertToPdf.ts" },
+  { match: /\/processing\/gridDebugLogger(\.js|\.ts)?$/,   target: "stubs/gridDebugLogger.ts" },
+  { match: /\/processing\/gridVisualizer(\.js|\.ts)?$/,    target: "stubs/gridVisualizer.ts" },
+];
+
+function liteparseNodeRedirects(): Plugin {
+  return {
+    name: "liteparse-node-redirects",
+    enforce: "pre",
+    async resolveId(source, importer) {
+      if (!importer) return null;
+      const abs = source.startsWith(".") ? resolve(dirname(importer), source) : source;
+      for (const { match, target } of FILE_REDIRECTS) {
+        if (match.test(abs) || match.test(source)) return resolve(target);
+      }
+      return null;
+    },
+  };
+}
+
+export default defineConfig({
+  plugins: [liteparseNodeRedirects()],
+  optimizeDeps: { include: ["tesseract.js"] },
+  resolve: {
+    alias: [
+      { find: "node:fs/promises", replacement: "stubs/empty.ts" },
+      { find: "node:fs",          replacement: "stubs/empty.ts" },
+      { find: "node:url",         replacement: "stubs/empty.ts" },
+      { find: "node:path",        replacement: "stubs/empty.ts" },
+      { find: "node:os",          replacement: "stubs/empty.ts" },
+      { find: "node:child_process", replacement: "stubs/empty.ts" },
+      { find: /^fs$/,             replacement: "stubs/empty.ts" },
+      { find: /^path$/,           replacement: "stubs/empty.ts" },
+      { find: /^os$/,             replacement: "stubs/empty.ts" },
+      { find: /^child_process$/,  replacement: "stubs/empty.ts" },
+      { find: "form-data",        replacement: "stubs/empty.ts" },
+      { find: "axios",            replacement: "stubs/empty.ts" },
+      { find: "file-type",        replacement: "stubs/file-type.ts" },
+    ],
+  },
+});
+```
+
+See [`scripts/browser-compat/`](scripts/browser-compat/) for a complete working example with all the stub files.
+
+#### What works in the browser
+
+- PDF parsing from `Uint8Array` input (use `file.arrayBuffer()` to get bytes from a `<input type="file">`)
+- OCR via Tesseract.js (runs in Web Workers, fetches language data from CDN on first use)
+- Text and JSON output formats
+
+#### What doesn't work
+
+- File path input (pass `Uint8Array` instead)
+- DOCX/XLSX/PPTX/image conversion (requires LibreOffice/ImageMagick)
+- HTTP OCR server backend
+- PDFium-based screenshots (replace with PDF.js canvas rendering — see [this example](https://gist.github.com/example))
+
 ### CLI Options
 
 #### Parse Command

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ See [`scripts/browser-compat/`](scripts/browser-compat/) for a complete working 
 - File path input (pass `Uint8Array` instead)
 - DOCX/XLSX/PPTX/image conversion (requires LibreOffice/ImageMagick)
 - HTTP OCR server backend
-- PDFium-based screenshots (replace with PDF.js canvas rendering — see [this example](https://gist.github.com/example))
+- Screenshots (these use PDFium + sharp, which are native Node addons)
 
 ### CLI Options
 

--- a/docs/src/content/docs/liteparse/guides/browser-usage.md
+++ b/docs/src/content/docs/liteparse/guides/browser-usage.md
@@ -5,7 +5,7 @@ sidebar:
   order: 6
 ---
 
-LiteParse's core parsing engine — PDF.js text extraction, spatial grid projection, and OCR via Tesseract.js — can run entirely in the browser. Since the library includes Node-only dependencies (sharp, fs, child_process, etc.), you need a bundler like [Vite](https://vite.dev/) to swap those out with browser-safe stubs at build time.
+LiteParse's core parsing engine (PDF.js text extraction, spatial grid projection, and OCR via Tesseract.js) can run entirely in the browser. Since the library includes Node-only dependencies (sharp, fs, child_process, etc.), you need a bundler like [Vite](https://vite.dev/) to swap those out with browser-safe stubs at build time.
 
 ## What works in the browser
 

--- a/docs/src/content/docs/liteparse/guides/browser-usage.md
+++ b/docs/src/content/docs/liteparse/guides/browser-usage.md
@@ -1,0 +1,207 @@
+---
+title: Browser Usage
+description: Run LiteParse in the browser with Vite.
+sidebar:
+  order: 6
+---
+
+LiteParse's core parsing engine — PDF.js text extraction, spatial grid projection, and OCR via Tesseract.js — can run entirely in the browser. Since the library includes Node-only dependencies (sharp, fs, child_process, etc.), you need a bundler like [Vite](https://vite.dev/) to swap those out with browser-safe stubs at build time.
+
+## What works in the browser
+
+- **PDF parsing** from `Uint8Array` input (use `file.arrayBuffer()` to get bytes from a file picker)
+- **OCR** via Tesseract.js (runs in Web Workers, fetches language data from CDN on first use)
+- **Text and JSON output formats**
+
+## What doesn't work
+
+- **File path input** — pass `Uint8Array` instead
+- **DOCX/XLSX/PPTX/image conversion** — requires LibreOffice/ImageMagick which aren't available in the browser
+- **HTTP OCR server** — irrelevant for client-side use; Tesseract.js runs directly in the browser
+- **Screenshots** — these use PDFium + sharp, which are native Node addons
+
+## Vite setup
+
+The setup requires two things:
+
+1. **A Vite plugin** that redirects Node-only source files to browser-safe stub replacements
+2. **`resolve.alias` entries** that stub out Node built-in modules (`fs`, `path`, `child_process`, etc.)
+
+### Full Vite config
+
+```typescript
+// vite.config.ts
+import { defineConfig, type Plugin } from "vite";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = (p: string) =>
+  resolve(fileURLToPath(new URL(".", import.meta.url)), p);
+
+// These Node-only files need browser replacements.
+// Point each target at your own stub file (see below).
+const FILE_REDIRECTS: Array<{ match: RegExp; target: string }> = [
+  {
+    match: /\/engines\/pdf\/pdfium-renderer(\.js|\.ts)?$/,
+    target: here("stubs/pdfium-renderer.ts"),
+  },
+  {
+    match: /\/engines\/pdf\/pdfjsImporter(\.js|\.ts)?$/,
+    target: here("stubs/pdfjsImporter.ts"),
+  },
+  {
+    match: /\/engines\/ocr\/http-simple(\.js|\.ts)?$/,
+    target: here("stubs/http-simple.ts"),
+  },
+  {
+    match: /\/conversion\/convertToPdf(\.js|\.ts)?$/,
+    target: here("stubs/convertToPdf.ts"),
+  },
+  {
+    match: /\/processing\/gridDebugLogger(\.js|\.ts)?$/,
+    target: here("stubs/gridDebugLogger.ts"),
+  },
+  {
+    match: /\/processing\/gridVisualizer(\.js|\.ts)?$/,
+    target: here("stubs/gridVisualizer.ts"),
+  },
+];
+
+function liteparseNodeRedirects(): Plugin {
+  return {
+    name: "liteparse-node-redirects",
+    enforce: "pre",
+    async resolveId(source, importer) {
+      if (!importer) return null;
+      const importerDir = dirname(importer);
+      const absolutePath = source.startsWith(".")
+        ? resolve(importerDir, source)
+        : source;
+      for (const { match, target } of FILE_REDIRECTS) {
+        if (match.test(absolutePath) || match.test(source)) {
+          return target;
+        }
+      }
+      return null;
+    },
+  };
+}
+
+export default defineConfig({
+  plugins: [liteparseNodeRedirects()],
+  optimizeDeps: {
+    include: ["tesseract.js"],
+  },
+  resolve: {
+    alias: [
+      { find: "node:fs/promises", replacement: here("stubs/empty.ts") },
+      { find: "node:fs", replacement: here("stubs/empty.ts") },
+      { find: "node:url", replacement: here("stubs/empty.ts") },
+      { find: "node:path", replacement: here("stubs/empty.ts") },
+      { find: "node:os", replacement: here("stubs/empty.ts") },
+      { find: "node:child_process", replacement: here("stubs/empty.ts") },
+      { find: /^fs$/, replacement: here("stubs/empty.ts") },
+      { find: /^fs\/promises$/, replacement: here("stubs/empty.ts") },
+      { find: /^path$/, replacement: here("stubs/empty.ts") },
+      { find: /^os$/, replacement: here("stubs/empty.ts") },
+      { find: /^child_process$/, replacement: here("stubs/empty.ts") },
+      { find: "form-data", replacement: here("stubs/empty.ts") },
+      { find: "axios", replacement: here("stubs/empty.ts") },
+      { find: "file-type", replacement: here("stubs/file-type.ts") },
+    ],
+  },
+  define: {
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  },
+});
+```
+
+### Stub files
+
+You need to create stub files that export the same interfaces as the Node-only modules but with browser-safe (or no-op) implementations. A complete working example with all stubs is available in the [`scripts/browser-compat/`](https://github.com/run-llama/liteparse/tree/main/scripts/browser-compat) directory.
+
+The key stubs:
+
+**`stubs/empty.ts`** — catch-all for Node built-ins:
+```typescript
+export default {};
+```
+
+**`stubs/convertToPdf.ts`** — only PDF magic-byte detection is needed:
+```typescript
+export async function convertToPdf() {
+  throw new Error("File conversion is not supported in browser environments.");
+}
+export async function convertBufferToPdf() {
+  throw new Error("File conversion is not supported in browser environments.");
+}
+export async function cleanupConversionFiles() {}
+export async function guessExtensionFromBuffer(data: Uint8Array) {
+  if (data[0] === 0x25 && data[1] === 0x50 && data[2] === 0x44 && data[3] === 0x46) {
+    return ".pdf";
+  }
+  return null;
+}
+```
+
+**`stubs/pdfjsImporter.ts`** — browser-safe PDF.js loader (no `node:url`/`node:path`):
+```typescript
+// @ts-expect-error vendored ESM build has no types
+import * as pdfjs from "@llamaindex/liteparse/vendor/pdfjs/pdf.mjs";
+
+export async function importPdfJs() {
+  return {
+    fn: (pdfjs as any).getDocument,
+    dir: new URL("@llamaindex/liteparse/vendor/pdfjs", import.meta.url).href,
+  };
+}
+```
+
+**`stubs/file-type.ts`** — minimal file type detection:
+```typescript
+export async function fileTypeFromBuffer(buf: Uint8Array) {
+  if (buf[0] === 0x25 && buf[1] === 0x50 && buf[2] === 0x44 && buf[3] === 0x46) {
+    return { ext: "pdf", mime: "application/pdf" };
+  }
+  return undefined;
+}
+export async function fileTypeFromFile() {
+  return undefined;
+}
+```
+
+The remaining stubs (`pdfium-renderer`, `http-simple`, `gridDebugLogger`, `gridVisualizer`) just need to export the same class/function names with no-op implementations. See the full example in `scripts/browser-compat/stubs/`.
+
+## Usage in your app
+
+Once the bundler is configured, use LiteParse the same way as in Node — just pass `Uint8Array` instead of file paths:
+
+```typescript
+import { LiteParse } from "@llamaindex/liteparse";
+
+const parser = new LiteParse({
+  ocrEnabled: true,
+  outputFormat: "json",
+});
+
+// From a file picker
+const fileInput = document.querySelector<HTMLInputElement>("#file")!;
+fileInput.addEventListener("change", async () => {
+  const file = fileInput.files?.[0];
+  if (!file) return;
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const result = await parser.parse(bytes);
+
+  console.log(result.text);
+  console.log(JSON.stringify(result.json, null, 2));
+});
+```
+
+## Known gotchas
+
+- **First OCR run is slow.** Tesseract.js fetches `eng.traineddata` (~10 MB) from the jsdelivr CDN on first use. Subsequent runs use the browser cache.
+- **`file://` doesn't work.** The PDF.js worker and WASM assets need to be served over HTTP. Use `vite dev` or a static server.
+- **Safari < 17.** Older Safari/iOS WebKit ships `ReadableStream` without `Symbol.asyncIterator`, which PDF.js needs. You may need a polyfill — see the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream#browser_compatibility).
+- **ArrayBuffer detachment.** PDF.js transfers the input buffer to its worker, which detaches the original `ArrayBuffer`. If you need the bytes again after parsing (e.g., for screenshots), read the file a second time with `file.arrayBuffer()`.
+- **Bundle size.** Expect ~500 KB for the app bundle plus ~2.3 MB for the PDF.js worker. Tesseract loads lazily on first OCR run.

--- a/scripts/browser-compat/entry.ts
+++ b/scripts/browser-compat/entry.ts
@@ -1,0 +1,10 @@
+// Minimal entry point that exercises the LiteParse browser import path.
+// If this bundles successfully with Vite, the browser compat config works.
+import { LiteParse } from "../../src/lib.js";
+export type { ParseResult, LiteParseConfig } from "../../src/lib.js";
+
+// Instantiate to verify the constructor doesn't crash at bundle time
+const parser = new LiteParse({ ocrEnabled: false, outputFormat: "text" });
+
+// Export so Vite doesn't tree-shake it away
+export { parser, LiteParse };

--- a/scripts/browser-compat/stubs/convertToPdf.ts
+++ b/scripts/browser-compat/stubs/convertToPdf.ts
@@ -1,0 +1,18 @@
+// Browser stub — only PDF input is supported, no file conversion.
+export const officeExtensions: string[] = [];
+export const spreadsheetExtensions: string[] = [];
+export const imageExtensions: string[] = [];
+export const htmlExtensions: string[] = [];
+export async function convertToPdf() {
+  throw new Error("File conversion is not supported in browser environments.");
+}
+export async function convertBufferToPdf() {
+  throw new Error("File conversion is not supported in browser environments.");
+}
+export async function cleanupConversionFiles() {}
+export async function guessExtensionFromBuffer(data: Uint8Array) {
+  if (data[0] === 0x25 && data[1] === 0x50 && data[2] === 0x44 && data[3] === 0x46) {
+    return ".pdf";
+  }
+  return null;
+}

--- a/scripts/browser-compat/stubs/empty.ts
+++ b/scripts/browser-compat/stubs/empty.ts
@@ -1,0 +1,2 @@
+// Empty stub for Node built-in modules that aren't available in browsers.
+export default {};

--- a/scripts/browser-compat/stubs/file-type.ts
+++ b/scripts/browser-compat/stubs/file-type.ts
@@ -1,0 +1,10 @@
+// Browser stub for file-type. Only PDF magic-byte detection is needed.
+export async function fileTypeFromBuffer(buf: Uint8Array) {
+  if (buf[0] === 0x25 && buf[1] === 0x50 && buf[2] === 0x44 && buf[3] === 0x46) {
+    return { ext: "pdf", mime: "application/pdf" };
+  }
+  return undefined;
+}
+export async function fileTypeFromFile() {
+  return undefined;
+}

--- a/scripts/browser-compat/stubs/gridDebugLogger.ts
+++ b/scripts/browser-compat/stubs/gridDebugLogger.ts
@@ -1,0 +1,36 @@
+// Browser stub — debug logging is a no-op.
+export interface GridDebugConfig { enabled: boolean; }
+export const DEFAULT_DEBUG_CONFIG = { enabled: false };
+export interface RenderedSegment { lineIndex: number; gridCol: number; text: string; snap: string; }
+export interface RenderTraceContext {}
+export interface VisualizerPageData { pageNum: number; segments: RenderedSegment[]; rawLines: string[]; }
+
+export class GridDebugLogger {
+  config = { enabled: false };
+  get enabled() { return false; }
+  get shouldVisualize() { return false; }
+  get visualizerPages(): VisualizerPageData[] { return []; }
+  get debugConfig() { return this.config; }
+  matchesBbox() { return false; }
+  setPage() {}
+  logBlock() {}
+  logFlowingBlock() {}
+  logStructuredBlock() {}
+  logFlowingLine() {}
+  logAnchors() {}
+  logSnapAssignment() {}
+  captureRender() {}
+  captureRawLines() {}
+  logRender() {}
+  logForwardAnchor() {}
+  logDuplicateResolution() {}
+  logBlockContext() {}
+  logRenderTrace() {}
+  logForwardAnchorMutation() {}
+  logLineComposition() {}
+  flushSync() {}
+  async flush() {}
+}
+
+export const NOOP_LOGGER = new GridDebugLogger();
+export function createGridDebugLogger() { return NOOP_LOGGER; }

--- a/scripts/browser-compat/stubs/gridVisualizer.ts
+++ b/scripts/browser-compat/stubs/gridVisualizer.ts
@@ -1,0 +1,3 @@
+// Browser stub — grid visualization is a no-op.
+export async function renderGridVisualization() {}
+export async function renderAllVisualizations() { return []; }

--- a/scripts/browser-compat/stubs/http-simple.ts
+++ b/scripts/browser-compat/stubs/http-simple.ts
@@ -1,0 +1,9 @@
+// Browser stub — HTTP OCR is not available, use Tesseract.js instead.
+export class HttpOcrEngine {
+  name = "http-ocr";
+  constructor() {
+    throw new Error("HTTP OCR engine is not available in browser environments.");
+  }
+  async recognize() { throw new Error("Not available in browser."); }
+  async recognizeBatch() { throw new Error("Not available in browser."); }
+}

--- a/scripts/browser-compat/stubs/pdfium-renderer.ts
+++ b/scripts/browser-compat/stubs/pdfium-renderer.ts
@@ -1,0 +1,11 @@
+// Browser stub for PdfiumRenderer.
+// A real browser app would replace this with a PDF.js canvas renderer.
+// This stub is enough to verify the bundle builds.
+export class PdfiumRenderer {
+  async init() {}
+  async loadDocument() {}
+  closeDocument() {}
+  async renderPageToBuffer() { return new Uint8Array(0); }
+  async extractImageBounds() { return []; }
+  async close() {}
+}

--- a/scripts/browser-compat/stubs/pdfjsImporter.ts
+++ b/scripts/browser-compat/stubs/pdfjsImporter.ts
@@ -1,0 +1,11 @@
+// Browser stub for pdfjsImporter.
+// In a real browser app, this would configure PDF.js worker and asset URLs.
+// @ts-expect-error vendored ESM build has no types
+import * as pdfjs from "../../../src/vendor/pdfjs/pdf.mjs";
+
+export async function importPdfJs() {
+  return {
+    fn: (pdfjs as { getDocument: unknown }).getDocument,
+    dir: new URL("../../../src/vendor/pdfjs", import.meta.url).href,
+  };
+}

--- a/scripts/browser-compat/vite.config.ts
+++ b/scripts/browser-compat/vite.config.ts
@@ -1,0 +1,100 @@
+/**
+ * Minimal Vite config that verifies LiteParse can be bundled for the browser.
+ * This mirrors the recommended configuration from the README.
+ *
+ * Run: npx vite build --config scripts/browser-compat/vite.config.ts
+ */
+import { defineConfig, type Plugin } from "vite";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const here = (p: string) => resolve(root, p);
+
+// Node-only source files that must be replaced with browser stubs.
+const FILE_REDIRECTS: Array<{ match: RegExp; target: string }> = [
+  {
+    match: /\/engines\/pdf\/pdfium-renderer(\.js|\.ts)?$/,
+    target: here("scripts/browser-compat/stubs/pdfium-renderer.ts"),
+  },
+  {
+    match: /\/engines\/pdf\/pdfjsImporter(\.js|\.ts)?$/,
+    target: here("scripts/browser-compat/stubs/pdfjsImporter.ts"),
+  },
+  {
+    match: /\/engines\/ocr\/http-simple(\.js|\.ts)?$/,
+    target: here("scripts/browser-compat/stubs/http-simple.ts"),
+  },
+  {
+    match: /\/conversion\/convertToPdf(\.js|\.ts)?$/,
+    target: here("scripts/browser-compat/stubs/convertToPdf.ts"),
+  },
+  {
+    match: /\/processing\/gridDebugLogger(\.js|\.ts)?$/,
+    target: here("scripts/browser-compat/stubs/gridDebugLogger.ts"),
+  },
+  {
+    match: /\/processing\/gridVisualizer(\.js|\.ts)?$/,
+    target: here("scripts/browser-compat/stubs/gridVisualizer.ts"),
+  },
+];
+
+function liteparseNodeRedirects(): Plugin {
+  return {
+    name: "liteparse-node-redirects",
+    enforce: "pre",
+    async resolveId(source, importer) {
+      if (!importer) return null;
+      const importerDir = dirname(importer);
+      const absolutePath = source.startsWith(".")
+        ? resolve(importerDir, source)
+        : source;
+      for (const { match, target } of FILE_REDIRECTS) {
+        if (match.test(absolutePath) || match.test(source)) {
+          return target;
+        }
+      }
+      return null;
+    },
+  };
+}
+
+export default defineConfig({
+  root: here("scripts/browser-compat"),
+  build: {
+    outDir: resolve(root, "dist-browser-compat"),
+    emptyOutDir: true,
+    target: "es2022",
+    rollupOptions: {
+      input: here("scripts/browser-compat/entry.ts"),
+    },
+  },
+  server: {
+    fs: { allow: [root] },
+  },
+  optimizeDeps: {
+    include: ["tesseract.js"],
+  },
+  plugins: [liteparseNodeRedirects()],
+  resolve: {
+    alias: [
+      { find: "node:fs/promises", replacement: here("scripts/browser-compat/stubs/empty.ts") },
+      { find: "node:fs", replacement: here("scripts/browser-compat/stubs/empty.ts") },
+      { find: "node:url", replacement: here("scripts/browser-compat/stubs/empty.ts") },
+      { find: "node:path", replacement: here("scripts/browser-compat/stubs/empty.ts") },
+      { find: "node:os", replacement: here("scripts/browser-compat/stubs/empty.ts") },
+      { find: "node:child_process", replacement: here("scripts/browser-compat/stubs/empty.ts") },
+      { find: /^fs$/, replacement: here("scripts/browser-compat/stubs/empty.ts") },
+      { find: /^fs\/promises$/, replacement: here("scripts/browser-compat/stubs/empty.ts") },
+      { find: /^path$/, replacement: here("scripts/browser-compat/stubs/empty.ts") },
+      { find: /^os$/, replacement: here("scripts/browser-compat/stubs/empty.ts") },
+      { find: /^child_process$/, replacement: here("scripts/browser-compat/stubs/empty.ts") },
+      { find: "form-data", replacement: here("scripts/browser-compat/stubs/empty.ts") },
+      { find: "axios", replacement: here("scripts/browser-compat/stubs/empty.ts") },
+      { find: "file-type", replacement: here("scripts/browser-compat/stubs/file-type.ts") },
+    ],
+  },
+  define: {
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  },
+});

--- a/src/engines/ocr/tesseract.ts
+++ b/src/engines/ocr/tesseract.ts
@@ -12,7 +12,9 @@ export class TesseractEngine implements OcrEngine {
   constructor(concurrency: number = 4, tessdataPath?: string) {
     this.concurrency = concurrency;
     // Use explicit path, then TESSDATA_PREFIX env var, then let tesseract.js default (CDN)
-    this.tessdataPath = tessdataPath || process.env.TESSDATA_PREFIX || undefined;
+    const envPath =
+      typeof process !== "undefined" && process.env ? process.env.TESSDATA_PREFIX : undefined;
+    this.tessdataPath = tessdataPath || envPath || undefined;
   }
 
   async initialize(language: string = "eng"): Promise<void> {

--- a/src/engines/pdf/pdfjs.ts
+++ b/src/engines/pdf/pdfjs.ts
@@ -669,13 +669,18 @@ export class PdfJsEngine implements PdfEngine {
       data = new Uint8Array(await fs.readFile(input));
       this.currentPdfPath = input;
     } else {
-      // pdf.js requires a plain Uint8Array, not a Buffer subclass
-      data = new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+      // pdf.js requires a plain Uint8Array, not a Buffer subclass. Copy
+      // rather than view-on-input, because pdf.js transfers the underlying
+      // ArrayBuffer to its worker — which would detach the caller's view
+      // and any downstream consumer (e.g. the OCR renderer) would see zero
+      // bytes. A fresh Uint8Array owns its own ArrayBuffer.
+      data = new Uint8Array(input);
       this.currentPdfPath = null;
     }
 
-    // Store data for buffer-based rendering
-    this.currentPdfData = data;
+    // Store data for buffer-based rendering. Keep a separate copy so the
+    // one we hand to pdf.js can be transferred without affecting this one.
+    this.currentPdfData = new Uint8Array(data);
 
     const loadingTask = getDocument({
       data,


### PR DESCRIPTION
Inspired by https://github.com/run-llama/liteparse/issues/147 and https://github.com/run-llama/liteparse/pull/148, this PR adds an initial attempt at browser support.

The support itself is nearly entirely dependent on using vite to stub out all the node/system stuff. This is admittedly a half measure. Full browser support would likely require either a separate package or a complete revamp of how `fs` and dependencies like `canvas` and `sharp` are used.