### PR TITLE
fix: correct tgz install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ git clone https://github.com/run-llama/liteparse.git
 cd liteparse
 npm run build
 npm pack
-npm install -g ./liteparse-*.tgz
+npm install -g ./llamaindex-liteparse-*.tgz
 ```
 
 ### Agent Skill


### PR DESCRIPTION
## Problem
The README uses an incorrect wildcard pattern (`liteparse-*.tgz`) for `npm install` that does not match the actual filename generated by `npm pack` causing `ENOENT: no such file or directory` error
```bash
npm install -g ./liteparse-*.tgz
```

## Changes
- Updated install command to use the correct tarball naming pattern (`llamaindex-liteparse-<version>.tgz`)
```bash
npm install -g ./llamaindex-liteparse-*.tgz
```