### PR TITLE
feat: Add OCR-only text mode for corrupted native PDF text layers

### DIFF
--- a/.changeset/hip-suits-speak.md
+++ b/.changeset/hip-suits-speak.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/liteparse": minor
+---
+
+Add `ocrTextMode` with an `ocr-only` option for pages where OCR runs. This lets callers ignore native PDF text on OCR'd pages when the document has a corrupted or hidden text layer, while keeping the existing merge behavior as the default.

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Options:
   --ocr-server-url <url>  HTTP OCR server URL (uses Tesseract if not provided)
   --no-ocr                Disable OCR
   --ocr-language <lang>   OCR language(s) (default: "en")
+  --ocr-text-mode <mode>  How to combine native text and OCR text (choices: "merge", "ocr-only")
   --num-workers <n>       Number of pages to OCR in parallel (default: CPU cores - 1)
   --max-pages <n>         Max pages to parse (default: "10000")
   --target-pages <pages>  Target pages (e.g., "1-5,10,15-20")
@@ -289,6 +290,7 @@ Options:
   --ocr-server-url <url>  HTTP OCR server URL (uses Tesseract if not provided)
   --no-ocr                Disable OCR
   --ocr-language <lang>   OCR language(s) (default: "en")
+  --ocr-text-mode <mode>  How to combine native text and OCR text (choices: "merge", "ocr-only")
   --num-workers <n>       Number of pages to OCR in parallel (default: CPU cores - 1)
   --max-pages <n>         Max pages to parse per file (default: "10000")
   --dpi <dpi>             DPI for rendering (default: "150")
@@ -427,6 +429,7 @@ Create a `liteparse.config.json` file:
 {
   "ocrLanguage": "en",
   "ocrEnabled": true,
+  "ocrTextMode": "merge",
   "maxPages": 1000,
   "dpi": 150,
   "outputFormat": "json",
@@ -435,6 +438,8 @@ Create a `liteparse.config.json` file:
   "password": "optional_password"
 }
 ```
+
+Set `"ocrTextMode": "ocr-only"` to use only OCR text on pages where OCR runs. This can help with PDFs whose native text layer is corrupted or hidden.
 
 For HTTP OCR servers, just add `ocrServerUrl`:
 

--- a/cli/parse.ts
+++ b/cli/parse.ts
@@ -4,7 +4,7 @@ import { existsSync, readdirSync, statSync } from "fs";
 import os from "os";
 import path from "path";
 import { LiteParse } from "../src/core/parser.js";
-import { LiteParseConfig, OutputFormat } from "../src/core/types.js";
+import { LiteParseConfig, OcrTextMode, OutputFormat } from "../src/core/types.js";
 import { performance } from "perf_hooks";
 import pkg from "../package.json" with { type: "json" };
 
@@ -21,6 +21,7 @@ interface ParseCommandOptions {
   ocrServerUrl?: string;
   ocr?: boolean;
   ocrLanguage?: string;
+  ocrTextMode?: string;
   numWorkers?: string;
   maxPages?: string;
   targetPages?: string;
@@ -54,6 +55,7 @@ interface BatchParseCommandOptions {
   ocrServerUrl?: string;
   ocr?: boolean;
   ocrLanguage?: string;
+  ocrTextMode?: string;
   numWorkers?: string;
   maxPages?: string;
   dpi?: string;
@@ -80,6 +82,12 @@ program
   .option("--ocr-server-url <url>", "HTTP OCR server URL (uses Tesseract if not provided)")
   .option("--no-ocr", "Disable OCR")
   .option("--ocr-language <lang>", "OCR language(s)", DEFAULT_LANGUAGE)
+  .addOption(
+    new Option("--ocr-text-mode <mode>", "How to combine native text and OCR text").choices([
+      "merge",
+      "ocr-only",
+    ])
+  )
   .option(
     "--num-workers <n>",
     "Number of pages to OCR in parallel. Defaults to number of CPU cores minus one."
@@ -148,6 +156,10 @@ program
         preserveVerySmallText: options.preserveSmallText || false,
         password: options.password,
       };
+
+      if (options.ocrTextMode) {
+        config.ocrTextMode = options.ocrTextMode as OcrTextMode;
+      }
 
       // Build debug config if any debug flags are set
       if (options.debug || options.debugTrace || options.debugVisualize) {
@@ -354,6 +366,12 @@ program
   .option("--ocr-server-url <url>", "HTTP OCR server URL (uses Tesseract if not provided)")
   .option("--no-ocr", "Disable OCR")
   .option("--ocr-language <lang>", "OCR language(s)", DEFAULT_LANGUAGE)
+  .addOption(
+    new Option("--ocr-text-mode <mode>", "How to combine native text and OCR text").choices([
+      "merge",
+      "ocr-only",
+    ])
+  )
   .option(
     "--num-workers <n>",
     "Number of pages to OCR in parallel. Defaults to number of CPU cores minus one."
@@ -432,6 +450,10 @@ program
         preciseBoundingBox: options.preciseBbox !== false,
         password: options.password,
       };
+
+      if (options.ocrTextMode) {
+        config.ocrTextMode = options.ocrTextMode as OcrTextMode;
+      }
 
       // Create a SINGLE parser instance for all files (key for batch efficiency)
       const parser = new LiteParse(config);

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -7,16 +7,19 @@ describe("test config", () => {
     const user_config: Partial<LiteParseConfig> = {};
     const config = mergeConfig(user_config);
     expect(config).toStrictEqual(DEFAULT_CONFIG);
+    expect(config.ocrTextMode).toBe("merge");
   });
   it("test merge config overrides defaults", () => {
     const user_config: Partial<LiteParseConfig> = {
       ocrLanguage: "fr",
       ocrServerUrl: "http://localhost:8000",
+      ocrTextMode: "ocr-only",
       dpi: 200,
     };
     const config = mergeConfig(user_config);
     expect(config.ocrLanguage).toBe(user_config.ocrLanguage);
     expect(config.ocrServerUrl).toBe(user_config.ocrServerUrl);
+    expect(config.ocrTextMode).toBe(user_config.ocrTextMode);
     expect(config.dpi).toBe(user_config.dpi);
   });
 });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -6,6 +6,7 @@ export const DEFAULT_CONFIG: LiteParseConfig = {
   ocrLanguage: "en",
   ocrEnabled: true,
   ocrServerUrl: undefined, // If set, uses HTTP OCR; otherwise uses Tesseract
+  ocrTextMode: "merge",
   numWorkers: 4, // Number of pages to OCR in parallel
 
   // Processing

--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -344,7 +344,7 @@ const {
 });
 
 import { LiteParse } from "./parser";
-import { LiteParseConfig, ScreenshotResult } from "./types";
+import { LiteParseConfig, ScreenshotResult, TextItem } from "./types";
 
 vi.mock("../conversion/convertToPdf.js", async () => {
   const actual = await vi.importActual<typeof import("../conversion/convertToPdf.js")>(
@@ -426,6 +426,7 @@ vi.mock("../processing/grid.js", async () => {
     ...actual,
     projectPagesToGrid: vi
       .fn()
+      .mockImplementation((pages) => structuredClone(pages))
       // these get modified, so we need to pass a deep copy of the array instead of the original one
       .mockImplementationOnce(() => structuredClone(mockParsedPages)) // no ocr - text
       .mockImplementationOnce(() => structuredClone(mockParsedPages)) // no ocr - json
@@ -595,6 +596,39 @@ describe("Parse tests", () => {
         return typeof page.boundingBoxes != "undefined";
       }).length
     ).toBe(0);
+  });
+
+  it("test ocrTextMode ocr-only uses only OCR text items", async () => {
+    const nativeTextItem: TextItem = {
+      str: "Native text",
+      x: 10,
+      y: 20,
+      width: 190,
+      height: 20,
+      w: 190,
+      h: 20,
+      fontName: "PDF",
+      fontSize: 20,
+      confidence: 1,
+    };
+
+    mockPages.forEach((page) => {
+      (page as { textItems: TextItem[] }).textItems = [nativeTextItem];
+    });
+
+    const config: Partial<LiteParseConfig> = {
+      ocrEnabled: true,
+      outputFormat: "text",
+      ocrTextMode: "ocr-only",
+    };
+    const liteparse = new LiteParse(config);
+    const result = await liteparse.parse("/tmp/test.docx");
+
+    expect(result.pages.at(0)!.textItems.map((item) => item.str)).toStrictEqual(
+      mockOcrResults.map((result) => result.text)
+    );
+    expect(result.pages.at(0)!.textItems.every((item) => item.fontName === "OCR")).toBe(true);
+    expect(result.pages.at(0)!.textItems.some((item) => item.fontName === "PDF")).toBe(false);
   });
 });
 

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -395,68 +395,74 @@ export class LiteParse {
         // Scale factor to convert from OCR pixels to PDF points
         // OCR operates at config.dpi, PDF uses 72 points per inch (PDF spec constant)
         const scaleFactor = 72 / this.config.dpi;
+        const useOcrOnly = this.config.ocrTextMode === "ocr-only";
+        const confidentOcrResults = ocrResults.filter((r) => r.confidence > 0.1);
+        let filteredOcrResults = confidentOcrResults;
 
-        // Helper to check if an OCR result overlaps with garbled regions
-        const overlapsGarbledRegion = (ocrBbox: number[]): boolean => {
-          if (!page.garbledTextRegions) return false;
+        if (!useOcrOnly) {
+          // Helper to check if an OCR result overlaps with garbled regions
+          const overlapsGarbledRegion = (ocrBbox: number[]): boolean => {
+            if (!page.garbledTextRegions) return false;
 
-          const ocrX = ocrBbox[0] * scaleFactor;
-          const ocrY = ocrBbox[1] * scaleFactor;
-          const ocrW = (ocrBbox[2] - ocrBbox[0]) * scaleFactor;
-          const ocrH = (ocrBbox[3] - ocrBbox[1]) * scaleFactor;
+            const ocrX = ocrBbox[0] * scaleFactor;
+            const ocrY = ocrBbox[1] * scaleFactor;
+            const ocrW = (ocrBbox[2] - ocrBbox[0]) * scaleFactor;
+            const ocrH = (ocrBbox[3] - ocrBbox[1]) * scaleFactor;
 
-          // Check overlap with any garbled region (with some tolerance)
-          const tolerance = 5; // PDF points
-          for (const region of page.garbledTextRegions) {
-            const overlapX =
-              ocrX < region.x + region.width + tolerance && ocrX + ocrW > region.x - tolerance;
-            const overlapY =
-              ocrY < region.y + region.height + tolerance && ocrY + ocrH > region.y - tolerance;
-            if (overlapX && overlapY) {
+            // Check overlap with any garbled region (with some tolerance)
+            const tolerance = 5; // PDF points
+            for (const region of page.garbledTextRegions) {
+              const overlapX =
+                ocrX < region.x + region.width + tolerance && ocrX + ocrW > region.x - tolerance;
+              const overlapY =
+                ocrY < region.y + region.height + tolerance && ocrY + ocrH > region.y - tolerance;
+              if (overlapX && overlapY) {
+                return true;
+              }
+            }
+            return false;
+          };
+
+          // Helper to check if an OCR result spatially overlaps with existing PDF text
+          // This prevents duplicating text that PDF already extracted correctly
+          const overlapsExistingText = (ocrBbox: number[]): boolean => {
+            const ocrX = ocrBbox[0] * scaleFactor;
+            const ocrY = ocrBbox[1] * scaleFactor;
+            const ocrW = (ocrBbox[2] - ocrBbox[0]) * scaleFactor;
+            const ocrH = (ocrBbox[3] - ocrBbox[1]) * scaleFactor;
+
+            const tolerance = 2; // PDF points - tighter tolerance for existing text
+            for (const item of page.textItems) {
+              const itemRight = item.x + (item.width || item.w || 0);
+              const itemBottom = item.y + (item.height || item.h || 0);
+
+              const overlapX = ocrX < itemRight + tolerance && ocrX + ocrW > item.x - tolerance;
+              const overlapY = ocrY < itemBottom + tolerance && ocrY + ocrH > item.y - tolerance;
+
+              if (overlapX && overlapY) {
+                return true;
+              }
+            }
+            return false;
+          };
+
+          filteredOcrResults = confidentOcrResults
+            .filter((r) => {
+              // For targeted OCR (garbled regions only), only include results that overlap
+              if (hasGarbledRegions && !needsFullOcr) {
+                return overlapsGarbledRegion(r.bbox);
+              }
+              // For full OCR, include all results
               return true;
-            }
-          }
-          return false;
-        };
+            })
+            .filter((r) => {
+              // Skip OCR results that spatially overlap with existing PDF text
+              // This prevents duplicating text that PDF already extracted correctly
+              return !overlapsExistingText(r.bbox);
+            });
+        }
 
-        // Helper to check if an OCR result spatially overlaps with existing PDF text
-        // This prevents duplicating text that PDF already extracted correctly
-        const overlapsExistingText = (ocrBbox: number[]): boolean => {
-          const ocrX = ocrBbox[0] * scaleFactor;
-          const ocrY = ocrBbox[1] * scaleFactor;
-          const ocrW = (ocrBbox[2] - ocrBbox[0]) * scaleFactor;
-          const ocrH = (ocrBbox[3] - ocrBbox[1]) * scaleFactor;
-
-          const tolerance = 2; // PDF points - tighter tolerance for existing text
-          for (const item of page.textItems) {
-            const itemRight = item.x + (item.width || item.w || 0);
-            const itemBottom = item.y + (item.height || item.h || 0);
-
-            const overlapX = ocrX < itemRight + tolerance && ocrX + ocrW > item.x - tolerance;
-            const overlapY = ocrY < itemBottom + tolerance && ocrY + ocrH > item.y - tolerance;
-
-            if (overlapX && overlapY) {
-              return true;
-            }
-          }
-          return false;
-        };
-
-        const ocrTextItems: TextItem[] = ocrResults
-          .filter((r) => r.confidence > 0.1) // Filter low confidence
-          .filter((r) => {
-            // For targeted OCR (garbled regions only), only include results that overlap
-            if (hasGarbledRegions && !needsFullOcr) {
-              return overlapsGarbledRegion(r.bbox);
-            }
-            // For full OCR, include all results
-            return true;
-          })
-          .filter((r) => {
-            // Skip OCR results that spatially overlap with existing PDF text
-            // This prevents duplicating text that PDF already extracted correctly
-            return !overlapsExistingText(r.bbox);
-          })
+        const ocrTextItems: TextItem[] = filteredOcrResults
           .map((r) => {
             // Clean OCR artifacts from table border misreads
             const cleanedText = cleanOcrTableArtifacts(r.text);
@@ -475,8 +481,13 @@ export class LiteParse {
           })
           .filter((item) => item.str.length > 0); // Skip items that became empty after cleaning
 
-        // Add OCR text items directly to page textItems
-        page.textItems.push(...ocrTextItems);
+        if (useOcrOnly) {
+          // Native PDF text can contain bad hidden layers; allow OCR to be the source of truth.
+          page.textItems = ocrTextItems;
+        } else {
+          // Add OCR text items directly to page textItems
+          page.textItems.push(...ocrTextItems);
+        }
         log(`  Found ${ocrTextItems.length} text items from OCR on page ${page.pageNum}`);
       }
     } catch (error) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -9,6 +9,14 @@ import type { GridDebugConfig } from "../processing/gridDebugLogger.js";
 export type OutputFormat = "json" | "text";
 
 /**
+ * Controls how OCR text is combined with native PDF text on pages where OCR runs.
+ *
+ * - `"merge"` keeps existing behavior by adding non-overlapping OCR text to native text.
+ * - `"ocr-only"` uses OCR text only for OCR'd pages, useful for PDFs with bad hidden text layers.
+ */
+export type OcrTextMode = "merge" | "ocr-only";
+
+/**
  * Accepted input types for {@link LiteParse.parse} and {@link LiteParse.screenshot}.
  *
  * - `string` — A file path to a document on disk.
@@ -57,6 +65,14 @@ export interface LiteParseConfig {
    * @see {@link https://github.com/run-llama/liteparse/blob/main/OCR_API_SPEC.md | OCR API Specification}
    */
   ocrServerUrl?: string;
+
+  /**
+   * How OCR text should be combined with native PDF text on pages where OCR runs.
+   * Use `"ocr-only"` when native PDF text is corrupted or hidden text should be ignored.
+   *
+   * @defaultValue `"merge"`
+   */
+  ocrTextMode: OcrTextMode;
 
   /**
    * Path to a directory containing Tesseract `.traineddata` files.


### PR DESCRIPTION
Adds a new `ocrTextMode` parser option for controlling how OCR text is combined with native PDF text on pages where OCR runs.

The default remains:

```json
{
  "ocrTextMode": "merge"
}
```

which preserves the existing behavior.

A new opt-in mode is added:

```json
{
  "ocrTextMode": "ocr-only"
}
```

When enabled, LiteParse uses OCR-derived text items as the source of truth for pages where OCR runs, instead of merging OCR results into the native PDF text layer.

## Motivation

Some PDFs contain a visible page image plus a corrupted or misleading native text layer. In those cases, PDF.js can extract native text items that look structurally valid but produce unreadable output after layout projection.

This creates two problems:

- The corrupted native text remains in `page.textItems`.
- The existing OCR merge path may discard OCR results that overlap native PDF text, assuming the native text is trustworthy.

For these PDFs, OCR successfully reads the visible document, but the final LiteParse output can still be dominated by the bad native text layer.

I cannot attach the source document used to reproduce this because it is proprietary, but the observed behavior was:

```text
Running OCR on pages...
  OCR on page 1...
  Found 0 text items from OCR on page 1
```

The OCR engine had returned results, but they were filtered out because they overlapped existing native PDF text. Using OCR as the only text source for OCR'd pages fixed the extracted output.

## Behavior

`ocrTextMode: "merge"`:

- Existing/default behavior.
- Keeps native PDF text.
- Adds OCR text that passes the existing confidence, garbled-region, and overlap filters.

`ocrTextMode: "ocr-only"`:

- Applies only to pages where OCR actually runs.
- Keeps OCR results above the existing confidence threshold.
- Skips native-text overlap filtering.
- Replaces `page.textItems` with OCR-derived text items for that page.

This does not force OCR to run on every page. It only changes the text-combination behavior after OCR has already been selected for a page.

## CLI

Adds the option to both parse commands:

```bash
lit parse document.pdf --ocr-text-mode ocr-only
lit batch-parse input-dir output-dir --ocr-text-mode ocr-only
```

## Why this is opt-in

The current merge behavior is still useful for normal PDFs where the native text layer is reliable and OCR only fills in missing image text.

`ocr-only` is intended for documents where the native text layer is known to be corrupted, hidden, or less reliable than OCR.