### PR TITLE
fix(conversion): remove temp dirs on buffer text passthrough

### DIFF
--- a/src/conversion/convertBufferToPdf.test.ts
+++ b/src/conversion/convertBufferToPdf.test.ts
@@ -1,0 +1,65 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { convertBufferToPdf, convertToPdf, getTmpDir } from "./convertToPdf.js";
+
+describe("convertBufferToPdf temp cleanup", () => {
+  let previousTmpDir: string | undefined;
+  let testTmpRoot: string;
+
+  afterEach(async () => {
+    if (previousTmpDir === undefined) {
+      delete process.env.LITEPARSE_TMPDIR;
+    } else {
+      process.env.LITEPARSE_TMPDIR = previousTmpDir;
+    }
+    await fs.rm(testTmpRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function withIsolatedTmpDir<T>(fn: () => Promise<T>): Promise<T> {
+    previousTmpDir = process.env.LITEPARSE_TMPDIR;
+    testTmpRoot = path.join(os.tmpdir(), `liteparse-cleanup-test-${Date.now()}`);
+    await fs.mkdir(testTmpRoot, { recursive: true });
+    process.env.LITEPARSE_TMPDIR = testTmpRoot;
+    return fn();
+  }
+
+  async function listLiteparseDirs(): Promise<string[]> {
+    const entries = await fs.readdir(testTmpRoot, { withFileTypes: true });
+    return entries.filter((e) => e.isDirectory() && e.name.startsWith("liteparse-")).map((e) => e.name);
+  }
+
+  it("removes staging temp dir on text passthrough", async () => {
+    await withIsolatedTmpDir(async () => {
+      const result = await convertBufferToPdf(Buffer.from("Hello, world\n", "utf-8"));
+      expect(result).toEqual({ content: "Hello, world\n" });
+      expect(await listLiteparseDirs()).toEqual([]);
+    });
+  });
+
+  it("does not leave extra temp dirs for path-based text passthrough", async () => {
+    await withIsolatedTmpDir(async () => {
+      const txtPath = path.join(testTmpRoot, "sample.txt");
+      await fs.writeFile(txtPath, "plain text content");
+
+      const result = await convertToPdf(txtPath);
+      expect(result).toEqual({ content: "plain text content" });
+      expect(await listLiteparseDirs()).toEqual([]);
+    });
+  });
+});
+
+describe("getTmpDir", () => {
+  it("respects LITEPARSE_TMPDIR", () => {
+    const custom = path.join(os.tmpdir(), "custom-liteparse-root");
+    const prev = process.env.LITEPARSE_TMPDIR;
+    process.env.LITEPARSE_TMPDIR = custom;
+    expect(getTmpDir()).toBe(custom);
+    if (prev === undefined) {
+      delete process.env.LITEPARSE_TMPDIR;
+    } else {
+      process.env.LITEPARSE_TMPDIR = prev;
+    }
+  });
+});

--- a/src/conversion/convertBufferToPdf.test.ts
+++ b/src/conversion/convertBufferToPdf.test.ts
@@ -27,7 +27,9 @@ describe("convertBufferToPdf temp cleanup", () => {
 
   async function listLiteparseDirs(): Promise<string[]> {
     const entries = await fs.readdir(testTmpRoot, { withFileTypes: true });
-    return entries.filter((e) => e.isDirectory() && e.name.startsWith("liteparse-")).map((e) => e.name);
+    return entries
+      .filter((e) => e.isDirectory() && e.name.startsWith("liteparse-"))
+      .map((e) => e.name);
   }
 
   it("removes staging temp dir on text passthrough", async () => {

--- a/src/conversion/convertToPdf.ts
+++ b/src/conversion/convertToPdf.ts
@@ -440,21 +440,27 @@ export async function convertToPdf(
       return { content };
     }
 
-    // Create temp directory for output
+    const needsBinaryConversion =
+      officeExtensions.includes(extension) ||
+      spreadsheetExtensions.includes(extension) ||
+      imageExtensions.includes(extension);
+
+    if (!needsBinaryConversion) {
+      const content = await fs.readFile(filePath, "utf-8");
+      return { content };
+    }
+
+    // Create temp directory for conversion output (office / spreadsheet / image only)
     const tmpDir = await fs.mkdtemp(path.join(getTmpDir(), "liteparse-"));
 
-    // Convert based on file type
     let pdfPath: string;
 
     if (officeExtensions.includes(extension)) {
       pdfPath = await convertOfficeDocument(filePath, tmpDir, password);
     } else if (spreadsheetExtensions.includes(extension)) {
       pdfPath = await convertOfficeDocument(filePath, tmpDir, password);
-    } else if (imageExtensions.includes(extension)) {
-      pdfPath = await convertImageToPdf(filePath, tmpDir);
     } else {
-      const content = await fs.readFile(filePath, "utf-8");
-      return { content };
+      pdfPath = await convertImageToPdf(filePath, tmpDir);
     }
 
     return {
@@ -470,18 +476,23 @@ export async function convertToPdf(
 }
 
 /**
- * Clean up temporary conversion files
+ * Remove a temp directory created under getTmpDir().
  */
-export async function cleanupConversionFiles(pdfPath: string): Promise<void> {
+async function removeTempDirectory(dir: string): Promise<void> {
   try {
-    // Only delete if in temp directory
-    if (pdfPath.includes(getTmpDir())) {
-      const dir = path.dirname(pdfPath);
+    if (dir.includes(getTmpDir())) {
       await fs.rm(dir, { recursive: true, force: true });
     }
   } catch {
     // Ignore cleanup errors
   }
+}
+
+/**
+ * Clean up temporary conversion files
+ */
+export async function cleanupConversionFiles(pdfPath: string): Promise<void> {
+  await removeTempDirectory(path.dirname(pdfPath));
 }
 
 /**
@@ -507,8 +518,12 @@ export async function convertBufferToPdf(
 
   // Write buffer to temp file with detected extension (use .bin for unknown)
   const tmpDir = await fs.mkdtemp(path.join(getTmpDir(), "liteparse-"));
-  const tmpPath = path.join(tmpDir, `input${ext || ".bin"}`);
-  await fs.writeFile(tmpPath, data);
-
-  return convertToPdf(tmpPath, password);
+  try {
+    const tmpPath = path.join(tmpDir, `input${ext || ".bin"}`);
+    await fs.writeFile(tmpPath, data);
+    return await convertToPdf(tmpPath, password);
+  } finally {
+    // Always remove the buffer staging dir (converted PDFs live in a separate temp dir)
+    await removeTempDirectory(tmpDir);
+  }
 }


### PR DESCRIPTION
Fixes #175 

## Summary

Fixes a silent disk leak when parsing **text buffers** via `LiteParse.parse(buffer)` (or when non-PDF buffers are routed through `convertBufferToPdf`). Temporary `liteparse-*` directories were created but not removed on text passthrough.

## Problem

1. **`convertBufferToPdf`** always wrote the buffer to a staging temp dir (`liteparse-AAA/input.bin`) and never deleted it when `convertToPdf` returned `{ content }`.
2. **`convertToPdf`** called `mkdtemp` before checking whether the file needed binary conversion, so text extensions like `.txt` / `.bin` could leave a second empty temp dir (`liteparse-BBB/`).

The parser returns early on text passthrough and never calls `cleanupConversionFiles()` (which only applies to converted PDF paths).

## Changes

- **`src/conversion/convertToPdf.ts`**
  - Only create a conversion output temp dir for office, spreadsheet, and image types.
  - Read text-only extensions as UTF-8 without `mkdtemp`.
  - Add `removeTempDirectory()` helper; use it from `cleanupConversionFiles` and buffer staging cleanup.
  - Wrap `convertBufferToPdf` in `try/finally` to always remove the buffer staging directory.
- **`src/conversion/convertBufferToPdf.test.ts`**
  - Integration tests with an isolated `LITEPARSE_TMPDIR` verifying no leftover `liteparse-*` dirs after buffer and path-based text passthrough.

## Before / after

| Scenario | Before | After |
|----------|--------|--------|
| `parse(Buffer.from("hello"))` | 1–2 leaked `liteparse-*` dirs | No leaked dirs |
| `convertToPdf("file.txt")` | Possible empty temp dir | No extra temp dir |
| Buffer → DOCX → PDF conversion | Staging dir leaked; PDF dir cleaned by parser | Staging dir removed; PDF dir still cleaned by parser |

## Test plan

- [x] `npm test -- src/conversion/convertToPdf.test.ts src/conversion/convertBufferToPdf.test.ts` (33 tests pass)
- [ ] Manual: `parse(Buffer.from("test"))` and confirm no new `liteparse-*` under `$TMP` / `%TEMP%`