### PR TITLE
fix(conversion): reject binary buffers and convert ZIP OOXML via LibreOffice

### DIFF
--- a/src/conversion/convertToPdf.test.ts
+++ b/src/conversion/convertToPdf.test.ts
@@ -157,7 +157,13 @@ vi.mock("fs", async () => {
       mkdtemp: vi.fn(async () => {
         return "/tmp/test";
       }),
-      readFile: vi.fn(async () => {
+      readFile: vi.fn(async (filePath: string) => {
+        if (filePath.includes("test.bin") || filePath.includes("input.bin")) {
+          return Buffer.from([0x00, 0x01, 0x02, 0x03]);
+        }
+        if (filePath.includes("binary_no_ext")) {
+          return Buffer.from([0x00, 0x05, 0xff]);
+        }
         return "hello world";
       }),
     },
@@ -351,6 +357,35 @@ describe("test convertToPdf", () => {
     const result = await convertToPdf("test.txt");
     expect(result).toStrictEqual({
       content: "hello world",
+    });
+  });
+
+  it("rejects .bin files as unsupported binary", async () => {
+    const result = await convertToPdf("test.bin");
+    expect(result).toMatchObject({
+      code: "UNSUPPORTED_FORMAT",
+      message: expect.stringContaining("Unsupported binary"),
+    });
+  });
+
+  it("converts .zip (OOXML container) via LibreOffice", async () => {
+    enqueueLibreOfficeLookup();
+    enqueueSpawnPlan({ stdout: "conversion successful", code: 0 });
+
+    const result = await convertToPdf("test.zip");
+    expect(result).toStrictEqual({
+      pdfPath: path.join("/tmp/test", "test.pdf"),
+      originalExtension: ".zip",
+    });
+  });
+
+  it("rejects extensionless binary content", async () => {
+    mockFileTypeFromFile.mockResolvedValue(undefined);
+
+    const result = await convertToPdf("binary_no_ext");
+    expect(result).toMatchObject({
+      code: "UNSUPPORTED_FORMAT",
+      message: expect.stringContaining("Unsupported binary"),
     });
   });
 });

--- a/src/conversion/convertToPdf.ts
+++ b/src/conversion/convertToPdf.ts
@@ -81,6 +81,78 @@ export const imageExtensions = [
 
 export const htmlExtensions = [".htm", ".html", ".xhtml"];
 
+/** Plain-text formats allowed to bypass PDF conversion */
+export const textPassthroughExtensions = [
+  ".txt",
+  ".text",
+  ".md",
+  ".markdown",
+  ".log",
+  ".ini",
+  ".json",
+  ".xml",
+  ".yml",
+  ".yaml",
+  ...htmlExtensions,
+];
+
+/**
+ * ZIP magic identifies OOXML containers (docx/xlsx/pptx); legacy OLE uses .cfb.
+ * file-type reports these as zip/cfb rather than specific office extensions.
+ */
+export const zipContainerExtensions = [".zip"];
+export const oleOfficeExtensions = [".cfb"];
+
+function isLikelyBinaryContent(data: Buffer): boolean {
+  const sample = data.subarray(0, Math.min(data.length, 8192));
+  if (sample.length === 0) {
+    return false;
+  }
+  if (sample.includes(0)) {
+    return true;
+  }
+  try {
+    new TextDecoder("utf-8", { fatal: true }).decode(sample);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+async function readTextPassthrough(
+  filePath: string
+): Promise<ConversionPassthrough | ConversionError> {
+  const data = await fs.readFile(filePath);
+  const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data as ArrayBuffer);
+  if (isLikelyBinaryContent(buffer)) {
+    return {
+      message:
+        "Unsupported binary format. Pass a file path with the correct extension, or provide a supported document type.",
+      code: "UNSUPPORTED_FORMAT",
+    };
+  }
+  return { content: buffer.toString("utf-8") };
+}
+
+function needsBinaryConversion(extension: string): boolean {
+  return (
+    officeExtensions.includes(extension) ||
+    spreadsheetExtensions.includes(extension) ||
+    imageExtensions.includes(extension) ||
+    zipContainerExtensions.includes(extension) ||
+    oleOfficeExtensions.includes(extension)
+  );
+}
+
+function usesOfficeConverter(extension: string): boolean {
+  return (
+    officeExtensions.includes(extension) ||
+    spreadsheetExtensions.includes(extension) ||
+    zipContainerExtensions.includes(extension) ||
+    oleOfficeExtensions.includes(extension)
+  );
+}
+
 /**
  * Guess file extension from file content using file-type magic byte detection.
  * Returns the path's own extension if present, otherwise inspects file bytes.
@@ -434,28 +506,15 @@ export async function convertToPdf(
       };
     }
 
-    // Unknown format or text-based — pass through as text
-    if (!extension) {
-      const content = await fs.readFile(filePath, "utf-8");
-      return { content };
+    if (!extension || !needsBinaryConversion(extension)) {
+      return readTextPassthrough(filePath);
     }
 
-    // Create temp directory for output
     const tmpDir = await fs.mkdtemp(path.join(getTmpDir(), "liteparse-"));
 
-    // Convert based on file type
-    let pdfPath: string;
-
-    if (officeExtensions.includes(extension)) {
-      pdfPath = await convertOfficeDocument(filePath, tmpDir, password);
-    } else if (spreadsheetExtensions.includes(extension)) {
-      pdfPath = await convertOfficeDocument(filePath, tmpDir, password);
-    } else if (imageExtensions.includes(extension)) {
-      pdfPath = await convertImageToPdf(filePath, tmpDir);
-    } else {
-      const content = await fs.readFile(filePath, "utf-8");
-      return { content };
-    }
+    const pdfPath = usesOfficeConverter(extension)
+      ? await convertOfficeDocument(filePath, tmpDir, password)
+      : await convertImageToPdf(filePath, tmpDir);
 
     return {
       pdfPath,
@@ -469,19 +528,21 @@ export async function convertToPdf(
   }
 }
 
-/**
- * Clean up temporary conversion files
- */
-export async function cleanupConversionFiles(pdfPath: string): Promise<void> {
+async function removeTempDirectory(dir: string): Promise<void> {
   try {
-    // Only delete if in temp directory
-    if (pdfPath.includes(getTmpDir())) {
-      const dir = path.dirname(pdfPath);
+    if (dir.includes(getTmpDir())) {
       await fs.rm(dir, { recursive: true, force: true });
     }
   } catch {
     // Ignore cleanup errors
   }
+}
+
+/**
+ * Clean up temporary conversion files
+ */
+export async function cleanupConversionFiles(pdfPath: string): Promise<void> {
+  await removeTempDirectory(path.dirname(pdfPath));
 }
 
 /**
@@ -505,10 +566,12 @@ export async function convertBufferToPdf(
 ): Promise<ConversionResult | ConversionPassthrough | ConversionError> {
   const ext = await guessExtensionFromBuffer(data);
 
-  // Write buffer to temp file with detected extension (use .bin for unknown)
   const tmpDir = await fs.mkdtemp(path.join(getTmpDir(), "liteparse-"));
-  const tmpPath = path.join(tmpDir, `input${ext || ".bin"}`);
-  await fs.writeFile(tmpPath, data);
-
-  return convertToPdf(tmpPath, password);
+  try {
+    const tmpPath = path.join(tmpDir, `input${ext || ".bin"}`);
+    await fs.writeFile(tmpPath, data);
+    return await convertToPdf(tmpPath, password);
+  } finally {
+    await removeTempDirectory(tmpDir);
+  }
 }


### PR DESCRIPTION
Fixes #177 

## Summary

Fixes silent misclassification of **binary buffers** as plain text when using `LiteParse.parse(buffer)` or `convertBufferToPdf()`.

Previously, unknown bytes (`.bin`), ZIP-shaped Office files (DOCX/XLSX/PPTX detected as `.zip`), and other non-convertible extensions were read as UTF-8 and returned as `{ pages: [], text: "…" }` with garbage content and no error.

## Problem

| Input | Before | After |
|-------|--------|--------|
| `parse(docxBuffer)` | Garbage text (`PK…`) | LibreOffice conversion (if installed) |
| `parse(binaryBuffer)` | Garbage text | `UNSUPPORTED_FORMAT` error |
| `parse(Buffer.from("hello"))` | OK | OK |
| `parse("file.docx")` (path) | OK | OK (unchanged) |

**Root causes:**
1. `convertToPdf` used a catch-all `else` that read any unknown extension as UTF-8 text.
2. OOXML files are ZIP archives; magic-byte detection returns `.zip`, which was not routed to LibreOffice.
3. `guessExtensionFromBuffer` → `null` wrote `input.bin`, which was also treated as text.

## Changes

- **`src/conversion/convertToPdf.ts`**
  - Add `readTextPassthrough()` with binary detection (null bytes / invalid UTF-8).
  - Route `.zip` and `.cfb` through `convertOfficeDocument()`.
  - Only create conversion temp dirs for formats that need LibreOffice/ImageMagick.
  - Wrap `convertBufferToPdf` staging dir cleanup in `try/finally`.
- **`src/conversion/convertToPdf.test.ts`**
  - Tests for `.bin` rejection, `.zip` office conversion, extensionless binary.
- **`src/conversion/convertBufferToPdf.test.ts`**
  - Integration tests for binary buffer rejection and plain-text buffers.

## Test plan

- [x] `npm test -- src/conversion/convertToPdf.test.ts src/conversion/convertBufferToPdf.test.ts` (35 tests pass)
- [ ] Manual: `parse(fs.readFileSync("report.docx"))` returns real text (not `PK…`)
- [ ] Manual: `parse(Buffer.from([0x00, 0xff]))` throws with unsupported format message