### PR TITLE
fix(parser): serialize parse and screenshot on shared LiteParse instance

### DIFF
--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -345,6 +345,8 @@ const {
 
 import { LiteParse } from "./parser";
 import { LiteParseConfig, ScreenshotResult } from "./types";
+import { PdfJsEngine } from "../engines/pdf/pdfjs.js";
+import { projectPagesToGrid } from "../processing/grid.js";
 
 vi.mock("../conversion/convertToPdf.js", async () => {
   const actual = await vi.importActual<typeof import("../conversion/convertToPdf.js")>(
@@ -616,5 +618,35 @@ describe("test screenshot", () => {
       mockScreenshotResults[2],
       mockScreenshotResults[3],
     ]);
+  });
+});
+
+describe("concurrent operations", () => {
+  it("serializes overlapping parse() calls on one instance", async () => {
+    let active = 0;
+    let maxActive = 0;
+
+    vi.mocked(projectPagesToGrid).mockReset();
+    vi.mocked(projectPagesToGrid).mockResolvedValue(structuredClone(mockParsedPages));
+
+    vi.mocked(PdfJsEngine).mockImplementationOnce(
+      class {
+        loadDocument = vi.fn(async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 30));
+          active -= 1;
+          return mockPdfDocument;
+        });
+        extractAllPages = vi.fn().mockResolvedValue(mockPages);
+        extractPage = vi.fn().mockResolvedValue(mockPages[0]);
+        renderPageImage = vi.fn();
+        close = vi.fn();
+      } as unknown as typeof PdfJsEngine
+    );
+
+    const parser = new LiteParse({ ocrEnabled: false, outputFormat: "text" });
+    await Promise.all([parser.parse("/tmp/a.pdf"), parser.parse("/tmp/b.pdf")]);
+    expect(maxActive).toBe(1);
   });
 });

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -59,6 +59,8 @@ export class LiteParse {
   private config: LiteParseConfig;
   private pdfEngine: PdfEngine;
   private ocrEngine?: OcrEngine;
+  /** Ensures only one parse/screenshot uses shared engines at a time */
+  private operationLock: Promise<void> = Promise.resolve();
 
   /**
    * Create a new LiteParse instance.
@@ -84,10 +86,24 @@ export class LiteParse {
   }
 
   /**
+   * Run an operation exclusively — concurrent `parse()` / `screenshot()` calls are queued.
+   */
+  private runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+    const next = this.operationLock.then(operation);
+    this.operationLock = next.then(
+      () => undefined,
+      () => undefined
+    );
+    return next;
+  }
+
+  /**
    * Parse a document and return the extracted text, page data, and optionally structured JSON.
    *
    * Supports PDFs natively. Non-PDF formats (DOCX, XLSX, images, etc.) are automatically
    * converted to PDF before parsing if the required system tools are installed.
+   *
+   * Concurrent calls on the same instance are serialized so shared PDF/OCR engines stay consistent.
    *
    * @param input - A file path, `Buffer`, or `Uint8Array` containing document bytes.
    *   When given raw bytes, PDF data is parsed directly with zero disk I/O.
@@ -98,6 +114,10 @@ export class LiteParse {
    * @throws Error if the file cannot be found, converted, or parsed.
    */
   async parse(input: LiteParseInput, quiet = false): Promise<ParseResult> {
+    return this.runExclusive(() => this.parseDocument(input, quiet));
+  }
+
+  private async parseDocument(input: LiteParseInput, quiet: boolean): Promise<ParseResult> {
     const log = (msg: string) => {
       if (!quiet) console.error(msg); // Progress goes to stderr
     };
@@ -231,11 +251,21 @@ export class LiteParse {
    *
    * @throws Error if the input is a text-based format that cannot be rendered.
    * @throws Error if the file cannot be found, converted, or rendered.
+   *
+   * Concurrent calls on the same instance are serialized so shared PDF engines stay consistent.
    */
   async screenshot(
     input: LiteParseInput,
     pageNumbers?: number[],
     quiet = false
+  ): Promise<ScreenshotResult[]> {
+    return this.runExclusive(() => this.screenshotDocument(input, pageNumbers, quiet));
+  }
+
+  private async screenshotDocument(
+    input: LiteParseInput,
+    pageNumbers: number[] | undefined,
+    quiet: boolean
   ): Promise<ScreenshotResult[]> {
     const log = (msg: string) => {
       if (!quiet) console.error(msg); // Progress goes to stderr


### PR DESCRIPTION
Fixes #179 

## Summary

Fixes unsafe concurrent use of a single `LiteParse` instance. Overlapping `parse()` or `screenshot()` calls shared one `PdfJsEngine` (and optional OCR engine) with mutable state, which could load the wrong PDF, return mixed text, or fail when one call closed resources another still needed.

Operations on the same instance are now **serialized** with an internal lock.

## Problem

`LiteParse` reused:

- `PdfJsEngine` — `currentPdfPath`, `currentPdfData`, shared `PdfiumRenderer`
- `TesseractEngine` (optional) — terminated in `parse()` `finally` while another call could still run

Example failure mode:

```javascript
await Promise.all([
  parser.parse("document-a.pdf"),
  parser.parse("document-b.pdf"),
]);
```

Could succeed with **wrong text** or **intermittent errors** depending on timing.

## Changes

- **`src/core/parser.ts`**
  - Add `runExclusive()` queue backed by `operationLock`
  - Public `parse()` / `screenshot()` run inside the lock
  - Implementation moved to private `parseDocument()` / `screenshotDocument()`
  - Document that concurrent calls on one instance are queued
- **`src/core/parser.test.ts`**
  - Test that overlapping `parse()` calls never have more than one active `loadDocument` at a time

## Behavior

| Before | After |
|--------|--------|
| Concurrent calls on one instance → races | Calls run one at a time (FIFO queue) |
| `new LiteParse()` per request | Still recommended for parallel throughput |
| Sequential `await parse(a); await parse(b)` | Unchanged (still works) |

**Note:** This does **not** make one instance faster in parallel — it makes it **correct**. For real parallelism, use separate `LiteParse` instances per job.