### PR TITLE
fix: surface OCR failures instead of swallowing them

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -21,6 +21,7 @@ export const DEFAULT_CONFIG: LiteParseConfig = {
   preserveVerySmallText: false,
   preserveLayoutAlignmentAcrossPages: false,
   password: undefined,
+  failOnOcrError: false,
 };
 
 export function mergeConfig(userConfig: Partial<LiteParseConfig>): LiteParseConfig {

--- a/src/core/parser.ocr-failure.test.ts
+++ b/src/core/parser.ocr-failure.test.ts
@@ -1,0 +1,125 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { OcrRecognitionError, OcrProcessingError } from "../engines/ocr/errors.js";
+
+const { mockRenderPageImage, recognize } = vi.hoisted(() => ({
+  mockRenderPageImage: vi.fn(async () => Buffer.from([1, 2, 3])),
+  recognize: vi.fn(),
+}));
+
+const mockPdfDocument = { numPages: 1, data: new Uint8Array([1, 2, 3]) };
+
+/** Page that triggers OCR: sparse text and an embedded image. */
+const mockOcrPage = {
+  pageNum: 1,
+  width: 612,
+  height: 792,
+  textItems: [],
+  paths: [],
+  images: [{ x: 0, y: 0, width: 100, height: 50 }],
+  annotations: [],
+};
+
+const mockParsedPage = {
+  pageNum: 1,
+  width: 612,
+  height: 792,
+  text: "",
+  textItems: [],
+};
+
+vi.mock("../conversion/convertToPdf.js", async () => {
+  const actual = await vi.importActual<typeof import("../conversion/convertToPdf.js")>(
+    "../conversion/convertToPdf.js"
+  );
+  return {
+    ...actual,
+    convertToPdf: vi.fn(async () => ({
+      pdfPath: "/tmp/test.pdf",
+      originalExtension: ".pdf",
+    })),
+    cleanupConversionFiles: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("../engines/pdf/pdfjs.js", () => ({
+  PdfJsEngine: vi.fn(
+    class {
+      loadDocument = vi.fn().mockResolvedValue(mockPdfDocument);
+      extractAllPages = vi.fn().mockResolvedValue([mockOcrPage]);
+      renderPageImage = mockRenderPageImage;
+      close = vi.fn(async () => {});
+    }
+  ),
+}));
+
+vi.mock("../processing/grid.js", () => ({
+  projectPagesToGrid: vi.fn(async (pages: Array<{ ocrFailed?: boolean; ocrError?: string }>) => [
+    {
+      ...mockParsedPage,
+      ocrFailed: pages[0]?.ocrFailed,
+      ocrError: pages[0]?.ocrError,
+    },
+  ]),
+}));
+
+vi.mock("../processing/bbox.js", () => ({
+  buildBoundingBoxes: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("../engines/ocr/tesseract.js", () => ({
+  TesseractEngine: vi.fn(
+    class {
+      terminate = vi.fn(async () => {});
+      recognize = recognize;
+    }
+  ),
+}));
+
+import { LiteParse } from "./parser.js";
+
+describe("LiteParse OCR failures", () => {
+  beforeEach(() => {
+    recognize.mockReset();
+    mockRenderPageImage.mockReset();
+    mockRenderPageImage.mockResolvedValue(Buffer.from([1, 2, 3]));
+  });
+
+  it("records ocrFailed and ocrWarnings when OCR fails (default)", async () => {
+    recognize.mockRejectedValueOnce(new OcrRecognitionError("Tesseract OCR failed for <buffer>: boom"));
+
+    const parser = new LiteParse({ ocrEnabled: true, outputFormat: "text" });
+    const result = await parser.parse("scan.pdf");
+
+    expect(result.ocrWarnings).toEqual([{ page: 1, message: "Tesseract OCR failed for <buffer>: boom" }]);
+    expect(result.pages[0]?.ocrFailed).toBe(true);
+    expect(result.pages[0]?.ocrError).toContain("boom");
+  });
+
+  it("includes ocrWarnings in JSON output", async () => {
+    recognize.mockRejectedValueOnce(new OcrRecognitionError("HTTP OCR down"));
+
+    const parser = new LiteParse({ ocrEnabled: true, outputFormat: "json" });
+    const result = await parser.parse("scan.pdf");
+
+    expect(result.json?.ocrWarnings).toEqual([{ page: 1, message: "HTTP OCR down" }]);
+    expect(result.json?.pages[0]?.ocrFailed).toBe(true);
+  });
+
+  it("throws OcrProcessingError when failOnOcrError is true", async () => {
+    recognize.mockRejectedValueOnce(new OcrRecognitionError("worker crashed"));
+
+    const parser = new LiteParse({ ocrEnabled: true, failOnOcrError: true });
+
+    await expect(parser.parse("scan.pdf")).rejects.toBeInstanceOf(OcrProcessingError);
+  });
+
+  it("marks page when renderPageImage fails", async () => {
+    mockRenderPageImage.mockRejectedValueOnce(new Error("render failed"));
+
+    const parser = new LiteParse({ ocrEnabled: true });
+    const result = await parser.parse("scan.pdf");
+
+    expect(recognize).not.toHaveBeenCalled();
+    expect(result.ocrWarnings?.[0]?.message).toContain("render failed");
+  });
+});

--- a/src/core/parser.ocr-failure.test.ts
+++ b/src/core/parser.ocr-failure.test.ts
@@ -85,12 +85,16 @@ describe("LiteParse OCR failures", () => {
   });
 
   it("records ocrFailed and ocrWarnings when OCR fails (default)", async () => {
-    recognize.mockRejectedValueOnce(new OcrRecognitionError("Tesseract OCR failed for <buffer>: boom"));
+    recognize.mockRejectedValueOnce(
+      new OcrRecognitionError("Tesseract OCR failed for <buffer>: boom")
+    );
 
     const parser = new LiteParse({ ocrEnabled: true, outputFormat: "text" });
     const result = await parser.parse("scan.pdf");
 
-    expect(result.ocrWarnings).toEqual([{ page: 1, message: "Tesseract OCR failed for <buffer>: boom" }]);
+    expect(result.ocrWarnings).toEqual([
+      { page: 1, message: "Tesseract OCR failed for <buffer>: boom" },
+    ]);
     expect(result.pages[0]?.ocrFailed).toBe(true);
     expect(result.pages[0]?.ocrError).toContain("boom");
   });

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -365,7 +365,9 @@ export class LiteParse {
     }
   }
 
-  private collectOcrWarnings(pages: { pageNum: number; ocrFailed?: boolean; ocrError?: string }[]): OcrWarning[] {
+  private collectOcrWarnings(
+    pages: { pageNum: number; ocrFailed?: boolean; ocrError?: string }[]
+  ): OcrWarning[] {
     return pages
       .filter((page) => page.ocrFailed)
       .map((page) => ({

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -23,6 +23,8 @@ import {
   guessExtensionFromBuffer,
 } from "../conversion/convertToPdf.js";
 import { cleanOcrTableArtifacts } from "../processing/textUtils.js";
+import { OcrProcessingError } from "../engines/ocr/errors.js";
+import type { OcrWarning } from "./types.js";
 
 /**
  * Main document parser class. Handles PDF parsing, OCR, format conversion,
@@ -184,9 +186,12 @@ export class LiteParse {
       // Build final text
       const fullText = processedPages.map((p) => p.text).join("\n\n");
 
+      const ocrWarnings = this.collectOcrWarnings(processedPages);
+
       const result: ParseResult = {
         pages: processedPages,
         text: fullText,
+        ...(ocrWarnings.length > 0 ? { ocrWarnings } : {}),
       };
 
       // Format based on output format
@@ -348,6 +353,25 @@ export class LiteParse {
     const limit = pLimit(this.config.numWorkers);
 
     await Promise.all(pages.map((page) => limit(() => this.processPageOcr(doc, page, log))));
+
+    const failedPages = pages.filter((page) => page.ocrFailed);
+    if (this.config.failOnOcrError && failedPages.length > 0) {
+      throw new OcrProcessingError(
+        failedPages.map((page) => ({
+          page: page.pageNum,
+          message: page.ocrError ?? "OCR failed",
+        }))
+      );
+    }
+  }
+
+  private collectOcrWarnings(pages: { pageNum: number; ocrFailed?: boolean; ocrError?: string }[]): OcrWarning[] {
+    return pages
+      .filter((page) => page.ocrFailed)
+      .map((page) => ({
+        page: page.pageNum,
+        message: page.ocrError ?? "OCR failed",
+      }));
   }
 
   /**
@@ -480,7 +504,10 @@ export class LiteParse {
         log(`  Found ${ocrTextItems.length} text items from OCR on page ${page.pageNum}`);
       }
     } catch (error) {
-      log(`  OCR failed for page ${page.pageNum}: ${error}`);
+      const message = error instanceof Error ? error.message : String(error);
+      page.ocrFailed = true;
+      page.ocrError = message;
+      log(`  OCR failed for page ${page.pageNum}: ${message}`);
     }
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -140,6 +140,15 @@ export interface LiteParseConfig {
   password?: string;
 
   /**
+   * When `true`, {@link LiteParse.parse} throws if OCR fails on any page that required it.
+   * When `false` (default), parsing completes and failed pages are marked with
+   * {@link ParsedPage.ocrFailed} and listed in {@link ParseResult.ocrWarnings}.
+   *
+   * @defaultValue `false`
+   */
+  failOnOcrError: boolean;
+
+  /**
    * Debug configuration for grid projection. When enabled, logs detailed
    * information about how text elements are snapped, anchored, and projected.
    * Can also generate visual PNG overlays of the projection.
@@ -308,6 +317,23 @@ export interface ParsedPage {
    * Present when {@link LiteParseConfig.preciseBoundingBox} is enabled.
    */
   boundingBoxes?: BoundingBox[];
+  /**
+   * `true` when OCR was required for this page but failed. Parsing still succeeds unless
+   * {@link LiteParseConfig.failOnOcrError} is enabled.
+   */
+  ocrFailed?: boolean;
+  /** Error message when {@link ocrFailed} is `true`. */
+  ocrError?: string;
+}
+
+/**
+ * Summary of an OCR failure on a specific page.
+ */
+export interface OcrWarning {
+  /** 1-indexed page number. */
+  page: number;
+  /** Human-readable failure reason. */
+  message: string;
 }
 
 /**
@@ -367,7 +393,13 @@ export interface ParseResultJson {
      * @deprecated Use `textItems` coordinates instead. Will be removed in v2.0.
      */
     boundingBoxes: BoundingBox[];
+    /** Present when OCR was required for this page but failed. */
+    ocrFailed?: boolean;
+    /** Error message when `ocrFailed` is `true`. */
+    ocrError?: string;
   }>;
+  /** OCR failures across the document. Omitted when there are no failures. */
+  ocrWarnings?: OcrWarning[];
 }
 
 /**
@@ -380,6 +412,11 @@ export interface ParseResult {
   text: string;
   /** Structured JSON data. Present when {@link LiteParseConfig.outputFormat} is `"json"`. */
   json?: ParseResultJson;
+  /**
+   * OCR failures by page. Present when OCR was required but failed and
+   * {@link LiteParseConfig.failOnOcrError} is `false`.
+   */
+  ocrWarnings?: OcrWarning[];
 }
 
 /**

--- a/src/engines/ocr/errors.ts
+++ b/src/engines/ocr/errors.ts
@@ -1,0 +1,26 @@
+/**
+ * Thrown when an OCR engine fails to recognize text from an image.
+ */
+export class OcrRecognitionError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "OcrRecognitionError";
+    if (options?.cause !== undefined) {
+      this.cause = options.cause;
+    }
+  }
+}
+
+/**
+ * Thrown when {@link LiteParseConfig.failOnOcrError} is enabled and one or more pages fail OCR.
+ */
+export class OcrProcessingError extends Error {
+  readonly failedPages: Array<{ page: number; message: string }>;
+
+  constructor(failedPages: Array<{ page: number; message: string }>) {
+    const summary = failedPages.map((f) => `page ${f.page}`).join(", ");
+    super(`OCR failed on ${failedPages.length} page(s): ${summary}`);
+    this.name = "OcrProcessingError";
+    this.failedPages = failedPages;
+  }
+}

--- a/src/engines/ocr/http-simple.test.ts
+++ b/src/engines/ocr/http-simple.test.ts
@@ -64,20 +64,23 @@ describe("test OCR simple HTTP server (single image)", () => {
 
   it("test server axios error", async () => {
     const server = new HttpOcrEngine("http://localhost:9999");
-    const result = await server.recognize("cat.png", { language: "en" });
-    expect(result.length).toBe(0);
+    await expect(server.recognize("cat.png", { language: "en" })).rejects.toThrow(
+      "OCR HTTP request failed"
+    );
   });
 
   it("test server generic error", async () => {
     const server = new HttpOcrEngine("http://localhost:10000");
-    const result = await server.recognize("cat.png", { language: "en" });
-    expect(result.length).toBe(0);
+    await expect(server.recognize("cat.png", { language: "en" })).rejects.toThrow(
+      "OCR failed for cat.png"
+    );
   });
 
   it("test server malformed response", async () => {
     const server = new HttpOcrEngine("http://localhost:9998");
-    const result = await server.recognize("cat.png", { language: "en" });
-    expect(result.length).toBe(0);
+    await expect(server.recognize("cat.png", { language: "en" })).rejects.toThrow(
+      "OCR server response missing results array"
+    );
   });
 });
 
@@ -90,28 +93,22 @@ describe("test OCR simple HTTP server (batch)", () => {
 
   it("test server axios error", async () => {
     const server = new HttpOcrEngine("http://localhost:9999");
-    const result = await server.recognizeBatch(["cat.png", "dog.png"], { language: "en" });
-    expect(result.length).toBe(2);
-    for (const r of result) {
-      expect(r.length).toBe(0);
-    }
+    await expect(server.recognizeBatch(["cat.png", "dog.png"], { language: "en" })).rejects.toThrow(
+      "OCR HTTP request failed"
+    );
   });
 
   it("test server generic error", async () => {
     const server = new HttpOcrEngine("http://localhost:10000");
-    const result = await server.recognizeBatch(["cat.png", "dog.png"], { language: "en" });
-    expect(result.length).toBe(2);
-    for (const r of result) {
-      expect(r.length).toBe(0);
-    }
+    await expect(server.recognizeBatch(["cat.png", "dog.png"], { language: "en" })).rejects.toThrow(
+      "OCR failed for cat.png"
+    );
   });
 
   it("test server malformed response", async () => {
     const server = new HttpOcrEngine("http://localhost:9998");
-    const result = await server.recognizeBatch(["cat.png", "dog.png"], { language: "en" });
-    expect(result.length).toBe(2);
-    for (const r of result) {
-      expect(r.length).toBe(0);
-    }
+    await expect(server.recognizeBatch(["cat.png", "dog.png"], { language: "en" })).rejects.toThrow(
+      "OCR server response missing results array"
+    );
   });
 });

--- a/src/engines/ocr/http-simple.ts
+++ b/src/engines/ocr/http-simple.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import FormData from "form-data";
 import fs from "fs";
 import { OcrEngine, OcrOptions, OcrResult } from "./interface.js";
+import { OcrRecognitionError } from "./errors.js";
 
 interface HttpOcrResponseItem {
   text: string;
@@ -50,8 +51,9 @@ export class HttpOcrEngine implements OcrEngine {
       const { results } = response.data;
 
       if (!Array.isArray(results)) {
-        console.warn("OCR server response missing results array:", response.data);
-        return [];
+        throw new OcrRecognitionError(
+          `OCR server response missing results array for ${typeof image === "string" ? image : "<buffer>"}`
+        );
       }
 
       return results.map((item: HttpOcrResponseItem) => ({
@@ -60,17 +62,21 @@ export class HttpOcrEngine implements OcrEngine {
         confidence: item.confidence,
       }));
     } catch (error) {
+      if (error instanceof OcrRecognitionError) {
+        throw error;
+      }
       const label = typeof image === "string" ? image : "<buffer>";
       if (axios.isAxiosError(error)) {
-        console.error(
-          `OCR HTTP error for ${label}:`,
-          error.response?.status,
-          error.response?.data?.error || error.message
-        );
-      } else {
-        console.error(`OCR error for ${label}:`, error);
+        const detail =
+          (error.response?.data as { error?: string } | undefined)?.error || error.message;
+        const status = error.response?.status;
+        const statusPart = status !== undefined ? ` (HTTP ${status})` : "";
+        throw new OcrRecognitionError(`OCR HTTP request failed for ${label}${statusPart}: ${detail}`, {
+          cause: error,
+        });
       }
-      return [];
+      const message = error instanceof Error ? error.message : String(error);
+      throw new OcrRecognitionError(`OCR failed for ${label}: ${message}`, { cause: error });
     }
   }
 

--- a/src/engines/ocr/http-simple.ts
+++ b/src/engines/ocr/http-simple.ts
@@ -71,9 +71,12 @@ export class HttpOcrEngine implements OcrEngine {
           (error.response?.data as { error?: string } | undefined)?.error || error.message;
         const status = error.response?.status;
         const statusPart = status !== undefined ? ` (HTTP ${status})` : "";
-        throw new OcrRecognitionError(`OCR HTTP request failed for ${label}${statusPart}: ${detail}`, {
-          cause: error,
-        });
+        throw new OcrRecognitionError(
+          `OCR HTTP request failed for ${label}${statusPart}: ${detail}`,
+          {
+            cause: error,
+          }
+        );
       }
       const message = error instanceof Error ? error.message : String(error);
       throw new OcrRecognitionError(`OCR failed for ${label}: ${message}`, { cause: error });

--- a/src/engines/ocr/tesseract.ts
+++ b/src/engines/ocr/tesseract.ts
@@ -1,5 +1,6 @@
 import { createWorker, createScheduler, Scheduler, Worker } from "tesseract.js";
 import { OcrEngine, OcrOptions, OcrResult } from "./interface.js";
+import { OcrRecognitionError } from "./errors.js";
 
 export class TesseractEngine implements OcrEngine {
   name = "tesseract";
@@ -151,8 +152,10 @@ export class TesseractEngine implements OcrEngine {
       return results.filter((r) => r.confidence > 0.3);
     } catch (error) {
       const label = typeof image === "string" ? image : "<buffer>";
-      console.error(`\nTesseract OCR error for ${label}:`, error);
-      return [];
+      const message = error instanceof Error ? error.message : String(error);
+      throw new OcrRecognitionError(`Tesseract OCR failed for ${label}: ${message}`, {
+        cause: error,
+      });
     }
   }
 

--- a/src/engines/pdf/interface.ts
+++ b/src/engines/pdf/interface.ts
@@ -48,6 +48,10 @@ export interface PageData {
   annotations?: Annotation[];
   /** Bounding boxes of garbled text that was filtered out (for targeted OCR) */
   garbledTextRegions?: BoundingBox[];
+  /** Set when OCR was required for this page but failed. */
+  ocrFailed?: boolean;
+  /** Error message when {@link ocrFailed} is true. */
+  ocrError?: string;
 }
 
 export interface Path {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -27,5 +27,7 @@ export type {
   SearchItemsOptions,
   ScreenshotResult,
   MarkupData,
+  OcrWarning,
 } from "./core/types.js";
+export { OcrRecognitionError, OcrProcessingError } from "./engines/ocr/errors.js";
 export type { GridDebugConfig } from "./processing/gridDebugLogger.js";

--- a/src/output/json.ts
+++ b/src/output/json.ts
@@ -3,7 +3,10 @@ import { ParseResult, ParsedPage, ParseResultJson } from "../core/types.js";
 /**
  * Build JSON output from parsed pages
  */
-export function buildJSON(pages: ParsedPage[], ocrWarnings?: ParseResultJson["ocrWarnings"]): ParseResultJson {
+export function buildJSON(
+  pages: ParsedPage[],
+  ocrWarnings?: ParseResultJson["ocrWarnings"]
+): ParseResultJson {
   const json: ParseResultJson = {
     pages: pages.map((page) => ({
       page: page.pageNum,

--- a/src/output/json.ts
+++ b/src/output/json.ts
@@ -3,8 +3,8 @@ import { ParseResult, ParsedPage, ParseResultJson } from "../core/types.js";
 /**
  * Build JSON output from parsed pages
  */
-export function buildJSON(pages: ParsedPage[]): ParseResultJson {
-  return {
+export function buildJSON(pages: ParsedPage[], ocrWarnings?: ParseResultJson["ocrWarnings"]): ParseResultJson {
+  const json: ParseResultJson = {
     pages: pages.map((page) => ({
       page: page.pageNum,
       width: page.width,
@@ -21,14 +21,20 @@ export function buildJSON(pages: ParsedPage[]): ParseResultJson {
         confidence: item.confidence ?? 1.0,
       })),
       boundingBoxes: page.boundingBoxes || [],
+      ...(page.ocrFailed !== undefined ? { ocrFailed: page.ocrFailed } : {}),
+      ...(page.ocrError !== undefined ? { ocrError: page.ocrError } : {}),
     })),
   };
+  if (ocrWarnings && ocrWarnings.length > 0) {
+    json.ocrWarnings = ocrWarnings;
+  }
+  return json;
 }
 
 /**
  * Format result as JSON string
  */
 export function formatJSON(result: ParseResult): string {
-  const jsonData = buildJSON(result.pages);
+  const jsonData = buildJSON(result.pages, result.ocrWarnings);
   return JSON.stringify(jsonData, null, 2);
 }

--- a/src/processing/gridProjection.ts
+++ b/src/processing/gridProjection.ts
@@ -2227,6 +2227,8 @@ export async function projectPagesToGrid(
       text,
       textItems: page.textItems,
       boundingBoxes: [],
+      ...(page.ocrFailed !== undefined ? { ocrFailed: page.ocrFailed } : {}),
+      ...(page.ocrError !== undefined ? { ocrError: page.ocrError } : {}),
     });
   }
 


### PR DESCRIPTION
## Summary

Fixes silent OCR data loss when recognition, rendering, or the HTTP OCR server fails. Previously, failures were only logged to stderr (or returned as empty arrays from OCR engines), and `parse()` still resolved successfully with incomplete text.

This MR:

- Introduces `OcrRecognitionError` and `OcrProcessingError` for OCR failure handling
- Updates Tesseract and HTTP OCR engines to **throw** on hard failures instead of returning `[]`
- Records per-page `ocrFailed` / `ocrError` when OCR was required but failed
- Adds `ocrWarnings` on `ParseResult` and JSON output for programmatic detection
- Adds `failOnOcrError` config (default `false`) to throw `OcrProcessingError` when any required page fails OCR
- Exports new types/errors from `@llamaindex/liteparse`

**Backward compatibility:** Default behavior still completes parsing; callers that need strict failure handling can set `failOnOcrError: true`. Empty OCR results on a successful run (e.g. blank scan) are unchanged and are not treated as errors.

Fixes #<issue-number>

## Changes

| Area | What changed |
|------|----------------|
| OCR engines | Throw `OcrRecognitionError` on recognition/network/malformed HTTP response |
| Parser | Mark failed pages, aggregate `ocrWarnings`, optional strict mode via `failOnOcrError` |
| Types / config | `OcrWarning`, `failOnOcrError`, page-level `ocrFailed` / `ocrError` |
| Output | Propagate flags through grid projection and JSON formatter |
| Library API | Export `OcrWarning`, `OcrRecognitionError`, `OcrProcessingError` |

## Usage

```typescript
// Default: parse succeeds, failures are visible on the result
const result = await parser.parse("scanned.pdf");
if (result.ocrWarnings?.length) {
  console.warn(result.ocrWarnings);
}

// Strict: throw when OCR fails on any page that required it
const strict = new LiteParse({ ocrEnabled: true, failOnOcrError: true });
await strict.parse("scanned.pdf"); // throws OcrProcessingError
```

Fixes #181 