### PR TITLE
refactor(parser): build result.json with buildJSON instead of stringify/parse

### DIFF
--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -15,7 +15,7 @@ import { TesseractEngine } from "../engines/ocr/tesseract.js";
 import { HttpOcrEngine } from "../engines/ocr/http-simple.js";
 import { projectPagesToGrid } from "../processing/grid.js";
 import { buildBoundingBoxes } from "../processing/bbox.js";
-import { formatJSON } from "../output/json.js";
+import { buildJSON } from "../output/json.js";
 import {
   convertToPdf,
   convertBufferToPdf,
@@ -192,7 +192,7 @@ export class LiteParse {
       // Format based on output format
       switch (this.config.outputFormat) {
         case "json":
-          result.json = JSON.parse(formatJSON(result));
+          result.json = buildJSON(result.pages);
           break;
         case "text":
           // Already in text format


### PR DESCRIPTION
## Summary

Removes an unnecessary JSON round-trip when `outputFormat` is `"json"`.

Previously, `parse()` built `result.json` via:

```ts
result.json = JSON.parse(formatJSON(result));
```

`formatJSON` already calls `buildJSON` and then `JSON.stringify` for pretty printing. Parsing that string back into an object added extra CPU and memory on every JSON parse, with no benefit for library callers.

Now:

```ts
result.json = buildJSON(result.pages);
```

`formatJSON` is unchanged and remains the right API for producing a formatted JSON **string** (e.g. CLI file output still uses `JSON.stringify(result.json, null, 2)`).

## Why

- Avoid redundant serialize → parse on large documents
- Clearer separation: `buildJSON` for objects, `formatJSON` for strings
- Same output shape for normal parse data (existing tests unchanged)