### PR TITLE
fix(ocr): selective embedded-image OCR instead of full-page on text-heavy PDFs

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -5,6 +5,7 @@ export const DEFAULT_CONFIG: LiteParseConfig = {
   // If ocrServerUrl is provided, uses HTTP OCR instead
   ocrLanguage: "en",
   ocrEnabled: true,
+  ocrScope: "selective",
   ocrServerUrl: undefined, // If set, uses HTTP OCR; otherwise uses Tesseract
   numWorkers: 4, // Number of pages to OCR in parallel
 

--- a/src/core/parser.selective-ocr.test.ts
+++ b/src/core/parser.selective-ocr.test.ts
@@ -1,0 +1,117 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const { mockRenderPageImage, recognize } = vi.hoisted(() => ({
+  mockRenderPageImage: vi.fn(async () => Buffer.from([1, 2, 3, 4, 5])),
+  recognize: vi.fn(),
+}));
+
+const mockPdfDocument = { numPages: 1, data: new Uint8Array([1, 2, 3]) };
+
+/** Text-heavy page with one embedded image (triggers old full-page OCR). */
+const mockTextHeavyPageWithImage = {
+  pageNum: 1,
+  width: 612,
+  height: 792,
+  textItems: [{ str: "A".repeat(500), x: 10, y: 10, width: 400, height: 12 }],
+  paths: [],
+  images: [{ x: 50, y: 60, width: 120, height: 80 }],
+  annotations: [],
+};
+
+const mockParsedPage = {
+  pageNum: 1,
+  width: 612,
+  height: 792,
+  text: "A".repeat(500),
+  textItems: [],
+};
+
+vi.mock("../conversion/convertToPdf.js", async () => {
+  const actual = await vi.importActual<typeof import("../conversion/convertToPdf.js")>(
+    "../conversion/convertToPdf.js"
+  );
+  return {
+    ...actual,
+    convertToPdf: vi.fn(async () => ({ pdfPath: "/tmp/test.pdf", originalExtension: ".pdf" })),
+    cleanupConversionFiles: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("../engines/pdf/pdfjs.js", () => ({
+  PdfJsEngine: vi.fn(
+    class {
+      loadDocument = vi.fn().mockResolvedValue(mockPdfDocument);
+      extractAllPages = vi.fn().mockResolvedValue([mockTextHeavyPageWithImage]);
+      renderPageImage = mockRenderPageImage;
+      close = vi.fn(async () => {});
+    }
+  ),
+}));
+
+vi.mock("../processing/grid.js", () => ({
+  projectPagesToGrid: vi.fn(async () => [structuredClone(mockParsedPage)]),
+}));
+
+vi.mock("../processing/bbox.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../processing/bbox.js")>("../processing/bbox.js");
+  return {
+    ...actual,
+    buildBoundingBoxes: vi.fn().mockReturnValue([]),
+  };
+});
+
+vi.mock("../processing/ocrPageRegions.js", async () => {
+  const actual = await vi.importActual<typeof import("../processing/ocrPageRegions.js")>(
+    "../processing/ocrPageRegions.js"
+  );
+  return {
+    ...actual,
+    cropPageImageToRegions: vi.fn(async () => [
+      { buffer: Buffer.from("crop-a"), offsetXPx: 10, offsetYPx: 20 },
+      { buffer: Buffer.from("crop-b"), offsetXPx: 200, offsetYPx: 30 },
+    ]),
+  };
+});
+
+vi.mock("../engines/ocr/tesseract.js", () => ({
+  TesseractEngine: vi.fn(
+    class {
+      terminate = vi.fn(async () => {});
+      recognize = recognize;
+    }
+  ),
+}));
+
+import { LiteParse } from "./parser.js";
+import { cropPageImageToRegions } from "../processing/ocrPageRegions.js";
+
+describe("LiteParse selective OCR", () => {
+  beforeEach(() => {
+    recognize.mockReset();
+    mockRenderPageImage.mockClear();
+    recognize.mockResolvedValue([{ text: "LogoCo", bbox: [0, 0, 50, 20], confidence: 0.95 }]);
+    vi.mocked(cropPageImageToRegions).mockClear();
+  });
+
+  it("OCRs image regions only on text-heavy pages (selective default)", async () => {
+    const parser = new LiteParse({ ocrEnabled: true, ocrScope: "selective" });
+    await parser.parse("deck.pdf");
+
+    expect(mockRenderPageImage).toHaveBeenCalledTimes(1);
+    expect(cropPageImageToRegions).toHaveBeenCalledTimes(1);
+    expect(recognize).toHaveBeenCalledTimes(2);
+    expect(recognize.mock.calls[0]?.[0]).toEqual(Buffer.from("crop-a"));
+    expect(recognize.mock.calls[1]?.[0]).toEqual(Buffer.from("crop-b"));
+    expect(recognize).not.toHaveBeenCalledWith(Buffer.from([1, 2, 3, 4, 5]), expect.any(Object));
+  });
+
+  it("uses full-page OCR on text-heavy pages when ocrScope is full", async () => {
+    const parser = new LiteParse({ ocrEnabled: true, ocrScope: "full" });
+    await parser.parse("deck.pdf");
+
+    expect(cropPageImageToRegions).not.toHaveBeenCalled();
+    expect(recognize).toHaveBeenCalledTimes(1);
+    expect(recognize).toHaveBeenCalledWith(Buffer.from([1, 2, 3, 4, 5]), expect.any(Object));
+  });
+});

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -23,6 +23,15 @@ import {
   guessExtensionFromBuffer,
 } from "../conversion/convertToPdf.js";
 import { cleanOcrTableArtifacts } from "../processing/textUtils.js";
+import { filterImagesForOCR } from "../processing/bbox.js";
+import {
+  cropPageImageToRegions,
+  offsetOcrResults,
+  overlapsImageRegions,
+  overlapsPageRegions,
+  resolveOcrPlan,
+} from "../processing/ocrPageRegions.js";
+import type { OcrResult } from "../engines/ocr/interface.js";
 
 /**
  * Main document parser class. Handles PDF parsing, OCR, format conversion,
@@ -360,22 +369,29 @@ export class LiteParse {
   ): Promise<void> {
     if (!this.ocrEngine) return;
 
-    // Check if page has very little text (indicating need for OCR)
     const textLength = page.textItems.reduce(
       (sum: number, item: TextItem) => sum + item.str.length,
       0
     );
 
-    // Determine if OCR is needed and what mode
-    const hasGarbledRegions = page.garbledTextRegions && page.garbledTextRegions.length > 0;
-    const needsFullOcr = textLength < 100 || page.images.length > 0;
+    const hasGarbledRegions = Boolean(page.garbledTextRegions?.length);
+    const imagesForOcr = filterImagesForOCR(page.images, {
+      width: page.width,
+      height: page.height,
+    });
 
-    if (!needsFullOcr && !hasGarbledRegions) {
+    const { needsFullPageOcr, needsImageRegionOcr } = resolveOcrPlan(
+      this.config.ocrScope,
+      textLength,
+      page.images.length,
+      imagesForOcr.length
+    );
+
+    if (!needsFullPageOcr && !needsImageRegionOcr && !hasGarbledRegions) {
       return;
     }
 
     try {
-      // Render page as image buffer
       const imageBuffer = await this.pdfEngine.renderPageImage(
         doc,
         page.pageNum,
@@ -383,102 +399,105 @@ export class LiteParse {
         this.config.password
       );
 
-      // Run OCR directly on the buffer (no temp file needed)
-      log(`  OCR on page ${page.pageNum}...`);
-      const ocrResults = await this.ocrEngine.recognize(imageBuffer, {
+      const ocrOptions = {
         language: this.config.ocrLanguage,
         correctRotation: true,
-      });
+      };
 
-      // Convert OCR results to text items and add to page
-      if (ocrResults.length > 0) {
-        // Scale factor to convert from OCR pixels to PDF points
-        // OCR operates at config.dpi, PDF uses 72 points per inch (PDF spec constant)
-        const scaleFactor = 72 / this.config.dpi;
+      const ocrResults: OcrResult[] = [];
 
-        // Helper to check if an OCR result overlaps with garbled regions
-        const overlapsGarbledRegion = (ocrBbox: number[]): boolean => {
-          if (!page.garbledTextRegions) return false;
-
-          const ocrX = ocrBbox[0] * scaleFactor;
-          const ocrY = ocrBbox[1] * scaleFactor;
-          const ocrW = (ocrBbox[2] - ocrBbox[0]) * scaleFactor;
-          const ocrH = (ocrBbox[3] - ocrBbox[1]) * scaleFactor;
-
-          // Check overlap with any garbled region (with some tolerance)
-          const tolerance = 5; // PDF points
-          for (const region of page.garbledTextRegions) {
-            const overlapX =
-              ocrX < region.x + region.width + tolerance && ocrX + ocrW > region.x - tolerance;
-            const overlapY =
-              ocrY < region.y + region.height + tolerance && ocrY + ocrH > region.y - tolerance;
-            if (overlapX && overlapY) {
-              return true;
-            }
+      if (needsFullPageOcr) {
+        log(`  OCR on page ${page.pageNum} (full page)...`);
+        ocrResults.push(...(await this.ocrEngine.recognize(imageBuffer, ocrOptions)));
+      } else {
+        if (needsImageRegionOcr) {
+          const crops = await cropPageImageToRegions(
+            imageBuffer,
+            page.width,
+            page.height,
+            this.config.dpi,
+            imagesForOcr
+          );
+          log(`  OCR on page ${page.pageNum} (${crops.length} image region(s))...`);
+          for (const crop of crops) {
+            const regionResults = await this.ocrEngine.recognize(crop.buffer, ocrOptions);
+            ocrResults.push(...offsetOcrResults(regionResults, crop.offsetXPx, crop.offsetYPx));
           }
-          return false;
-        };
+        }
 
-        // Helper to check if an OCR result spatially overlaps with existing PDF text
-        // This prevents duplicating text that PDF already extracted correctly
-        const overlapsExistingText = (ocrBbox: number[]): boolean => {
-          const ocrX = ocrBbox[0] * scaleFactor;
-          const ocrY = ocrBbox[1] * scaleFactor;
-          const ocrW = (ocrBbox[2] - ocrBbox[0]) * scaleFactor;
-          const ocrH = (ocrBbox[3] - ocrBbox[1]) * scaleFactor;
-
-          const tolerance = 2; // PDF points - tighter tolerance for existing text
-          for (const item of page.textItems) {
-            const itemRight = item.x + (item.width || item.w || 0);
-            const itemBottom = item.y + (item.height || item.h || 0);
-
-            const overlapX = ocrX < itemRight + tolerance && ocrX + ocrW > item.x - tolerance;
-            const overlapY = ocrY < itemBottom + tolerance && ocrY + ocrH > item.y - tolerance;
-
-            if (overlapX && overlapY) {
-              return true;
-            }
-          }
-          return false;
-        };
-
-        const ocrTextItems: TextItem[] = ocrResults
-          .filter((r) => r.confidence > 0.1) // Filter low confidence
-          .filter((r) => {
-            // For targeted OCR (garbled regions only), only include results that overlap
-            if (hasGarbledRegions && !needsFullOcr) {
-              return overlapsGarbledRegion(r.bbox);
-            }
-            // For full OCR, include all results
-            return true;
-          })
-          .filter((r) => {
-            // Skip OCR results that spatially overlap with existing PDF text
-            // This prevents duplicating text that PDF already extracted correctly
-            return !overlapsExistingText(r.bbox);
-          })
-          .map((r) => {
-            // Clean OCR artifacts from table border misreads
-            const cleanedText = cleanOcrTableArtifacts(r.text);
-            return {
-              str: cleanedText,
-              x: r.bbox[0] * scaleFactor,
-              y: r.bbox[1] * scaleFactor,
-              width: (r.bbox[2] - r.bbox[0]) * scaleFactor,
-              height: (r.bbox[3] - r.bbox[1]) * scaleFactor,
-              w: (r.bbox[2] - r.bbox[0]) * scaleFactor,
-              h: (r.bbox[3] - r.bbox[1]) * scaleFactor,
-              fontName: "OCR",
-              fontSize: (r.bbox[3] - r.bbox[1]) * scaleFactor,
-              confidence: Math.round(r.confidence * 1000) / 1000,
-            };
-          })
-          .filter((item) => item.str.length > 0); // Skip items that became empty after cleaning
-
-        // Add OCR text items directly to page textItems
-        page.textItems.push(...ocrTextItems);
-        log(`  Found ${ocrTextItems.length} text items from OCR on page ${page.pageNum}`);
+        if (hasGarbledRegions) {
+          log(`  OCR on page ${page.pageNum} (garbled regions)...`);
+          ocrResults.push(...(await this.ocrEngine.recognize(imageBuffer, ocrOptions)));
+        }
       }
+
+      if (ocrResults.length === 0) {
+        return;
+      }
+
+      const scaleFactor = 72 / this.config.dpi;
+      const garbledRegions = page.garbledTextRegions ?? [];
+
+      const overlapsExistingText = (ocrBbox: number[]): boolean => {
+        const ocrX = ocrBbox[0] * scaleFactor;
+        const ocrY = ocrBbox[1] * scaleFactor;
+        const ocrW = (ocrBbox[2] - ocrBbox[0]) * scaleFactor;
+        const ocrH = (ocrBbox[3] - ocrBbox[1]) * scaleFactor;
+
+        const tolerance = 2;
+        for (const item of page.textItems) {
+          const itemRight = item.x + (item.width || item.w || 0);
+          const itemBottom = item.y + (item.height || item.h || 0);
+
+          const overlapX = ocrX < itemRight + tolerance && ocrX + ocrW > item.x - tolerance;
+          const overlapY = ocrY < itemBottom + tolerance && ocrY + ocrH > item.y - tolerance;
+
+          if (overlapX && overlapY) {
+            return true;
+          }
+        }
+        return false;
+      };
+
+      const shouldKeepOcrResult = (ocrBbox: number[]): boolean => {
+        if (needsFullPageOcr) {
+          return true;
+        }
+
+        if (needsImageRegionOcr && overlapsImageRegions(ocrBbox, imagesForOcr, scaleFactor)) {
+          return true;
+        }
+
+        if (hasGarbledRegions && overlapsPageRegions(ocrBbox, garbledRegions, scaleFactor)) {
+          return true;
+        }
+
+        return false;
+      };
+
+      const ocrTextItems: TextItem[] = ocrResults
+        .filter((r) => r.confidence > 0.1)
+        .filter((r) => shouldKeepOcrResult(r.bbox))
+        .filter((r) => !overlapsExistingText(r.bbox))
+        .map((r) => {
+          const cleanedText = cleanOcrTableArtifacts(r.text);
+          return {
+            str: cleanedText,
+            x: r.bbox[0] * scaleFactor,
+            y: r.bbox[1] * scaleFactor,
+            width: (r.bbox[2] - r.bbox[0]) * scaleFactor,
+            height: (r.bbox[3] - r.bbox[1]) * scaleFactor,
+            w: (r.bbox[2] - r.bbox[0]) * scaleFactor,
+            h: (r.bbox[3] - r.bbox[1]) * scaleFactor,
+            fontName: "OCR",
+            fontSize: (r.bbox[3] - r.bbox[1]) * scaleFactor,
+            confidence: Math.round(r.confidence * 1000) / 1000,
+          };
+        })
+        .filter((item) => item.str.length > 0);
+
+      page.textItems.push(...ocrTextItems);
+      log(`  Found ${ocrTextItems.length} text items from OCR on page ${page.pageNum}`);
     } catch (error) {
       log(`  OCR failed for page ${page.pageNum}: ${error}`);
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -9,6 +9,15 @@ import type { GridDebugConfig } from "../processing/gridDebugLogger.js";
 export type OutputFormat = "json" | "text";
 
 /**
+ * Controls how OCR is applied per page.
+ *
+ * - `"selective"` — Full-page OCR only on text-sparse pages; embedded images on
+ *   text-heavy pages are OCR'd by region. Matches documented selective OCR behavior.
+ * - `"full"` — Legacy behavior: any embedded image triggers full-page OCR.
+ */
+export type OcrScope = "selective" | "full";
+
+/**
  * Accepted input types for {@link LiteParse.parse} and {@link LiteParse.screenshot}.
  *
  * - `string` — A file path to a document on disk.
@@ -44,11 +53,18 @@ export interface LiteParseConfig {
 
   /**
    * Whether to run OCR on pages with little or no native text.
-   * When enabled, LiteParse selectively OCRs only images and text-sparse regions.
+   * When enabled, LiteParse selectively OCRs embedded image regions and text-sparse pages.
    *
    * @defaultValue `true`
    */
   ocrEnabled: boolean;
+
+  /**
+   * How OCR is scoped per page. See {@link OcrScope}.
+   *
+   * @defaultValue `"selective"`
+   */
+  ocrScope: OcrScope;
 
   /**
    * URL of an HTTP OCR server implementing the LiteParse OCR API.

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -18,6 +18,7 @@ export type {
   LiteParseConfig,
   LiteParseInput,
   OutputFormat,
+  OcrScope,
   ParseResult,
   ParseResultJson,
   ParsedPage,

--- a/src/processing/ocrPageRegions.test.ts
+++ b/src/processing/ocrPageRegions.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import sharp from "sharp";
+import {
+  cropPageImageToRegions,
+  offsetOcrResults,
+  overlapsImageRegions,
+  resolveOcrPlan,
+} from "./ocrPageRegions.js";
+
+describe("resolveOcrPlan", () => {
+  it("selective: full page only when text is sparse", () => {
+    expect(resolveOcrPlan("selective", 50, 3, 2)).toEqual({
+      needsFullPageOcr: true,
+      needsImageRegionOcr: false,
+    });
+  });
+
+  it("selective: image regions when text-heavy page has images", () => {
+    expect(resolveOcrPlan("selective", 500, 2, 1)).toEqual({
+      needsFullPageOcr: false,
+      needsImageRegionOcr: true,
+    });
+  });
+
+  it("selective: skip OCR when text-heavy and no filtered images", () => {
+    expect(resolveOcrPlan("selective", 500, 0, 0)).toEqual({
+      needsFullPageOcr: false,
+      needsImageRegionOcr: false,
+    });
+  });
+
+  it("full: legacy behavior triggers full page when images exist", () => {
+    expect(resolveOcrPlan("full", 500, 1, 1)).toEqual({
+      needsFullPageOcr: true,
+      needsImageRegionOcr: false,
+    });
+  });
+});
+
+describe("offsetOcrResults", () => {
+  it("shifts bounding boxes by crop offset", () => {
+    const results = offsetOcrResults(
+      [{ text: "hi", bbox: [10, 20, 30, 40], confidence: 0.9 }],
+      100,
+      50
+    );
+    expect(results[0]?.bbox).toEqual([110, 70, 130, 90]);
+  });
+});
+
+describe("overlapsImageRegions", () => {
+  it("detects overlap between OCR box and image region", () => {
+    const scaleFactor = 72 / 150;
+    const images = [{ x: 100, y: 200, width: 80, height: 40 }];
+    const ocrBboxPx = [100 / scaleFactor, 200 / scaleFactor, 150 / scaleFactor, 240 / scaleFactor];
+    expect(overlapsImageRegions(ocrBboxPx, images, scaleFactor)).toBe(true);
+  });
+});
+
+describe("cropPageImageToRegions", () => {
+  it("extracts image-sized crops from a page render", async () => {
+    const pageWidthPt = 612;
+    const pageHeightPt = 792;
+    const dpi = 150;
+    const pageWidthPx = Math.round((pageWidthPt * dpi) / 72);
+    const pageHeightPx = Math.round((pageHeightPt * dpi) / 72);
+
+    const pageBuffer = await sharp({
+      create: {
+        width: pageWidthPx,
+        height: pageHeightPx,
+        channels: 3,
+        background: { r: 255, g: 255, b: 255 },
+      },
+    })
+      .png()
+      .toBuffer();
+
+    const crops = await cropPageImageToRegions(pageBuffer, pageWidthPt, pageHeightPt, dpi, [
+      { x: 50, y: 60, width: 120, height: 80 },
+    ]);
+
+    expect(crops).toHaveLength(1);
+    const meta = await sharp(crops[0]!.buffer).metadata();
+    expect(meta.width).toBeGreaterThan(0);
+    expect(meta.height).toBeGreaterThan(0);
+    expect(crops[0]!.offsetXPx).toBeGreaterThanOrEqual(0);
+    expect(crops[0]!.offsetYPx).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/processing/ocrPageRegions.ts
+++ b/src/processing/ocrPageRegions.ts
@@ -1,0 +1,162 @@
+import sharp from "sharp";
+import type { Image } from "../engines/pdf/interface.js";
+import type { OcrResult } from "../engines/ocr/interface.js";
+
+/** How broadly to run OCR on a page. */
+export type OcrScope = "selective" | "full";
+
+export interface PageRegion {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface PageImageCrop {
+  buffer: Buffer;
+  /** Crop origin in full-page render pixels (top-left). */
+  offsetXPx: number;
+  offsetYPx: number;
+}
+
+const REGION_MATCH_TOLERANCE_PT = 5;
+
+/**
+ * Decide full-page vs per-image OCR for a page.
+ */
+export function resolveOcrPlan(
+  ocrScope: OcrScope,
+  textLength: number,
+  rawImageCount: number,
+  filteredImageCount: number
+): { needsFullPageOcr: boolean; needsImageRegionOcr: boolean } {
+  if (ocrScope === "full") {
+    return {
+      needsFullPageOcr: textLength < 100 || rawImageCount > 0,
+      needsImageRegionOcr: false,
+    };
+  }
+
+  return {
+    needsFullPageOcr: textLength < 100,
+    needsImageRegionOcr: textLength >= 100 && filteredImageCount > 0,
+  };
+}
+
+/**
+ * Crop embedded image regions from a full-page render for selective OCR.
+ */
+export async function cropPageImageToRegions(
+  pageBuffer: Buffer,
+  pageWidthPt: number,
+  pageHeightPt: number,
+  dpi: number,
+  images: Image[]
+): Promise<PageImageCrop[]> {
+  if (images.length === 0) {
+    return [];
+  }
+
+  const metadata = await sharp(pageBuffer).metadata();
+  const pageWidthPx = metadata.width ?? Math.max(1, Math.round((pageWidthPt * dpi) / 72));
+  const pageHeightPx = metadata.height ?? Math.max(1, Math.round((pageHeightPt * dpi) / 72));
+
+  const scaleX = pageWidthPx / pageWidthPt;
+  const scaleY = pageHeightPx / pageHeightPt;
+
+  const crops: PageImageCrop[] = [];
+
+  for (const image of images) {
+    const left = Math.max(0, Math.floor(image.x * scaleX));
+    const top = Math.max(0, Math.floor(image.y * scaleY));
+    const width = Math.min(pageWidthPx - left, Math.max(1, Math.ceil(image.width * scaleX)));
+    const height = Math.min(pageHeightPx - top, Math.max(1, Math.ceil(image.height * scaleY)));
+
+    if (width < 1 || height < 1) {
+      continue;
+    }
+
+    const buffer = await sharp(pageBuffer).extract({ left, top, width, height }).png().toBuffer();
+
+    crops.push({ buffer, offsetXPx: left, offsetYPx: top });
+  }
+
+  return crops;
+}
+
+/**
+ * Map OCR bounding boxes from crop space into full-page render pixel space.
+ */
+export function offsetOcrResults(
+  results: OcrResult[],
+  offsetXPx: number,
+  offsetYPx: number
+): OcrResult[] {
+  if (offsetXPx === 0 && offsetYPx === 0) {
+    return results;
+  }
+
+  return results.map((result) => ({
+    ...result,
+    bbox: [
+      result.bbox[0] + offsetXPx,
+      result.bbox[1] + offsetYPx,
+      result.bbox[2] + offsetXPx,
+      result.bbox[3] + offsetYPx,
+    ] as [number, number, number, number],
+  }));
+}
+
+/**
+ * Whether an OCR box (full-page render pixels) overlaps any image region (PDF points).
+ */
+export function overlapsImageRegions(
+  ocrBboxPx: number[],
+  images: Image[],
+  scaleFactor: number,
+  tolerancePt: number = REGION_MATCH_TOLERANCE_PT
+): boolean {
+  const ocrX = ocrBboxPx[0] * scaleFactor;
+  const ocrY = ocrBboxPx[1] * scaleFactor;
+  const ocrW = (ocrBboxPx[2] - ocrBboxPx[0]) * scaleFactor;
+  const ocrH = (ocrBboxPx[3] - ocrBboxPx[1]) * scaleFactor;
+
+  for (const image of images) {
+    const overlapX =
+      ocrX < image.x + image.width + tolerancePt && ocrX + ocrW > image.x - tolerancePt;
+    const overlapY =
+      ocrY < image.y + image.height + tolerancePt && ocrY + ocrH > image.y - tolerancePt;
+    if (overlapX && overlapY) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Whether an OCR box (full-page render pixels) overlaps a rectangular region (PDF points).
+ */
+export function overlapsPageRegions(
+  ocrBboxPx: number[],
+  regions: PageRegion[],
+  scaleFactor: number,
+  tolerancePt: number = REGION_MATCH_TOLERANCE_PT
+): boolean {
+  const ocrX = ocrBboxPx[0] * scaleFactor;
+  const ocrY = ocrBboxPx[1] * scaleFactor;
+  const ocrW = (ocrBboxPx[2] - ocrBboxPx[0]) * scaleFactor;
+  const ocrH = (ocrBboxPx[3] - ocrBboxPx[1]) * scaleFactor;
+
+  for (const region of regions) {
+    const overlapX =
+      ocrX < region.x + region.width + tolerancePt && ocrX + ocrW > region.x - tolerancePt;
+    const overlapY =
+      ocrY < region.y + region.height + tolerancePt && ocrY + ocrH > region.y - tolerancePt;
+    if (overlapX && overlapY) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
Fixes #184 

## Summary

Aligns runtime OCR behavior with **documented selective OCR** in `AGENTS.md`, `LiteParseConfig` JSDoc, and the project data-flow description. Before this change, implementation diverged from docs: any embedded image forced **full-page** OCR even on text-heavy pages.

**Documentation this MR implements:**

| Source | Stated behavior |
|--------|-----------------|
| **`AGENTS.md` § Selective OCR** | *"OCR only runs on embedded images where text extraction failed, not the entire document."* |
| **`AGENTS.md` data flow (step 4)** | *"Images rendered and OCR'd for text-sparse areas"* |
| **`LiteParseConfig` (`ocrEnabled`)** | *"LiteParse selectively OCRs embedded image regions and text-sparse pages."* |

**What was wrong:** `needsFullOcr = textLength < 100 \|\| page.images.length > 0` treated every logo/icon/chart as a signal to render and OCR the **entire page**, which contradicts the above.

**What this MR does:** Default `ocrScope: "selective"` — full-page OCR only on sparse pages (`textLength < 100`); on text-heavy pages, OCR **filtered embedded image regions** via `filterImagesForOCR` + per-region crops. Legacy behavior remains available as `ocrScope: "full"`.

## Changes

| Area | What changed |
|------|----------------|
| **`ocrScope` config** | `"selective"` (default, matches docs) or `"full"` (pre-fix behavior) |
| **`ocrPageRegions.ts`** | OCR plan, `sharp` crops per image bbox, coordinate offset, region overlap filters |
| **`parser.ts`** | Reuses `filterImagesForOCR`; sparse pages → full-page OCR; text-heavy pages → regional OCR; garbled regions unchanged in spirit |
| **Tests** | Unit tests for region helpers + parser tests for selective vs full scope |
| **`lib.ts`** | Exports `OcrScope` |

## Behavior

### `ocrScope: "selective"` (default — matches documentation)

| Page condition | OCR behavior |
|----------------|--------------|
| `textLength < 100` | Full-page OCR (text-sparse / scanned pages) |
| Text-heavy + embedded images | One page render → crop each filtered image → OCR regions only |
| Garbled text regions (non-sparse) | Full-page OCR, results filtered to garbled boxes |

### `ocrScope: "full"` (legacy escape hatch)

Previous behavior: `textLength < 100 || images.length > 0` → full-page OCR.

## Usage

```typescript
// Default — documented selective OCR
const parser = new LiteParse({ ocrEnabled: true });

// Opt-in legacy behavior
const legacy = new LiteParse({ ocrEnabled: true, ocrScope: "full" });
```