### PR TITLE
fix(parser): honor outputFormat json for text passthrough files

### DIFF
--- a/src/core/parser.text-passthrough.test.ts
+++ b/src/core/parser.text-passthrough.test.ts
@@ -1,0 +1,44 @@
+import { vi, describe, it, expect } from "vitest";
+
+vi.mock("../conversion/convertToPdf.js", async () => {
+  const actual = await vi.importActual<typeof import("../conversion/convertToPdf.js")>(
+    "../conversion/convertToPdf.js"
+  );
+  return {
+    ...actual,
+    convertToPdf: vi.fn(async () => ({ content: "Hello from notes.txt" })),
+    cleanupConversionFiles: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("../engines/pdf/pdfjs.js", () => ({
+  PdfJsEngine: vi.fn(
+    class {
+      loadDocument = vi.fn();
+      close = vi.fn(async () => {});
+    }
+  ),
+}));
+
+import { LiteParse } from "./parser.js";
+
+describe("LiteParse text passthrough", () => {
+  it("returns result.json when outputFormat is json (default)", async () => {
+    const parser = new LiteParse({ ocrEnabled: false, outputFormat: "json" });
+    const result = await parser.parse("notes.txt");
+
+    expect(result.text).toBe("Hello from notes.txt");
+    expect(result.pages).toHaveLength(1);
+    expect(result.pages[0]?.pageNum).toBe(1);
+    expect(result.json?.pages[0]?.text).toBe("Hello from notes.txt");
+  });
+
+  it("returns no result.json when outputFormat is text", async () => {
+    const parser = new LiteParse({ ocrEnabled: false, outputFormat: "text" });
+    const result = await parser.parse("notes.txt");
+
+    expect(result.text).toBe("Hello from notes.txt");
+    expect(result.pages).toHaveLength(1);
+    expect(result.json).toBeUndefined();
+  });
+});

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -23,6 +23,7 @@ import {
   guessExtensionFromBuffer,
 } from "../conversion/convertToPdf.js";
 import { cleanOcrTableArtifacts } from "../processing/textUtils.js";
+import { buildTextPassthroughResult } from "./textPassthrough.js";
 
 /**
  * Main document parser class. Handles PDF parsing, OCR, format conversion,
@@ -116,7 +117,7 @@ export class LiteParse {
 
       if ("content" in conversionResult) {
         log(`File is a text-based format. Returning content directly.`);
-        return { pages: [], text: conversionResult.content };
+        return buildTextPassthroughResult(conversionResult.content, this.config);
       }
 
       const pdfPath = conversionResult.pdfPath;
@@ -145,7 +146,7 @@ export class LiteParse {
 
         if ("content" in conversionResult) {
           log(`Buffer is a text-based format. Returning content directly.`);
-          return { pages: [], text: conversionResult.content };
+          return buildTextPassthroughResult(conversionResult.content, this.config);
         }
 
         needsCleanup = true;

--- a/src/core/textPassthrough.test.ts
+++ b/src/core/textPassthrough.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_CONFIG } from "./config.js";
+import { buildTextPassthroughPages, buildTextPassthroughResult } from "./textPassthrough.js";
+
+describe("buildTextPassthroughPages", () => {
+  it("returns one synthetic page with the full text", () => {
+    const pages = buildTextPassthroughPages("Hello\nWorld");
+    expect(pages).toHaveLength(1);
+    expect(pages[0]?.pageNum).toBe(1);
+    expect(pages[0]?.text).toBe("Hello\nWorld");
+    expect(pages[0]?.textItems[0]?.str).toBe("Hello\nWorld");
+  });
+});
+
+describe("buildTextPassthroughResult", () => {
+  it("includes result.json when outputFormat is json", () => {
+    const result = buildTextPassthroughResult("Plain text file.", {
+      ...DEFAULT_CONFIG,
+      outputFormat: "json",
+    });
+
+    expect(result.text).toBe("Plain text file.");
+    expect(result.pages).toHaveLength(1);
+    expect(result.json).toBeDefined();
+    expect(result.json?.pages).toHaveLength(1);
+    expect(result.json?.pages[0]?.text).toBe("Plain text file.");
+    expect(result.json?.pages[0]?.textItems[0]?.text).toBe("Plain text file.");
+  });
+
+  it("omits result.json when outputFormat is text", () => {
+    const result = buildTextPassthroughResult("Plain text file.", {
+      ...DEFAULT_CONFIG,
+      outputFormat: "text",
+    });
+
+    expect(result.text).toBe("Plain text file.");
+    expect(result.pages).toHaveLength(1);
+    expect(result.json).toBeUndefined();
+  });
+});

--- a/src/core/textPassthrough.ts
+++ b/src/core/textPassthrough.ts
@@ -1,0 +1,50 @@
+import { LiteParseConfig, ParseResult, ParsedPage, TextItem } from "./types.js";
+import { buildJSON } from "../output/json.js";
+
+/** Nominal page size (US Letter in PDF points) for text-only passthrough results. */
+const TEXT_PASSTHROUGH_PAGE_WIDTH = 612;
+const TEXT_PASSTHROUGH_PAGE_HEIGHT = 792;
+
+/**
+ * Build a single synthetic page for text-based passthrough inputs (.txt, .csv, etc.).
+ */
+export function buildTextPassthroughPages(content: string): ParsedPage[] {
+  const textItem: TextItem = {
+    str: content,
+    x: 0,
+    y: 0,
+    width: TEXT_PASSTHROUGH_PAGE_WIDTH,
+    height: TEXT_PASSTHROUGH_PAGE_HEIGHT,
+    fontName: "Text",
+    fontSize: 12,
+    confidence: 1.0,
+  };
+
+  return [
+    {
+      pageNum: 1,
+      width: TEXT_PASSTHROUGH_PAGE_WIDTH,
+      height: TEXT_PASSTHROUGH_PAGE_HEIGHT,
+      text: content,
+      textItems: [textItem],
+      boundingBoxes: [],
+    },
+  ];
+}
+
+/**
+ * Build a {@link ParseResult} for text-based passthrough, honoring {@link LiteParseConfig.outputFormat}.
+ */
+export function buildTextPassthroughResult(content: string, config: LiteParseConfig): ParseResult {
+  const pages = buildTextPassthroughPages(content);
+  const result: ParseResult = {
+    pages,
+    text: content,
+  };
+
+  if (config.outputFormat === "json") {
+    result.json = buildJSON(pages);
+  }
+
+  return result;
+}

--- a/src/core/textPassthrough.ts
+++ b/src/core/textPassthrough.ts
@@ -15,6 +15,8 @@ export function buildTextPassthroughPages(content: string): ParsedPage[] {
     y: 0,
     width: TEXT_PASSTHROUGH_PAGE_WIDTH,
     height: TEXT_PASSTHROUGH_PAGE_HEIGHT,
+    w: TEXT_PASSTHROUGH_PAGE_WIDTH,
+    h: TEXT_PASSTHROUGH_PAGE_HEIGHT,
     fontName: "Text",
     fontSize: 12,
     confidence: 1.0,


### PR DESCRIPTION
Fixes #186 

## Summary

Fixes text passthrough ignoring `outputFormat: "json"` and returning an empty `pages` array. `.txt`, `.csv`, and similar inputs now return the same `ParseResult` shape as PDF parses when JSON output is configured.

**Before:** Early return was only `{ pages: [], text: content }` — `result.json` was never set even though the default config is `outputFormat: "json"`.

**After:** `buildTextPassthroughResult()` builds one synthetic page and sets `result.json` via `buildJSON()` when `outputFormat === "json"`.

## Issues addressed

| Issue | Fix |
|-------|-----|
| **#7** — Text passthrough ignores `outputFormat: "json"` | `result.json` populated when `outputFormat` is `"json"` |
| **#8** — Text passthrough returns `pages: []` | One synthetic page (`pageNum: 1`) with `text` and `textItems` |

## Changes

| File | What changed |
|------|----------------|
| `src/core/textPassthrough.ts` | `buildTextPassthroughPages()`, `buildTextPassthroughResult()` |
| `src/core/parser.ts` | Path and buffer passthrough use the helper instead of bare `{ pages: [], text }` |
| Tests | Unit tests for helper + parser integration tests |

## Result shape

```typescript
// outputFormat: "json" (default)
const result = await parser.parse("notes.txt");
result.text;              // full file content
result.pages.length;      // 1
result.json?.pages[0].text; // same content — defined

// outputFormat: "text"
result.json;              // undefined (unchanged)
```

## Test plan

- [x] `npm test -- --run src/core/textPassthrough.test.ts`
- [x] `npm test -- --run src/core/parser.text-passthrough.test.ts`
- [x] `npm test -- --run src/core/parser.test.ts`
- [ ] CI `format:check` passes
- [ ] Manual: `lit parse notes.txt -f json` writes valid JSON with a `pages` array
- [ ] Manual: `outputFormat: "text"` still omits `result.json`