### PR TITLE
fix: reuse Tesseract worker pool across parse() calls

### DIFF
--- a/cli/parse.ts
+++ b/cli/parse.ts
@@ -172,47 +172,47 @@ program
       const parser = new LiteParse(config);
 
       try {
-      // Read from stdin or file
-      let input: string | Buffer;
-      if (isStdin) {
-        const chunks: Buffer[] = [];
-        for await (const chunk of process.stdin) {
-          chunks.push(chunk);
+        // Read from stdin or file
+        let input: string | Buffer;
+        if (isStdin) {
+          const chunks: Buffer[] = [];
+          for await (const chunk of process.stdin) {
+            chunks.push(chunk);
+          }
+          input = Buffer.concat(chunks);
+          if (input.length === 0) {
+            console.error("Error: No data received from stdin");
+            process.exit(1);
+          }
+        } else {
+          input = file;
         }
-        input = Buffer.concat(chunks);
-        if (input.length === 0) {
-          console.error("Error: No data received from stdin");
-          process.exit(1);
+
+        // Parse document (quiet flag controls progress output)
+        const result = await parser.parse(input, quiet);
+
+        // Format output based on format
+        let output: string;
+        switch (config.outputFormat) {
+          case "json":
+            output = JSON.stringify(result.json, null, 2);
+            break;
+          case "text":
+          default:
+            output = result.text;
+            break;
         }
-      } else {
-        input = file;
-      }
 
-      // Parse document (quiet flag controls progress output)
-      const result = await parser.parse(input, quiet);
-
-      // Format output based on format
-      let output: string;
-      switch (config.outputFormat) {
-        case "json":
-          output = JSON.stringify(result.json, null, 2);
-          break;
-        case "text":
-        default:
-          output = result.text;
-          break;
-      }
-
-      // Write to file or stdout
-      if (options.output) {
-        await fs.writeFile(options.output, output);
-        if (!quiet) {
-          console.error(`\n✓ Parsed ${result.pages.length} pages → ${options.output}`);
+        // Write to file or stdout
+        if (options.output) {
+          await fs.writeFile(options.output, output);
+          if (!quiet) {
+            console.error(`\n✓ Parsed ${result.pages.length} pages → ${options.output}`);
+          }
+        } else {
+          // Output result to stdout (can be piped)
+          console.log(output);
         }
-      } else {
-        // Output result to stdout (can be piped)
-        console.log(output);
-      }
       } finally {
         await parser.destroy();
       }
@@ -284,22 +284,22 @@ program
 
       let results;
       try {
-      // Generate screenshots
-      results = await parser.screenshot(file, pageNumbers, quiet);
+        // Generate screenshots
+        results = await parser.screenshot(file, pageNumbers, quiet);
 
-      // Save screenshots
-      for (const result of results) {
-        const filename = `page_${result.pageNum}.${options.format || DEFAULT_SCREENSHOT_FORMAT}`;
-        const filepath = path.join(outputDir, filename);
-        await fs.writeFile(filepath, result.imageBuffer);
-        if (!quiet) {
-          console.error(`✓ ${filepath} (${result.width}x${result.height})`);
+        // Save screenshots
+        for (const result of results) {
+          const filename = `page_${result.pageNum}.${options.format || DEFAULT_SCREENSHOT_FORMAT}`;
+          const filepath = path.join(outputDir, filename);
+          await fs.writeFile(filepath, result.imageBuffer);
+          if (!quiet) {
+            console.error(`✓ ${filepath} (${result.width}x${result.height})`);
+          }
         }
-      }
 
-      if (!quiet) {
-        console.error(`\n✓ Generated ${results.length} screenshots → ${outputDir}`);
-      }
+        if (!quiet) {
+          console.error(`\n✓ Generated ${results.length} screenshots → ${outputDir}`);
+        }
       } finally {
         await parser.destroy();
       }
@@ -446,66 +446,66 @@ program
       const parser = new LiteParse(config);
 
       try {
-      // Process files
-      let successCount = 0;
-      let errorCount = 0;
-      const outputExt = options.format === "json" ? ".json" : ".txt";
+        // Process files
+        let successCount = 0;
+        let errorCount = 0;
+        const outputExt = options.format === "json" ? ".json" : ".txt";
 
-      for (let i = 0; i < files.length; i++) {
-        const file = files[i];
-        const relativePath = path.relative(inputDir, file);
-        const outputPath = path.join(outputDir, relativePath.replace(/\.[^.]+$/, outputExt));
+        for (let i = 0; i < files.length; i++) {
+          const file = files[i];
+          const relativePath = path.relative(inputDir, file);
+          const outputPath = path.join(outputDir, relativePath.replace(/\.[^.]+$/, outputExt));
 
-        // Create output subdirectory if needed
-        const outputSubdir = path.dirname(outputPath);
-        if (!existsSync(outputSubdir)) {
-          await fs.mkdir(outputSubdir, { recursive: true });
+          // Create output subdirectory if needed
+          const outputSubdir = path.dirname(outputPath);
+          if (!existsSync(outputSubdir)) {
+            await fs.mkdir(outputSubdir, { recursive: true });
+          }
+
+          try {
+            const fileStart = performance.now();
+            const result = await parser.parse(file, true); // Always quiet for individual files
+
+            // Format output
+            let output: string;
+            if (options.format === "json") {
+              output = JSON.stringify(result.json, null, 2);
+            } else {
+              output = result.text;
+            }
+
+            await fs.writeFile(outputPath, output);
+            successCount++;
+
+            if (!quiet) {
+              const fileTime = (performance.now() - fileStart).toFixed(0);
+              console.error(
+                `[${i + 1}/${files.length}] ✓ ${relativePath} (${result.pages.length} pages, ${fileTime}ms)`
+              );
+            }
+          } catch (error: unknown) {
+            errorCount++;
+            if (!quiet) {
+              const message = error instanceof Error ? error.message : String(error);
+              console.error(`[${i + 1}/${files.length}] ✗ ${relativePath}: ${message}`);
+            }
+          }
         }
 
-        try {
-          const fileStart = performance.now();
-          const result = await parser.parse(file, true); // Always quiet for individual files
+        const totalTime = ((performance.now() - startTime) / 1000).toFixed(2);
+        const avgTime =
+          files.length > 0 ? ((performance.now() - startTime) / files.length).toFixed(0) : 0;
 
-          // Format output
-          let output: string;
-          if (options.format === "json") {
-            output = JSON.stringify(result.json, null, 2);
-          } else {
-            output = result.text;
-          }
-
-          await fs.writeFile(outputPath, output);
-          successCount++;
-
-          if (!quiet) {
-            const fileTime = (performance.now() - fileStart).toFixed(0);
-            console.error(
-              `[${i + 1}/${files.length}] ✓ ${relativePath} (${result.pages.length} pages, ${fileTime}ms)`
-            );
-          }
-        } catch (error: unknown) {
-          errorCount++;
-          if (!quiet) {
-            const message = error instanceof Error ? error.message : String(error);
-            console.error(`[${i + 1}/${files.length}] ✗ ${relativePath}: ${message}`);
-          }
+        if (!quiet) {
+          console.error("");
+          console.error(`Batch complete: ${successCount} succeeded, ${errorCount} failed`);
+          console.error(`Total time: ${totalTime}s (avg ${avgTime}ms/file)`);
+          console.error(`Output: ${outputDir}`);
         }
-      }
 
-      const totalTime = ((performance.now() - startTime) / 1000).toFixed(2);
-      const avgTime =
-        files.length > 0 ? ((performance.now() - startTime) / files.length).toFixed(0) : 0;
-
-      if (!quiet) {
-        console.error("");
-        console.error(`Batch complete: ${successCount} succeeded, ${errorCount} failed`);
-        console.error(`Total time: ${totalTime}s (avg ${avgTime}ms/file)`);
-        console.error(`Output: ${outputDir}`);
-      }
-
-      if (errorCount > 0) {
-        process.exit(1);
-      }
+        if (errorCount > 0) {
+          process.exit(1);
+        }
       } finally {
         await parser.destroy();
       }

--- a/cli/parse.ts
+++ b/cli/parse.ts
@@ -171,6 +171,7 @@ program
       // Create parser
       const parser = new LiteParse(config);
 
+      try {
       // Read from stdin or file
       let input: string | Buffer;
       if (isStdin) {
@@ -211,6 +212,9 @@ program
       } else {
         // Output result to stdout (can be piped)
         console.log(output);
+      }
+      } finally {
+        await parser.destroy();
       }
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
@@ -278,8 +282,10 @@ program
       // Create parser
       const parser = new LiteParse(config);
 
+      let results;
+      try {
       // Generate screenshots
-      const results = await parser.screenshot(file, pageNumbers, quiet);
+      results = await parser.screenshot(file, pageNumbers, quiet);
 
       // Save screenshots
       for (const result of results) {
@@ -293,6 +299,9 @@ program
 
       if (!quiet) {
         console.error(`\n✓ Generated ${results.length} screenshots → ${outputDir}`);
+      }
+      } finally {
+        await parser.destroy();
       }
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
@@ -436,6 +445,7 @@ program
       // Create a SINGLE parser instance for all files (key for batch efficiency)
       const parser = new LiteParse(config);
 
+      try {
       // Process files
       let successCount = 0;
       let errorCount = 0;
@@ -495,6 +505,9 @@ program
 
       if (errorCount > 0) {
         process.exit(1);
+      }
+      } finally {
+        await parser.destroy();
       }
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -32,7 +32,7 @@ The core module contains the main orchestrator class, configuration management, 
 - **Engine auto-detection**: If `ocrServerUrl` is provided, uses HTTP OCR; otherwise defaults to Tesseract.js for zero-setup experience
 - **Selective OCR**: Only runs OCR on pages with <100 characters of text OR pages with embedded images
 - **Progress logging to stderr**: Keeps stdout clean for piped output
-- **Graceful cleanup**: Always cleans up temp files and terminates OCR workers
+- **Graceful cleanup**: Cleans up temp files per parse; call `destroy()` to terminate OCR workers when done with the instance
 
 ---
 

--- a/src/core/parser.tesseract-lifecycle.test.ts
+++ b/src/core/parser.tesseract-lifecycle.test.ts
@@ -1,0 +1,97 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const mockTerminate = vi.hoisted(() => vi.fn(async () => {}));
+const mockRecognize = vi.hoisted(() => vi.fn(async () => []));
+
+const mockPdfDocument = { numPages: 1 };
+const mockPages = [
+  {
+    pageNum: 1,
+    width: 612,
+    height: 792,
+    textItems: [],
+    paths: [],
+    images: [{ x: 0, y: 0, width: 100, height: 100 }],
+    annotations: [],
+  },
+];
+
+vi.mock("../conversion/convertToPdf.js", async () => {
+  const actual = await vi.importActual<typeof import("../conversion/convertToPdf.js")>(
+    "../conversion/convertToPdf.js"
+  );
+  return {
+    ...actual,
+    convertToPdf: vi.fn(async (input: string) => ({
+      pdfPath: input,
+      originalExtension: ".pdf",
+    })),
+    cleanupConversionFiles: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("../engines/pdf/pdfjs.js", () => ({
+  PdfJsEngine: vi.fn(
+    class {
+      loadDocument = vi.fn().mockResolvedValue(mockPdfDocument);
+      extractAllPages = vi.fn().mockResolvedValue(mockPages);
+      renderPageImage = vi.fn(async () => Buffer.from([1, 2, 3]));
+      close = vi.fn(async () => {});
+    }
+  ),
+}));
+
+vi.mock("../engines/ocr/tesseract.js", () => ({
+  TesseractEngine: vi.fn(
+    class {
+      terminate = mockTerminate;
+      recognize = mockRecognize;
+    }
+  ),
+}));
+
+vi.mock("../processing/grid.js", () => ({
+  projectPagesToGrid: vi.fn(async (pages: unknown[]) => pages),
+}));
+
+vi.mock("../processing/bbox.js", () => ({
+  buildBoundingBoxes: vi.fn(() => []),
+}));
+
+vi.mock("../output/json.js", () => ({
+  formatJSON: vi.fn(() => '{"pages":[]}'),
+}));
+
+import { LiteParse } from "./parser";
+
+describe("Tesseract worker lifecycle", () => {
+  beforeEach(() => {
+    mockTerminate.mockClear();
+    mockRecognize.mockClear();
+  });
+
+  it("does not terminate Tesseract workers after each parse()", async () => {
+    const parser = new LiteParse({ ocrEnabled: true, outputFormat: "text" });
+
+    await parser.parse("doc1.pdf");
+    await parser.parse("doc2.pdf");
+
+    expect(mockTerminate).not.toHaveBeenCalled();
+    expect(mockRecognize).toHaveBeenCalled();
+  });
+
+  it("terminates Tesseract workers when destroy() is called", async () => {
+    const parser = new LiteParse({ ocrEnabled: true, outputFormat: "text" });
+
+    await parser.parse("doc1.pdf");
+    await parser.destroy();
+
+    expect(mockTerminate).toHaveBeenCalledTimes(1);
+  });
+
+  it("destroy() is safe when OCR is disabled", async () => {
+    const parser = new LiteParse({ ocrEnabled: false });
+    await expect(parser.destroy()).resolves.toBeUndefined();
+    expect(mockTerminate).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -201,12 +201,8 @@ export class LiteParse {
 
       return result;
     } finally {
-      // Always release resources, even if processing throws
+      // Always release per-document resources, even if processing throws
       await this.pdfEngine.close(doc);
-
-      if (this.ocrEngine && "terminate" in this.ocrEngine) {
-        await (this.ocrEngine as TesseractEngine).terminate();
-      }
 
       if (needsCleanup && cleanupPath) {
         await cleanupConversionFiles(cleanupPath);
@@ -481,6 +477,19 @@ export class LiteParse {
       }
     } catch (error) {
       log(`  OCR failed for page ${page.pageNum}: ${error}`);
+    }
+  }
+
+  /**
+   * Release long-lived resources held by this parser instance.
+   *
+   * Terminates the Tesseract worker pool when built-in OCR is enabled. Safe to call
+   * multiple times. After `destroy()`, further `parse()` / `screenshot()` calls are
+   * allowed but will re-initialize OCR workers on demand.
+   */
+  async destroy(): Promise<void> {
+    if (this.ocrEngine && "terminate" in this.ocrEngine) {
+      await (this.ocrEngine as TesseractEngine).terminate();
     }
   }
 

--- a/src/engines/ocr/README.md
+++ b/src/engines/ocr/README.md
@@ -51,7 +51,7 @@ Maps common ISO 639-1 codes to Tesseract's 3-letter codes:
 - `initialize(language)` - Create/recreate worker for language
 - `recognize(image, options)` - OCR single image (accepts file path or Buffer)
 - `recognizeBatch(images, options)` - OCR multiple images sequentially
-- `terminate()` - Clean up worker (called by LiteParse after parsing)
+- `terminate()` - Clean up worker pool (call via `LiteParse.destroy()` when done with the instance)
 
 **Design Decisions:**
 - **30% confidence threshold**: Filters noisy OCR results (tesseract.ts:59)


### PR DESCRIPTION
Fixes #188 

## Summary

- Stop calling `TesseractEngine.terminate()` in `parse()`'s `finally` block so a single `LiteParse` instance keeps a warm OCR worker pool across documents.
- Add `LiteParse.destroy()` for explicit shutdown when the parser is no longer needed.
- Call `parser.destroy()` from CLI `parse`, `screenshot`, and `batch` commands so one-shot runs still release workers on exit.

Fixes the performance issue where every `parse()` tore down and recreated all Tesseract workers (often adding seconds per file in batch jobs). HTTP OCR is unchanged (`HttpOcrEngine` has no `terminate()`).

## Motivation

`LiteParse` is constructed once and reused for many files (batch scripts, servers, notebooks). The previous lifecycle called `terminate()` after every `parse()`, defeating `TesseractEngine.initialize()`'s worker caching and forcing full pool recreation on each document.

## API change

**New:** `await parser.destroy()` — terminates the built-in Tesseract worker pool when done.

**Behavior change:** `parse()` no longer terminates OCR workers automatically. Callers that need cleanup should call `destroy()` (CLI does this automatically).