### PR TITLE
fix: screenshot() uses PDFium only (no double PDF load or text extraction)

### DIFF
--- a/src/core/parser.screenshot-pdfium.test.ts
+++ b/src/core/parser.screenshot-pdfium.test.ts
@@ -1,0 +1,74 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const mockLoadDocument = vi.hoisted(() => vi.fn(async () => {}));
+const mockGetPageCount = vi.hoisted(() => vi.fn(() => 2));
+const mockRenderPage = vi.hoisted(() =>
+  vi.fn(async (_pdfInput: string | Uint8Array, pageNumber: number) => ({
+    imageBuffer: Buffer.from([pageNumber]),
+    width: 100 * pageNumber,
+    height: 200 * pageNumber,
+  }))
+);
+const mockClose = vi.hoisted(() => vi.fn(async () => {}));
+const mockPdfJsLoadDocument = vi.hoisted(() => vi.fn());
+
+vi.mock("../conversion/convertToPdf.js", async () => {
+  const actual = await vi.importActual<typeof import("../conversion/convertToPdf.js")>(
+    "../conversion/convertToPdf.js"
+  );
+  return {
+    ...actual,
+    convertToPdf: vi.fn(async (input: string) => ({
+      pdfPath: input,
+      originalExtension: ".pdf",
+    })),
+    cleanupConversionFiles: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("../engines/pdf/pdfjs.js", () => ({
+  PdfJsEngine: vi.fn(
+    class {
+      loadDocument = mockPdfJsLoadDocument;
+      close = vi.fn(async () => {});
+    }
+  ),
+}));
+
+vi.mock("../engines/pdf/pdfium-renderer.js", () => ({
+  PdfiumRenderer: vi.fn(
+    class {
+      loadDocument = mockLoadDocument;
+      getPageCount = mockGetPageCount;
+      renderPage = mockRenderPage;
+      close = mockClose;
+    }
+  ),
+}));
+
+import { LiteParse } from "./parser";
+
+describe("screenshot() PDFium-only path", () => {
+  beforeEach(() => {
+    mockLoadDocument.mockClear();
+    mockGetPageCount.mockClear();
+    mockRenderPage.mockClear();
+    mockClose.mockClear();
+    mockPdfJsLoadDocument.mockClear();
+  });
+
+  it("does not load the PDF with PDF.js", async () => {
+    const parser = new LiteParse({ ocrEnabled: false });
+    const results = await parser.screenshot("document.pdf", [1, 2]);
+
+    expect(mockPdfJsLoadDocument).not.toHaveBeenCalled();
+    expect(mockLoadDocument).toHaveBeenCalledTimes(1);
+    expect(mockGetPageCount).toHaveBeenCalledTimes(1);
+    expect(mockRenderPage).toHaveBeenCalledTimes(2);
+    expect(results).toEqual([
+      { pageNum: 1, width: 100, height: 200, imageBuffer: Buffer.from([1]) },
+      { pageNum: 2, width: 200, height: 400, imageBuffer: Buffer.from([2]) },
+    ]);
+    expect(mockClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -458,6 +458,12 @@ vi.mock("../engines/pdf/pdfium-renderer.js", async () => {
 
         loadDocument = vi.fn(async () => {});
         closeDocument = vi.fn();
+        getPageCount = vi.fn(() => 5);
+        renderPage = vi.fn(async () => ({
+          imageBuffer: Buffer.from(new Uint8Array([1, 2, 3, 4, 5])),
+          width: 612,
+          height: 792,
+        }));
         renderPageToBuffer = vi.fn(async () => Buffer.from(new Uint8Array([1, 2, 3, 4, 5])));
         close = vi.fn(async () => {});
       }

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -243,7 +243,6 @@ export class LiteParse {
 
     log(`Generating screenshots for: ${typeof input === "string" ? input : "<buffer>"}`);
 
-    let doc: PdfDocument;
     let pdfInput: string | Uint8Array;
     let needsCleanup = false;
     let cleanupPath: string | undefined;
@@ -266,15 +265,12 @@ export class LiteParse {
         log(`Converted ${conversionResult.originalExtension} to PDF`);
       }
 
-      doc = await this.pdfEngine.loadDocument(pdfPath, this.config.password);
       pdfInput = pdfPath;
     } else {
       const ext = await guessExtensionFromBuffer(input);
 
       if (ext === ".pdf") {
-        const data = input instanceof Uint8Array ? input : new Uint8Array(input);
-        doc = await this.pdfEngine.loadDocument(data, this.config.password);
-        pdfInput = data;
+        pdfInput = input instanceof Uint8Array ? input : new Uint8Array(input);
       } else {
         const conversionResult = await convertBufferToPdf(input, this.config.password);
 
@@ -289,17 +285,16 @@ export class LiteParse {
         needsCleanup = true;
         cleanupPath = conversionResult.pdfPath;
         log(`Converted ${conversionResult.originalExtension} buffer to PDF`);
-        doc = await this.pdfEngine.loadDocument(conversionResult.pdfPath, this.config.password);
         pdfInput = conversionResult.pdfPath;
       }
     }
 
-    const totalPages = doc.numPages;
-    const results: ScreenshotResult[] = [];
-    const pages = pageNumbers || Array.from({ length: totalPages }, (_, i) => i + 1);
-
     const renderer = new PdfiumRenderer();
     await renderer.loadDocument(pdfInput, this.config.password);
+
+    const totalPages = renderer.getPageCount();
+    const results: ScreenshotResult[] = [];
+    const pages = pageNumbers || Array.from({ length: totalPages }, (_, i) => i + 1);
 
     try {
       for (const pageNum of pages) {
@@ -309,20 +304,17 @@ export class LiteParse {
         }
 
         log(`Rendering page ${pageNum}...`);
-        const imageBuffer = await renderer.renderPageToBuffer(pdfInput, pageNum, this.config.dpi);
-
-        const pageData = await this.pdfEngine.extractPage(doc, pageNum, { extractImages: false });
+        const rendered = await renderer.renderPage(pdfInput, pageNum, this.config.dpi);
 
         results.push({
           pageNum,
-          width: pageData.width,
-          height: pageData.height,
-          imageBuffer,
+          width: rendered.width,
+          height: rendered.height,
+          imageBuffer: rendered.imageBuffer,
         });
       }
     } finally {
       await renderer.close();
-      await this.pdfEngine.close(doc);
 
       if (needsCleanup && cleanupPath) {
         await cleanupConversionFiles(cleanupPath);

--- a/src/engines/pdf/README.md
+++ b/src/engines/pdf/README.md
@@ -96,7 +96,10 @@ Used for generating page images for OCR and the `screenshot` command. Provides b
 
 **Methods:**
 - `init()` - Initialize PDFium library (called automatically)
-- `renderPageToBuffer(pdfInput, pageNumber, dpi)` - Render page to PNG buffer. Accepts a file path (`string`), `Buffer`, or `Uint8Array`.
+- `loadDocument(pdfInput, password?)` - Cache a document for repeated page operations.
+- `getPageCount()` - Page count for the loaded document (used by `screenshot()`).
+- `renderPage(pdfInput, pageNumber, dpi)` - Render page to PNG buffer with pixel `width`/`height`.
+- `renderPageToBuffer(pdfInput, pageNumber, dpi)` - Same render; returns the buffer only (used by OCR paths).
 - `close()` - Cleanup PDFium resources
 
 **Design Decision:**

--- a/src/engines/pdf/pdfium-renderer.test.ts
+++ b/src/engines/pdf/pdfium-renderer.test.ts
@@ -12,7 +12,11 @@ const mockPDFiumPageRender = {
 const mockPdfiumPage = {
   render: vi.fn(
     async (options: {
-      render: (renderOptions: { width: number; height: number; data: Uint8Array }) => Promise<unknown>;
+      render: (renderOptions: {
+        width: number;
+        height: number;
+        data: Uint8Array;
+      }) => Promise<unknown>;
     }) => {
       await options.render({
         width: mockPDFiumPageRender.width,

--- a/src/engines/pdf/pdfium-renderer.test.ts
+++ b/src/engines/pdf/pdfium-renderer.test.ts
@@ -10,15 +10,25 @@ const mockPDFiumPageRender = {
 };
 
 const mockPdfiumPage = {
-  render: vi.fn(async () => {
-    return mockPDFiumPageRender;
-  }),
+  render: vi.fn(
+    async (options: {
+      render: (renderOptions: { width: number; height: number; data: Uint8Array }) => Promise<unknown>;
+    }) => {
+      await options.render({
+        width: mockPDFiumPageRender.width,
+        height: mockPDFiumPageRender.height,
+        data: mockPDFiumPageRender.data,
+      });
+      return mockPDFiumPageRender;
+    }
+  ),
 };
 
 const mockPdfiumDoc = {
   getPage: vi.fn(() => {
     return mockPdfiumPage;
   }),
+  getPageCount: vi.fn(() => 3),
   destroy: vi.fn(),
 };
 
@@ -72,6 +82,14 @@ describe("test renderPageToBuffer", () => {
     const renderer = new PdfiumRenderer();
     const result = await renderer.renderPageToBuffer("test.pdf", 1);
     expect(result).toStrictEqual(Buffer.from(mockPDFiumPageRender.data));
+  });
+
+  it("renderPage returns pixel dimensions from the render callback", async () => {
+    const renderer = new PdfiumRenderer();
+    const result = await renderer.renderPage("test.pdf", 1, 150);
+    expect(result.width).toBe(612);
+    expect(result.height).toBe(792);
+    expect(result.imageBuffer).toStrictEqual(Buffer.from(mockPDFiumPageRender.data));
   });
 
   it("test error propagation", async () => {
@@ -130,5 +148,17 @@ describe("document caching", () => {
 
     await renderer.close();
     expect(mockPdfiumDoc.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("getPageCount reads from the cached document", async () => {
+    const renderer = new PdfiumRenderer();
+    await renderer.loadDocument("test.pdf");
+    expect(renderer.getPageCount()).toBe(3);
+    expect(mockPdfiumDoc.getPageCount).toHaveBeenCalled();
+  });
+
+  it("getPageCount throws when no document is loaded", () => {
+    const renderer = new PdfiumRenderer();
+    expect(() => renderer.getPageCount()).toThrow(/loadDocument/i);
   });
 });

--- a/src/engines/pdf/pdfium-renderer.ts
+++ b/src/engines/pdf/pdfium-renderer.ts
@@ -33,6 +33,14 @@ interface PdfiumPageInternal {
   objects(): Iterable<{ type: string; objectIdx: number }>;
 }
 
+export interface RenderedPageBuffer {
+  imageBuffer: Buffer;
+  /** Rendered image width in pixels at the requested DPI. */
+  width: number;
+  /** Rendered image height in pixels at the requested DPI. */
+  height: number;
+}
+
 /**
  * PDFium-based PDF screenshot renderer
  * Uses native PDFium library for high-quality, fast screenshots
@@ -67,6 +75,16 @@ export class PdfiumRenderer {
     }
   }
 
+  /**
+   * Number of pages in the document loaded by {@link loadDocument}.
+   */
+  getPageCount(): number {
+    if (!this.cachedDocument) {
+      throw new Error("Document not loaded. Call loadDocument() first.");
+    }
+    return this.cachedDocument.getPageCount();
+  }
+
   private async getOrLoadDocument(
     pdfInput: string | Buffer | Uint8Array,
     password?: string
@@ -81,21 +99,25 @@ export class PdfiumRenderer {
     return { document, isTemporary: true };
   }
 
-  async renderPageToBuffer(
+  async renderPage(
     pdfInput: string | Buffer | Uint8Array,
     pageNumber: number,
     dpi: number = 150,
     password?: string
-  ): Promise<Buffer> {
+  ): Promise<RenderedPageBuffer> {
     const { document, isTemporary } = await this.getOrLoadDocument(pdfInput, password);
 
     try {
       const page = document.getPage(pageNumber - 1);
       const scale = dpi / 72;
+      let width = 0;
+      let height = 0;
 
       const image = await page.render({
         scale,
         render: async (options: PDFiumPageRenderOptions) => {
+          width = options.width;
+          height = options.height;
           return await sharp(options.data, {
             raw: {
               width: options.width,
@@ -113,12 +135,26 @@ export class PdfiumRenderer {
         },
       });
 
-      return Buffer.from(image.data);
+      return {
+        imageBuffer: Buffer.from(image.data),
+        width,
+        height,
+      };
     } finally {
       if (isTemporary) {
         document.destroy();
       }
     }
+  }
+
+  async renderPageToBuffer(
+    pdfInput: string | Buffer | Uint8Array,
+    pageNumber: number,
+    dpi: number = 150,
+    password?: string
+  ): Promise<Buffer> {
+    const rendered = await this.renderPage(pdfInput, pageNumber, dpi, password);
+    return rendered.imageBuffer;
   }
 
   /**


### PR DESCRIPTION
Fixes #190 

## Summary

- Refactor `screenshot()` to use **PDFium only** — no `pdfEngine.loadDocument()`, no per-page `extractPage()`.
- Add `PdfiumRenderer.getPageCount()` and `renderPage()` returning `{ imageBuffer, width, height }` in **rendered pixels**.
- Keep `renderPageToBuffer()` for OCR paths (`pdfjs.ts`); it delegates to `renderPage()`.

Fixes redundant work where every `screenshot()` call loaded the PDF in both PDF.js and PDFium, then ran full `getTextContent()` on each page only to copy viewport width/height (PDF points, not bitmap pixels).

## Motivation

`screenshot()` only needs page count, raster images, and dimensions. PDF.js is for text extraction in `parse()`; using it here duplicated parsing and wasted CPU on text-heavy PDFs.

## Behavior change

| Before | After |
|--------|--------|
| PDF.js + PDFium load per call | Single PDFium load |
| `extractPage()` + `getTextContent()` per page | No text extraction |
| `width`/`height` from PDF.js viewport (points) | Pixel size from PDFium render callback |

`parse()` and OCR rendering are unchanged.