### PR TITLE
fix: clean up convertBufferToPdf input staging directory

### DIFF
--- a/src/conversion/README.md
+++ b/src/conversion/README.md
@@ -36,11 +36,11 @@ LiteParse's core parsing works on PDFs. This module extends support to 50+ forma
 - Returns `ConversionError` with `message` and `code` on failure
 - If already PDF, returns path unchanged
 
-`convertBufferToPdf(data)` - Entry point for buffer input
+`convertBufferToPdf(data)` - Entry point for buffer input; cleans up the input staging directory after conversion (unless the PDF is served from that same directory)
 - Detects format from magic bytes, writes to temp file, then delegates to `convertToPdf`
 - Used when `LiteParse.parse()` receives a non-PDF `Buffer` or `Uint8Array`
 
-`cleanupConversionFiles(pdfPath)` - Removes temp files after parsing
+`cleanupConversionFiles(pdfPath)` / `cleanupTempPath(path)` - Removes temp files or directories under `getTmpDir()` after parsing
 - Only deletes files in the configured temp directory (`LITEPARSE_TMPDIR` or OS default)
 - Called by `LiteParse.parse()` after processing
 

--- a/src/conversion/convertToPdf.test.ts
+++ b/src/conversion/convertToPdf.test.ts
@@ -135,6 +135,9 @@ vi.mock("child_process", () => ({
   spawn: spawnMock,
 }));
 
+const mockRm = vi.hoisted(() => vi.fn(async () => {}));
+const mkdtempDirs = vi.hoisted(() => [] as string[]);
+
 vi.mock("fs", async () => {
   const actual = await vi.importActual<typeof import("fs")>("fs");
   return {
@@ -155,11 +158,18 @@ vi.mock("fs", async () => {
         return;
       }),
       mkdtemp: vi.fn(async () => {
-        return "/tmp/test";
+        const dir = path.join(os.tmpdir(), `liteparse-${mkdtempDirs.length}`);
+        mkdtempDirs.push(dir);
+        return dir;
       }),
+      rm: mockRm,
+      writeFile: vi.fn(async () => {}),
       readFile: vi.fn(async () => {
         return "hello world";
       }),
+      stat: vi.fn(async (filePath: string) => ({
+        isDirectory: () => /liteparse-\d+$/.test(String(filePath)),
+      })),
     },
   };
 });
@@ -172,6 +182,7 @@ import {
   convertOfficeDocument,
   convertImageToPdf,
   convertToPdf,
+  convertBufferToPdf,
   getTmpDir,
 } from "./convertToPdf";
 
@@ -179,6 +190,8 @@ afterEach(() => {
   spawnPlans.length = 0;
   spawnMock.mockClear();
   mockFileTypeFromFile.mockReset();
+  mockRm.mockClear();
+  mkdtempDirs.length = 0;
   vi.restoreAllMocks();
 });
 
@@ -320,7 +333,7 @@ describe("test convertToPdf", () => {
 
     const result = await convertToPdf("test_1.docx");
     expect(result).toStrictEqual({
-      pdfPath: path.join("/tmp/test", "test_1.pdf"),
+      pdfPath: path.join(os.tmpdir(), "liteparse-0", "test_1.pdf"),
       originalExtension: ".docx",
     });
   });
@@ -331,7 +344,7 @@ describe("test convertToPdf", () => {
 
     const result = await convertToPdf("test.xlsx");
     expect(result).toStrictEqual({
-      pdfPath: path.join("/tmp/test", "test.pdf"),
+      pdfPath: path.join(os.tmpdir(), "liteparse-0", "test.pdf"),
       originalExtension: ".xlsx",
     });
   });
@@ -342,7 +355,7 @@ describe("test convertToPdf", () => {
 
     const result = await convertToPdf("test.png");
     expect(result).toStrictEqual({
-      pdfPath: path.join("/tmp/test", "test.pdf"),
+      pdfPath: path.join(os.tmpdir(), "liteparse-0", "test.pdf"),
       originalExtension: ".png",
     });
   });
@@ -394,6 +407,53 @@ describe("test guessExtensionFromBuffer", () => {
   it("works with Uint8Array input", async () => {
     const pdfBytes = new Uint8Array(Buffer.from("%PDF-1.7"));
     expect(await guessExtensionFromBuffer(pdfBytes)).toBe(".pdf");
+  });
+});
+
+describe("test convertBufferToPdf", () => {
+  it("removes input staging dir when PDF is written to a separate output dir", async () => {
+    enqueueImageMagickLookup();
+    enqueueSpawnPlan({ stdout: "conversion successful", code: 0 });
+
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const result = await convertBufferToPdf(pngBytes);
+
+    const stagingDir = path.join(os.tmpdir(), "liteparse-0");
+    const outputDir = path.join(os.tmpdir(), "liteparse-1");
+
+    expect(result).toMatchObject({
+      pdfPath: path.join(outputDir, "input.pdf"),
+      originalExtension: ".png",
+    });
+    expect(mkdtempDirs).toEqual([stagingDir, outputDir]);
+    expect(mockRm).toHaveBeenCalledWith(stagingDir, {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it("keeps staging dir when converted PDF path is inside staging (PDF buffer)", async () => {
+    const pdfBytes = Buffer.from("%PDF-1.4");
+    const result = await convertBufferToPdf(pdfBytes);
+
+    const stagingDir = path.join(os.tmpdir(), "liteparse-0");
+    expect(result).toMatchObject({
+      pdfPath: path.join(stagingDir, "input.pdf"),
+      originalExtension: ".pdf",
+    });
+    expect(mockRm).not.toHaveBeenCalled();
+  });
+
+  it("removes staging dir on text passthrough", async () => {
+    const unknownBytes = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+    const result = await convertBufferToPdf(unknownBytes);
+
+    const stagingDir = path.join(os.tmpdir(), "liteparse-0");
+    expect(result).toMatchObject({ content: "hello world" });
+    expect(mockRm).toHaveBeenCalledWith(stagingDir, {
+      recursive: true,
+      force: true,
+    });
   });
 });
 

--- a/src/conversion/convertToPdf.ts
+++ b/src/conversion/convertToPdf.ts
@@ -470,18 +470,27 @@ export async function convertToPdf(
 }
 
 /**
+ * Remove a temp file or directory created under {@link getTmpDir}.
+ */
+export async function cleanupTempPath(tempPath: string): Promise<void> {
+  if (!tempPath.includes(getTmpDir())) {
+    return;
+  }
+
+  try {
+    const stat = await fs.stat(tempPath);
+    const target = stat.isDirectory() ? tempPath : path.dirname(tempPath);
+    await fs.rm(target, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors (missing path, permissions, etc.)
+  }
+}
+
+/**
  * Clean up temporary conversion files
  */
 export async function cleanupConversionFiles(pdfPath: string): Promise<void> {
-  try {
-    // Only delete if in temp directory
-    if (pdfPath.includes(getTmpDir())) {
-      const dir = path.dirname(pdfPath);
-      await fs.rm(dir, { recursive: true, force: true });
-    }
-  } catch {
-    // Ignore cleanup errors
-  }
+  await cleanupTempPath(pdfPath);
 }
 
 /**
@@ -506,9 +515,25 @@ export async function convertBufferToPdf(
   const ext = await guessExtensionFromBuffer(data);
 
   // Write buffer to temp file with detected extension (use .bin for unknown)
-  const tmpDir = await fs.mkdtemp(path.join(getTmpDir(), "liteparse-"));
-  const tmpPath = path.join(tmpDir, `input${ext || ".bin"}`);
-  await fs.writeFile(tmpPath, data);
+  const stagingDir = await fs.mkdtemp(path.join(getTmpDir(), "liteparse-"));
+  const tmpPath = path.join(stagingDir, `input${ext || ".bin"}`);
+  let retainStaging = false;
 
-  return convertToPdf(tmpPath, password);
+  try {
+    await fs.writeFile(tmpPath, data);
+    const result = await convertToPdf(tmpPath, password);
+
+    // When the PDF lives in the staging dir (buffer detected as PDF), the parser
+    // cleans up via cleanupConversionFiles(pdfPath). Otherwise drop staging now —
+    // convertToPdf has finished reading the input file from a separate output dir.
+    if ("pdfPath" in result) {
+      retainStaging = path.resolve(path.dirname(result.pdfPath)) === path.resolve(stagingDir);
+    }
+
+    return result;
+  } finally {
+    if (!retainStaging) {
+      await cleanupTempPath(stagingDir);
+    }
+  }
 }


### PR DESCRIPTION
Fixes #192

## Summary

- Clean up the **input staging** temp directory created by `convertBufferToPdf` after `convertToPdf` finishes, when the output PDF is written to a **separate** temp directory.
- Add `cleanupTempPath()` and use it from `cleanupConversionFiles` and buffer staging cleanup.
- Add tests for staging removal (separate output dir), retention (PDF buffer in same dir), and text passthrough.

Fixes **N2**: each non-PDF `parse(buffer)` / `screenshot(buffer)` left behind `liteparse-*/input.docx` (or similar) while only the output PDF directory was removed.

## Motivation

`convertBufferToPdf` creates **dir A** (uploaded bytes) and `convertToPdf` creates **dir B** (converted PDF). The parser only called `cleanupConversionFiles(pdfPath)`, which deletes **B**. **A** was never removed.

## Behavior

| Case | Staging dir (A) | Output PDF dir (B) |
|------|-----------------|---------------------|
| DOCX/image buffer → PDF in new dir | Removed in `convertBufferToPdf` `finally` | Still cleaned by parser `finally` |
| PDF buffer written to staging | Kept until parser `cleanupConversionFiles` | Same dir as A |
| Text passthrough / conversion error | Removed in `finally` | N/A or parser cleanup |

No change for file-path input (`parse("file.docx")`) — no `convertBufferToPdf` staging.

## Test plan

- [x] `npm test -- src/conversion/convertToPdf.test.ts` (33 tests)
- [ ] `parse(Buffer)` with DOCX bytes — no orphaned `liteparse-*` dirs with `input.*` after parse
- [ ] `parse(pdfBuffer)` — still works; temp cleaned via existing `cleanupPath`
- [ ] Repeat buffer parses — temp dir count does n