### PR TITLE
fix: route non-PDF path conversion through parse_input for bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,7 +1205,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "liteparse"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "clap",
  "image",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "liteparse-napi"
-version = "2.0.0"
+version = "2.0.0-beta.3"
 dependencies = [
  "image",
  "liteparse",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "liteparse-python"
-version = "2.0.0"
+version = "2.0.0-beta.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "liteparse-wasm"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.2"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/crates/liteparse-napi/Cargo.toml
+++ b/crates/liteparse-napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liteparse-napi"
-version = "2.0.0"
+version = "2.0.0-beta.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,7 +14,7 @@ default = ["tesseract"]
 tesseract = ["liteparse/tesseract"]
 
 [dependencies]
-liteparse = { package = "liteparse", version = "2.0.0-beta.1", path = "../liteparse", default-features = false }
+liteparse = { package = "liteparse", version = "2.0.0-beta.2", path = "../liteparse", default-features = false }
 pdfium-sys = { package = "liteparse-pdfium-sys", version = "1.0.0", path = "../pdfium-sys" }
 napi = { version = "2", features = ["async", "serde-json", "napi9"] }
 napi-derive = "2"

--- a/crates/liteparse-python/Cargo.toml
+++ b/crates/liteparse-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liteparse-python"
-version = "2.0.0"
+version = "2.0.0-beta.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,7 +15,7 @@ default = ["tesseract"]
 tesseract = ["liteparse/tesseract"]
 
 [dependencies]
-liteparse = { package = "liteparse", version = "2.0.0-beta.1", path = "../liteparse", default-features = false }
+liteparse = { package = "liteparse", version = "2.0.0-beta.2", path = "../liteparse", default-features = false }
 pdfium-sys = { package = "liteparse-pdfium-sys", version = "1.0.0", path = "../pdfium-sys" }
 pdfium = { package = "liteparse-pdfium", version = "1.0.0", path = "../pdfium" }
 clap = { version = "4.5.55", features = ["derive"] }

--- a/crates/liteparse-wasm/Cargo.toml
+++ b/crates/liteparse-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liteparse-wasm"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/liteparse/Cargo.toml
+++ b/crates/liteparse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liteparse"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/liteparse/src/parser.rs
+++ b/crates/liteparse/src/parser.rs
@@ -58,18 +58,7 @@ impl LiteParse {
     /// [`LiteParse::parse_input`] with [`PdfInput::Bytes`] instead.
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn parse(&self, input: &str) -> Result<ParseResult, LiteParseError> {
-        // Resolve file path to a PdfInput (convert non-PDFs first)
-        let _tmp_dir;
-        let pdf_input = if conversion::is_pdf(input) {
-            PdfInput::Path(input.to_string())
-        } else {
-            let (converted, tmp_dir) =
-                conversion::convert_to_pdf(input, self.config.password.as_deref(), false).await?;
-            _tmp_dir = tmp_dir;
-            PdfInput::Path(converted.pdf_path)
-        };
-
-        self.parse_input(pdf_input).await
+        self.parse_input(PdfInput::Path(input.to_string())).await
     }
 
     /// Parse a document from either a file path or raw bytes.
@@ -86,7 +75,10 @@ impl LiteParse {
         let t0 = web_time::Instant::now();
 
         let mut is_converted = false;
+        #[cfg(not(target_arch = "wasm32"))]
         let _tmp_dir: Option<tempfile::TempDir>;
+        #[cfg(not(target_arch = "wasm32"))]
+        let _conv_tmp_dir: Option<tempfile::TempDir>;
 
         let validated_input = {
             #[cfg(target_arch = "wasm32")]
@@ -96,7 +88,22 @@ impl LiteParse {
 
             #[cfg(not(target_arch = "wasm32"))]
             match input {
-                PdfInput::Path(p) => PdfInput::Path(p),
+                PdfInput::Path(p) => {
+                    if conversion::is_pdf(&p) {
+                        PdfInput::Path(p)
+                    } else {
+                        let (converted, tmp_dir) = conversion::convert_to_pdf(
+                            &p,
+                            self.config.password.as_deref(),
+                            false,
+                        )
+                        .await?;
+                        _conv_tmp_dir = tmp_dir;
+                        // The on-disk source isn't ours to delete; only the
+                        // converted temp file should be cleaned up by `tmp_dir`.
+                        PdfInput::Path(converted.pdf_path)
+                    }
+                }
                 PdfInput::Bytes(b) => {
                     let (converted, tmp_dir) =
                         convert_data_to_pdf(b, self.config.password.as_deref()).await?;

--- a/crates/liteparse/src/parser.rs
+++ b/crates/liteparse/src/parser.rs
@@ -92,12 +92,9 @@ impl LiteParse {
                     if conversion::is_pdf(&p) {
                         PdfInput::Path(p)
                     } else {
-                        let (converted, tmp_dir) = conversion::convert_to_pdf(
-                            &p,
-                            self.config.password.as_deref(),
-                            false,
-                        )
-                        .await?;
+                        let (converted, tmp_dir) =
+                            conversion::convert_to_pdf(&p, self.config.password.as_deref(), false)
+                                .await?;
                         _conv_tmp_dir = tmp_dir;
                         // The on-disk source isn't ours to delete; only the
                         // converted temp file should be cleaned up by `tmp_dir`.

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@llamaindex/liteparse",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "Fast, lightweight PDF and document parsing with spatial text extraction",
   "type": "module",
   "main": "./dist/lib.js",
@@ -51,10 +51,10 @@
     "typescript": "~5.9.2"
   },
   "optionalDependencies": {
-    "@llamaindex/liteparse-darwin-arm64": "2.0.0-beta.2",
-    "@llamaindex/liteparse-linux-arm64-gnu": "2.0.0-beta.2",
-    "@llamaindex/liteparse-linux-x64-gnu": "2.0.0-beta.2",
-    "@llamaindex/liteparse-win32-x64-msvc": "2.0.0-beta.2"
+    "@llamaindex/liteparse-darwin-arm64": "2.0.0-beta.3",
+    "@llamaindex/liteparse-linux-arm64-gnu": "2.0.0-beta.3",
+    "@llamaindex/liteparse-linux-x64-gnu": "2.0.0-beta.3",
+    "@llamaindex/liteparse-win32-x64-msvc": "2.0.0-beta.3"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "liteparse"
-version = "2.0.0b2"
+version = "2.0.0b3"
 description = "Python bindings for LiteParse - fast, lightweight PDF and document parsing"
 readme = "README.md"
 license = "MIT"

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@llamaindex/liteparse-wasm",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Fast, lightweight PDF parsing with spatial text extraction — WebAssembly build for browsers",
   "type": "module",
   "main": "./pkg/liteparse_wasm.js",


### PR DESCRIPTION
## Summary

The Node.js and Python bindings were failing to parse non-PDF files (images, office docs) by path, even though the same inputs worked through the Rust CLI/library.

## Root cause

The bindings call `parser.parse_input(PdfInput::Path(...))` directly:

- napi (`crates/liteparse-napi/src/lib.rs`): `Either::A(path) => PdfInput::Path(path)`
- python (`crates/liteparse-python/src/lib.rs`): `let pdf_input = PdfInput::Path(input);`

But `parse_input` only handled the **Bytes** → PDF conversion. The non-PDF **path** → PDF conversion lived only in `LiteParse::parse(&str)`, which the bindings don't use. As a result, image/office paths were handed straight to PDFium, which can't load them.

The Rust integration tests pass because they go through `lit.parse(path)`, which did the conversion before delegating.

## Fix

Moved the non-PDF path conversion into `parse_input` itself so every entry point (Rust `parse`, napi `parse`, python `parse`/`parse_bytes`) gets the same behavior. `parse(&str)` is now a thin wrapper around `parse_input(PdfInput::Path(...))`. No binding code changes required.

The converted temp dir is held in a scoped binding for cleanup on drop, mirroring the existing pattern used for the Bytes branch.

## Verification

All 7 `crates/liteparse/tests/integration_test.rs` tests pass, including the path-based image and office-doc cases.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>