### PR TITLE
feat: add format conversion to screenshot() for non-PDF inputs (v1 parity)

### DIFF
--- a/crates/liteparse-napi/src/lib.rs
+++ b/crates/liteparse-napi/src/lib.rs
@@ -46,59 +46,37 @@ impl LiteParse {
     }
 
     /// Take screenshots of document pages. Returns PNG image buffers.
+    ///
+    /// Non-PDF files are automatically converted to PDF before rendering when
+    /// LibreOffice/ImageMagick are available.
     #[napi]
-    pub fn screenshot(
+    pub async fn screenshot(
         &self,
-        input: String,
+        input: Either<String, Buffer>,
         page_numbers: Option<Vec<u32>>,
     ) -> Result<Vec<JsScreenshotResult>> {
-        let dpi = self.config.dpi;
-        let lib = pdfium::Library::init();
-        let document = lib
-            .load_document(&input, self.config.password.as_deref())
-            .map_err(|e| Error::from_reason(e.to_string()))?;
-        let page_count = document.page_count() as u32;
+        use liteparse::types::PdfInput;
 
-        let pages: Vec<u32> = match page_numbers {
-            Some(nums) => nums,
-            None => (1..=page_count).collect(),
+        let pdf_input = match input {
+            Either::A(path) => PdfInput::Path(path),
+            Either::B(buf) => PdfInput::Bytes(buf.to_vec()),
         };
 
-        let mut results = Vec::with_capacity(pages.len());
-        for page_num in pages {
-            if page_num < 1 || page_num > page_count {
-                return Err(Error::from_reason(format!(
-                    "page {page_num} out of range (document has {page_count} pages)"
-                )));
-            }
-            let page = document
-                .page((page_num - 1) as i32)
-                .map_err(|e| Error::from_reason(e.to_string()))?;
-            let bitmap = page
-                .render(dpi)
-                .map_err(|e| Error::from_reason(e.to_string()))?;
+        let results = self
+            .inner
+            .screenshot_input(pdf_input, page_numbers)
+            .await
+            .map_err(|e| Error::from_reason(e.to_string()))?;
 
-            let width = bitmap.width() as u32;
-            let height = bitmap.height() as u32;
-            let rgba = bitmap.to_rgba();
-
-            // Encode as PNG into a buffer
-            let mut png_buf: Vec<u8> = Vec::new();
-            let encoder = image::codecs::png::PngEncoder::new(&mut png_buf);
-            use image::ImageEncoder;
-            encoder
-                .write_image(&rgba, width, height, image::ColorType::Rgba8.into())
-                .map_err(|e| Error::from_reason(format!("PNG encode failed: {e}")))?;
-
-            results.push(JsScreenshotResult {
-                page_num,
-                width,
-                height,
-                image_buffer: png_buf.into(),
-            });
-        }
-
-        Ok(results)
+        Ok(results
+            .into_iter()
+            .map(|r| JsScreenshotResult {
+                page_num: r.page_num,
+                width: r.width,
+                height: r.height,
+                image_buffer: r.image_bytes.into(),
+            })
+            .collect())
     }
 
     /// Get the current configuration.

--- a/crates/liteparse-python/src/cli.rs
+++ b/crates/liteparse-python/src/cli.rs
@@ -21,7 +21,7 @@ struct Cli {
 enum Commands {
     /// Parse a document file (PDF, DOCX, XLSX, PPTX, images, etc.)
     Parse(ParseCommand),
-    /// Generate screenshots of PDF pages
+    /// Generate screenshots of document pages (PDF, DOCX, XLSX, images, etc.)
     Screenshot(ScreenshotCommand),
     /// Parse multiple documents in batch mode
     BatchParse(BatchParseCommand),
@@ -175,23 +175,23 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
 
             std::fs::create_dir_all(&cmd.output_dir)?;
 
-            let lib = pdfium::Library::init();
-            let document = lib.load_document(&cmd.file, cmd.password.as_deref())?;
-            let page_count = document.page_count();
+            let config = LiteParseConfig {
+                target_pages: cmd.target_pages.clone(),
+                dpi: cmd.dpi,
+                password: cmd.password.clone(),
+                quiet: cmd.quiet,
+                ..Default::default()
+            };
+            let lp = LiteParse::new(config);
+            let results = rt.block_on(lp.screenshot(&cmd.file, target_pages))?;
 
-            for page_index in 0..page_count {
-                let page_number = page_index as u32 + 1;
-                if let Some(ref targets) = target_pages
-                    && !targets.contains(&page_number)
-                {
-                    continue;
-                }
-                let output_path = format!("{}/page_{}.png", cmd.output_dir, page_number);
-                render::screenshot(&cmd.file, page_number, cmd.dpi, &output_path)?;
+            for result in results {
+                let output_path = format!("{}/page_{}.png", cmd.output_dir, result.page_num);
+                std::fs::write(&output_path, &result.image_bytes)?;
                 if !cmd.quiet {
                     eprintln!(
                         "[liteparse] screenshot page {} → {}",
-                        page_number, output_path
+                        result.page_num, output_path
                     );
                 }
             }

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -192,7 +192,6 @@ struct LiteParse {
     inner: liteparse::parser::LiteParse,
     config: LiteParseConfig,
     runtime: tokio::runtime::Runtime,
-    pdfium: pdfium::Library,
 }
 
 #[pymethods]
@@ -271,13 +270,11 @@ impl LiteParse {
         let inner = liteparse::parser::LiteParse::new(cfg.clone());
         let runtime = tokio::runtime::Runtime::new()
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
-        let pdfium = pdfium::Library::init();
 
         Ok(Self {
             inner,
             config: cfg,
             runtime,
-            pdfium,
         })
     }
 
@@ -300,6 +297,9 @@ impl LiteParse {
     }
 
     /// Take screenshots of document pages. Returns a list of ScreenshotResult.
+    ///
+    /// Non-PDF files are automatically converted to PDF before rendering when
+    /// LibreOffice/ImageMagick are available.
     #[pyo3(signature = (input, page_numbers = None))]
     fn screenshot(
         &self,
@@ -307,58 +307,21 @@ impl LiteParse {
         input: String,
         page_numbers: Option<Vec<u32>>,
     ) -> PyResult<Vec<PyScreenshotResult>> {
-        let dpi = self.config.dpi;
-        let password = self.config.password.clone();
-        py.detach(move || {
-            let document = self
-                .pdfium
-                .load_document(&input, password.as_deref())
+        py.detach(|| {
+            let results = self
+                .runtime
+                .block_on(self.inner.screenshot(&input, page_numbers))
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
-            let page_count = document.page_count() as u32;
 
-            let pages: Vec<u32> = match page_numbers {
-                Some(nums) => nums,
-                None => (1..=page_count).collect(),
-            };
-
-            let mut results = Vec::with_capacity(pages.len());
-            for page_num in pages {
-                if page_num < 1 || page_num > page_count {
-                    return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                        "page {page_num} out of range (document has {page_count} pages)"
-                    )));
-                }
-                let page = document.page((page_num - 1) as i32).map_err(|e| {
-                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())
-                })?;
-                let bitmap = page.render(dpi).map_err(|e| {
-                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())
-                })?;
-
-                let width = bitmap.width() as u32;
-                let height = bitmap.height() as u32;
-                let rgba = bitmap.to_rgba();
-
-                let mut png_buf: Vec<u8> = Vec::new();
-                let encoder = image::codecs::png::PngEncoder::new(&mut png_buf);
-                use image::ImageEncoder;
-                encoder
-                    .write_image(&rgba, width, height, image::ColorType::Rgba8.into())
-                    .map_err(|e| {
-                        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                            "PNG encode failed: {e}"
-                        ))
-                    })?;
-
-                results.push(PyScreenshotResult {
-                    page_num,
-                    width,
-                    height,
-                    image_buffer: png_buf,
-                });
-            }
-
-            Ok(results)
+            Ok(results
+                .into_iter()
+                .map(|r| PyScreenshotResult {
+                    page_num: r.page_num,
+                    width: r.width,
+                    height: r.height,
+                    image_buffer: r.image_bytes,
+                })
+                .collect())
         })
     }
 

--- a/crates/liteparse/src/conversion.rs
+++ b/crates/liteparse/src/conversion.rs
@@ -20,6 +20,9 @@ const IMAGE_EXTENSIONS: &[&str] = &[
     "jpg", "jpeg", "png", "gif", "bmp", "tiff", "tif", "webp", "svg",
 ];
 
+/// Plain-text extensions that cannot be rendered as page images.
+const TEXT_ONLY_EXTENSIONS: &[&str] = &["txt", "md", "markdown", "log"];
+
 /// Extensions that require Ghostscript for ImageMagick conversion.
 const GHOSTSCRIPT_REQUIRED_EXTENSIONS: &[&str] = &["svg", "eps", "ps", "ai"];
 
@@ -61,6 +64,104 @@ pub fn is_pdf(path: &str) -> bool {
 }
 
 /// Check if a file extension is supported (either PDF or convertible).
+/// Returns true when the extension denotes a plain-text format with no page layout.
+pub fn is_text_only_extension(ext: &str) -> bool {
+    TEXT_ONLY_EXTENSIONS.contains(&ext.to_lowercase().as_str())
+}
+
+pub fn screenshot_text_format_error(ext: &str) -> LiteParseError {
+    LiteParseError::Conversion(format!(
+        "Cannot screenshot text-based format (.{ext}). Convert to PDF first."
+    ))
+}
+
+/// Keeps converted PDF temp directories alive until rendering or parsing completes.
+#[derive(Debug)]
+pub struct PdfInputGuard {
+    /// Conversion output directory; kept alive until this guard is dropped.
+    #[allow(dead_code)]
+    conv_tmp: Option<TempDir>,
+    /// Set when non-PDF bytes were staged and converted; requires explicit staging cleanup.
+    pub bytes_converted: bool,
+}
+
+impl PdfInputGuard {
+    pub fn cleanup_bytes_staging(&self, input: &crate::types::PdfInput) {
+        if self.bytes_converted {
+            if let crate::types::PdfInput::Path(p) = input
+                && let Some(parent) = Path::new(p).parent()
+            {
+                let _ = std::fs::remove_dir_all(parent);
+            }
+        }
+    }
+}
+
+/// Resolve a document input to a PDF suitable for rendering or text extraction.
+///
+/// When `reject_text_formats` is true, plain-text files (`.txt`, etc.) return a
+/// clear error instead of attempting conversion.
+pub async fn resolve_pdf_input(
+    input: crate::types::PdfInput,
+    password: Option<&str>,
+    reject_text_formats: bool,
+) -> Result<(crate::types::PdfInput, PdfInputGuard), LiteParseError> {
+    use crate::types::PdfInput;
+
+    match input {
+        PdfInput::Path(p) => {
+            let ext = Path::new(&p)
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("");
+            if reject_text_formats && is_text_only_extension(ext) {
+                return Err(screenshot_text_format_error(ext));
+            }
+            if is_pdf(&p) {
+                Ok((
+                    PdfInput::Path(p),
+                    PdfInputGuard {
+                        conv_tmp: None,
+                        bytes_converted: false,
+                    },
+                ))
+            } else {
+                let (converted, tmp_dir) = convert_to_pdf(&p, password, false).await?;
+                Ok((
+                    PdfInput::Path(converted.pdf_path),
+                    PdfInputGuard {
+                        conv_tmp: tmp_dir,
+                        bytes_converted: false,
+                    },
+                ))
+            }
+        }
+        PdfInput::Bytes(b) => {
+            let ext = guess_extension_from_data(&b);
+            if ext.as_deref() == Some("pdf") {
+                return Ok((
+                    PdfInput::Bytes(b),
+                    PdfInputGuard {
+                        conv_tmp: None,
+                        bytes_converted: false,
+                    },
+                ));
+            }
+            if reject_text_formats && ext.as_ref().is_some_and(|e| is_text_only_extension(e)) {
+                return Err(screenshot_text_format_error(ext.as_ref().unwrap()));
+            }
+            let (converted, tmp_dir) = convert_data_to_pdf(b, password).await?;
+            Ok((
+                PdfInput::Path(converted.pdf_path),
+                PdfInputGuard {
+                    conv_tmp: tmp_dir,
+                    bytes_converted: true,
+                },
+            ))
+        }
+    }
+}
+
 pub fn is_supported_extension(path: &str) -> bool {
     let ext = match Path::new(path).extension().and_then(|e| e.to_str()) {
         Some(e) => e.to_lowercase(),
@@ -592,6 +693,38 @@ mod tests {
     #[tokio::test]
     async fn test_is_path_executable_nonexistent() {
         assert!(!is_path_executable("/no/such/path/zzz").await);
+    }
+
+    #[test]
+    fn test_is_text_only_extension() {
+        assert!(is_text_only_extension("txt"));
+        assert!(is_text_only_extension("TXT"));
+        assert!(is_text_only_extension("md"));
+        assert!(!is_text_only_extension("pdf"));
+        assert!(!is_text_only_extension("docx"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_pdf_input_rejects_text_for_screenshot() {
+        use crate::types::PdfInput;
+
+        let err = resolve_pdf_input(PdfInput::Path("/tmp/readme.txt".into()), None, true)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Cannot screenshot text-based format"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_pdf_input_pdf_bytes_zero_disk() {
+        use crate::types::PdfInput;
+
+        let pdf_bytes = b"%PDF-1.4\n";
+        let (input, guard) = resolve_pdf_input(PdfInput::Bytes(pdf_bytes.to_vec()), None, true)
+            .await
+            .unwrap();
+        assert!(matches!(input, PdfInput::Bytes(_)));
+        assert!(!guard.bytes_converted);
     }
 
     #[tokio::test]

--- a/crates/liteparse/src/lib.rs
+++ b/crates/liteparse/src/lib.rs
@@ -7,7 +7,7 @@
 // ── Public API re-exports ──────────────────────────────────────────────
 pub use config::{LiteParseConfig, OutputFormat};
 pub use error::LiteParseError;
-pub use parser::{LiteParse, ParseResult};
+pub use parser::{LiteParse, ParseResult, ScreenshotResult};
 pub use search::{SearchOptions, search_items};
 pub use types::{ParsedPage, TextItem};
 

--- a/crates/liteparse/src/main.rs
+++ b/crates/liteparse/src/main.rs
@@ -21,7 +21,7 @@ struct Cli {
 enum Commands {
     /// Parse a document file (PDF, DOCX, XLSX, PPTX, images, etc.)
     Parse(ParseCommand),
-    /// Generate screenshots of PDF pages
+    /// Generate screenshots of document pages (PDF, DOCX, XLSX, images, etc.)
     Screenshot(ScreenshotCommand),
     /// Parse multiple documents in batch mode
     BatchParse(BatchParseCommand),
@@ -91,7 +91,7 @@ struct ParseCommand {
 
 #[derive(Args, Debug)]
 struct ScreenshotCommand {
-    /// Input file path
+    /// Input document path (PDF, DOCX, XLSX, images, etc.)
     file: String,
 
     /// Output directory for screenshots
@@ -247,26 +247,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             std::fs::create_dir_all(&cmd.output_dir)?;
 
-            let lib = pdfium::Library::init();
-            let document = lib.load_document(&cmd.file, cmd.password.as_deref())?;
-            let page_count = document.page_count();
+            let config = LiteParseConfig {
+                target_pages: cmd.target_pages.clone(),
+                dpi: cmd.dpi,
+                password: cmd.password.clone(),
+                quiet: cmd.quiet,
+                ..Default::default()
+            };
+            let lp = LiteParse::new(config);
+            let results = lp.screenshot(&cmd.file, target_pages).await?;
 
-            for page_index in 0..page_count {
-                let page_number = page_index as u32 + 1;
-
-                if let Some(ref targets) = target_pages
-                    && !targets.contains(&page_number)
-                {
-                    continue;
-                }
-
-                let output_path = format!("{}/page_{}.png", cmd.output_dir, page_number);
-                render::screenshot(&cmd.file, page_number, cmd.dpi, &output_path)?;
+            for result in results {
+                let output_path = format!("{}/page_{}.png", cmd.output_dir, result.page_num);
+                std::fs::write(&output_path, &result.image_bytes)?;
 
                 if !cmd.quiet {
                     eprintln!(
                         "[liteparse] screenshot page {} → {}",
-                        page_number, output_path
+                        result.page_num, output_path
                     );
                 }
             }

--- a/crates/liteparse/src/parser.rs
+++ b/crates/liteparse/src/parser.rs
@@ -1,10 +1,6 @@
-use std::path::Path;
-
 use crate::config::{LiteParseConfig, parse_target_pages};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::conversion;
-#[cfg(not(target_arch = "wasm32"))]
-use crate::conversion::convert_data_to_pdf;
 use crate::error::LiteParseError;
 use crate::extract;
 use crate::ocr::OcrEngine;
@@ -14,6 +10,8 @@ use crate::ocr::http_simple::HttpOcrEngine;
 use crate::ocr::tesseract::TesseractOcrEngine;
 use crate::ocr_merge;
 use crate::projection;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::render;
 use crate::types::{ParsedPage, PdfInput};
 
 /// Result of parsing a document.
@@ -22,6 +20,15 @@ pub struct ParseResult {
     pub pages: Vec<ParsedPage>,
     /// Full document text, concatenated from all pages.
     pub text: String,
+}
+
+/// Result of rendering a single page screenshot.
+#[derive(Debug, Clone)]
+pub struct ScreenshotResult {
+    pub page_num: u32,
+    pub width: u32,
+    pub height: u32,
+    pub image_bytes: Vec<u8>,
 }
 
 /// Main LiteParse orchestrator.
@@ -74,42 +81,12 @@ impl LiteParse {
 
         let t0 = web_time::Instant::now();
 
-        let mut is_converted = false;
         #[cfg(not(target_arch = "wasm32"))]
-        let _tmp_dir: Option<tempfile::TempDir>;
-        #[cfg(not(target_arch = "wasm32"))]
-        let _conv_tmp_dir: Option<tempfile::TempDir>;
+        let (validated_input, guard) =
+            conversion::resolve_pdf_input(input, self.config.password.as_deref(), false).await?;
 
-        let validated_input = {
-            #[cfg(target_arch = "wasm32")]
-            {
-                input
-            }
-
-            #[cfg(not(target_arch = "wasm32"))]
-            match input {
-                PdfInput::Path(p) => {
-                    if conversion::is_pdf(&p) {
-                        PdfInput::Path(p)
-                    } else {
-                        let (converted, tmp_dir) =
-                            conversion::convert_to_pdf(&p, self.config.password.as_deref(), false)
-                                .await?;
-                        _conv_tmp_dir = tmp_dir;
-                        // The on-disk source isn't ours to delete; only the
-                        // converted temp file should be cleaned up by `tmp_dir`.
-                        PdfInput::Path(converted.pdf_path)
-                    }
-                }
-                PdfInput::Bytes(b) => {
-                    let (converted, tmp_dir) =
-                        convert_data_to_pdf(b, self.config.password.as_deref()).await?;
-                    _tmp_dir = tmp_dir;
-                    is_converted = true;
-                    PdfInput::Path(converted.pdf_path)
-                }
-            }
-        };
+        #[cfg(target_arch = "wasm32")]
+        let validated_input = input;
 
         // Determine which pages to extract
         let target_pages = self
@@ -199,18 +176,72 @@ impl LiteParse {
         log(&format!("[liteparse] total: {:.1}ms", total));
 
         // Office docs and images that are temporarily created from bytes
-        // are removed, but not PDFs, as they pass through the coversion logic
+        // are removed, but not PDFs, as they pass through the conversion logic
         // and are used directly as input.
-        // With this block, we insure that temporary PDFs created from bytes and/or
-        // converted from Office/image files are cleaned up as well.
-        if is_converted && let PdfInput::Path(p) = validated_input {
-            std::fs::remove_dir_all(Path::new(&p).parent().unwrap())?;
-        }
+        #[cfg(not(target_arch = "wasm32"))]
+        guard.cleanup_bytes_staging(&validated_input);
 
         Ok(ParseResult {
             pages: parsed_pages,
             text: full_text,
         })
+    }
+
+    /// Generate screenshots of document pages as PNG bytes.
+    ///
+    /// Non-PDF files are automatically converted to PDF first (requires
+    /// LibreOffice/ImageMagick on the system). Plain-text formats cannot be
+    /// rendered and return a clear error.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn screenshot(
+        &self,
+        input: &str,
+        page_numbers: Option<Vec<u32>>,
+    ) -> Result<Vec<ScreenshotResult>, LiteParseError> {
+        self.screenshot_input(PdfInput::Path(input.to_string()), page_numbers)
+            .await
+    }
+
+    /// Generate screenshots from a file path or raw bytes.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn screenshot_input(
+        &self,
+        input: PdfInput,
+        page_numbers: Option<Vec<u32>>,
+    ) -> Result<Vec<ScreenshotResult>, LiteParseError> {
+        let log = |msg: &str| {
+            if !self.config.quiet {
+                eprintln!("{}", msg);
+            }
+        };
+
+        let (validated_input, guard) =
+            conversion::resolve_pdf_input(input, self.config.password.as_deref(), true).await?;
+
+        if let PdfInput::Path(ref path) = validated_input
+            && !conversion::is_pdf(path)
+        {
+            log("[liteparse] converted input to PDF for screenshot rendering");
+        }
+
+        let rendered = render::render_pages_to_png(
+            &validated_input,
+            page_numbers.as_deref(),
+            self.config.dpi,
+            self.config.password.as_deref(),
+        )?;
+
+        guard.cleanup_bytes_staging(&validated_input);
+
+        Ok(rendered
+            .into_iter()
+            .map(|page| ScreenshotResult {
+                page_num: page.page_num,
+                width: page.width,
+                height: page.height,
+                image_bytes: page.png_bytes,
+            })
+            .collect())
     }
 
     pub fn config(&self) -> &LiteParseConfig {

--- a/crates/liteparse/src/render.rs
+++ b/crates/liteparse/src/render.rs
@@ -1,7 +1,81 @@
 use crate::error::LiteParseError;
-use image::{ImageBuffer, Rgba};
+use crate::types::PdfInput;
+use image::ImageEncoder;
 use pdfium::Library;
 use serde::Serialize;
+
+/// A single rendered page as PNG bytes.
+#[derive(Debug, Clone)]
+pub struct RenderedPage {
+    pub page_num: u32,
+    pub width: u32,
+    pub height: u32,
+    pub png_bytes: Vec<u8>,
+}
+
+/// Render selected pages from a PDF input to PNG bytes.
+pub fn render_pages_to_png(
+    input: &PdfInput,
+    page_numbers: Option<&[u32]>,
+    dpi: f32,
+    password: Option<&str>,
+) -> Result<Vec<RenderedPage>, LiteParseError> {
+    let lib = Library::init();
+    match input {
+        PdfInput::Path(path) => {
+            let document = lib.load_document(path, password)?;
+            render_document_pages(&document, page_numbers, dpi)
+        }
+        PdfInput::Bytes(data) => {
+            let document = lib.load_document_from_bytes(data, password)?;
+            render_document_pages(&document, page_numbers, dpi)
+        }
+    }
+}
+
+fn render_document_pages(
+    document: &pdfium::Document,
+    page_numbers: Option<&[u32]>,
+    dpi: f32,
+) -> Result<Vec<RenderedPage>, LiteParseError> {
+    let page_count = document.page_count() as u32;
+    let pages: Vec<u32> = match page_numbers {
+        Some(nums) => nums.to_vec(),
+        None => (1..=page_count).collect(),
+    };
+
+    let mut results = Vec::with_capacity(pages.len());
+    for page_num in pages {
+        if page_num < 1 || page_num > page_count {
+            return Err(LiteParseError::Other(format!(
+                "page {page_num} out of range (document has {page_count} pages)"
+            )));
+        }
+
+        let page = document.page((page_num - 1) as i32)?;
+        let bitmap = page.render(dpi)?;
+        let width = bitmap.width() as u32;
+        let height = bitmap.height() as u32;
+        let rgba = bitmap.to_rgba();
+        let png_bytes = encode_png(&rgba, width, height)?;
+
+        results.push(RenderedPage {
+            page_num,
+            width,
+            height,
+            png_bytes,
+        });
+    }
+
+    Ok(results)
+}
+
+fn encode_png(rgba: &[u8], width: u32, height: u32) -> Result<Vec<u8>, LiteParseError> {
+    let mut png_buf = Vec::new();
+    let encoder = image::codecs::png::PngEncoder::new(&mut png_buf);
+    encoder.write_image(rgba, width, height, image::ColorType::Rgba8.into())?;
+    Ok(png_buf)
+}
 
 /// Render a single page to a PNG file.
 pub fn screenshot(
@@ -9,44 +83,40 @@ pub fn screenshot(
     page_num: u32,
     dpi: f32,
     output_path: &str,
+    password: Option<&str>,
 ) -> Result<(), LiteParseError> {
-    let lib = Library::init();
-    let document = lib.load_document(pdf_path, None)?;
-    let page = document.page((page_num - 1) as i32)?;
-    let bitmap = page.render(dpi)?;
+    let input = PdfInput::Path(pdf_path.to_string());
+    let pages = render_pages_to_png(&input, Some(&[page_num]), dpi, password)?;
+    let page = pages
+        .into_iter()
+        .next()
+        .ok_or_else(|| LiteParseError::Other("no page rendered".into()))?;
 
-    let width = bitmap.width() as u32;
-    let height = bitmap.height() as u32;
-    let rgba = bitmap.to_rgba();
+    std::fs::write(output_path, &page.png_bytes)?;
 
-    let img: ImageBuffer<Rgba<u8>, Vec<u8>> = ImageBuffer::from_raw(width, height, rgba).ok_or(
-        LiteParseError::Other("failed to create image buffer".into()),
-    )?;
-
-    img.save(output_path)?;
     eprintln!(
-        "[rust-bin] rendered page {} at {dpi} DPI → {output_path} ({width}×{height})",
-        page_num
+        "[rust-bin] rendered page {} at {dpi} DPI → {output_path} ({}×{})",
+        page_num, page.width, page.height
     );
 
     Ok(())
 }
 
 /// Render a single page and write raw PNG bytes to stdout.
-pub fn screenshot_to_stdout(pdf_path: &str, page_num: u32, dpi: f32) -> Result<(), LiteParseError> {
-    let lib = Library::init();
-    let document = lib.load_document(pdf_path, None)?;
-    let page = document.page((page_num - 1) as i32)?;
-    let bitmap = page.render(dpi)?;
+pub fn screenshot_to_stdout(
+    pdf_path: &str,
+    page_num: u32,
+    dpi: f32,
+    password: Option<&str>,
+) -> Result<(), LiteParseError> {
+    let input = PdfInput::Path(pdf_path.to_string());
+    let pages = render_pages_to_png(&input, Some(&[page_num]), dpi, password)?;
+    let page = pages
+        .into_iter()
+        .next()
+        .ok_or_else(|| LiteParseError::Other("no page rendered".into()))?;
 
-    let width = bitmap.width() as u32;
-    let height = bitmap.height() as u32;
-    let rgba = bitmap.to_rgba();
-
-    let encoder = image::codecs::png::PngEncoder::new(std::io::stdout().lock());
-    use image::ImageEncoder;
-    encoder.write_image(&rgba, width, height, image::ColorType::Rgba8.into())?;
-
+    std::io::Write::write_all(&mut std::io::stdout().lock(), &page.png_bytes)?;
     Ok(())
 }
 
@@ -118,6 +188,7 @@ mod tests {
             1,
             72.0,
             "/tmp/out.png",
+            None,
         );
         assert!(r.is_err());
     }

--- a/crates/liteparse/tests/integration_test.rs
+++ b/crates/liteparse/tests/integration_test.rs
@@ -7,6 +7,52 @@ use serial_test::serial;
 
 #[tokio::test]
 #[serial]
+async fn test_screenshot_image_integration() {
+    let env_var = std::env::var("SKIP_INTEGRATION_TESTS");
+    if let Ok(v) = env_var
+        && v == "yes"
+    {
+        return;
+    }
+    let lit = LiteParse::new(LiteParseConfig::default());
+    let results = lit
+        .screenshot("../../integration_tests_data/receipt.png", None)
+        .await
+        .expect("Should be able to screenshot converted image");
+    assert_eq!(results.len(), 1);
+    assert!(results[0].width > 0);
+    assert!(results[0].height > 0);
+    assert!(!results[0].image_bytes.is_empty());
+}
+
+#[tokio::test]
+#[serial]
+async fn test_screenshot_pdf_integration() {
+    let lit = LiteParse::new(LiteParseConfig::default());
+    let results = lit
+        .screenshot("../../integration_tests_data/sample.pdf", None)
+        .await
+        .expect("Should be able to screenshot PDF");
+    assert_eq!(results.len(), 1);
+    assert!(!results[0].image_bytes.is_empty());
+}
+
+#[tokio::test]
+async fn test_screenshot_rejects_text_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let txt_path = dir.path().join("notes.txt");
+    std::fs::write(&txt_path, "hello").unwrap();
+    let lit = LiteParse::new(LiteParseConfig::default());
+    let err = lit
+        .screenshot(txt_path.to_str().unwrap(), None)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("Cannot screenshot text-based format"));
+}
+
+#[tokio::test]
+#[serial]
 async fn test_convert_data_to_pdf_integration() {
     let env_var = std::env::var("SKIP_INTEGRATION_TESTS");
     if let Ok(v) = env_var

--- a/docs/src/content/docs/liteparse/cli-reference.md
+++ b/docs/src/content/docs/liteparse/cli-reference.md
@@ -115,7 +115,7 @@ lit batch-parse ./documents ./output --format json --no-ocr
 
 ## `lit screenshot`
 
-Generate page images from a PDF.
+Generate page images from a document (PDF, DOCX, XLSX, images, etc.).
 
 ```
 lit screenshot [options] <file>
@@ -125,7 +125,7 @@ lit screenshot [options] <file>
 
 | Argument | Description |
 |----------|-------------|
-| `file` | Path to the PDF file |
+| `file` | Path to the document file |
 
 ### Options
 
@@ -140,8 +140,11 @@ lit screenshot [options] <file>
 ### Examples
 
 ```bash
-# Screenshot all pages
+# Screenshot all pages of a PDF
 lit screenshot document.pdf -o ./pages
+
+# Screenshot a Word document (requires LibreOffice)
+lit screenshot report.docx -o ./pages
 
 # First 5 pages at high DPI
 lit screenshot document.pdf --target-pages "1-5" --dpi 300 -o ./pages

--- a/packages/node/native.d.ts
+++ b/packages/node/native.d.ts
@@ -64,7 +64,7 @@ export declare class LiteParse {
   /** Parse a document. Accepts a file path (string) or raw PDF bytes (Buffer). */
   parse(input: string | Buffer): Promise<JsParseResult>
   /** Take screenshots of document pages. Returns PNG image buffers. */
-  screenshot(input: string, pageNumbers?: Array<number> | undefined | null): Array<JsScreenshotResult>
+  screenshot(input: string | Buffer, pageNumbers?: Array<number> | undefined | null): Promise<Array<JsScreenshotResult>>
   /** Get the current configuration. */
   get config(): JsLiteParseConfig
 }

--- a/packages/node/src/lib.ts
+++ b/packages/node/src/lib.ts
@@ -115,11 +115,17 @@ export class LiteParse {
     };
   }
 
-  screenshot(
-    input: string,
+  async screenshot(
+    input: LiteParseInput,
     pageNumbers?: number[],
-  ): ScreenshotResult[] {
-    return this._native.screenshot(input, pageNumbers ?? null).map((r) => ({
+  ): Promise<ScreenshotResult[]> {
+    const nativeInput =
+      typeof input === "string" ? input : Buffer.from(input);
+    const results = await this._native.screenshot(
+      nativeInput,
+      pageNumbers ?? null,
+    );
+    return results.map((r) => ({
       pageNum: r.pageNum,
       width: r.width,
       height: r.height,

--- a/packages/node/src/native.ts
+++ b/packages/node/src/native.ts
@@ -68,9 +68,9 @@ export interface NativeScreenshotResult {
 export interface LiteParseNative {
   parse(input: string | Buffer): Promise<NativeParseResult>;
   screenshot(
-    input: string,
+    input: string | Buffer,
     pageNumbers?: number[] | null,
-  ): NativeScreenshotResult[];
+  ): Promise<NativeScreenshotResult[]>;
   format(result: NativeParseResult): string;
   readonly config: LiteParseNativeConfig;
 }

--- a/packages/python/liteparse/parser.py
+++ b/packages/python/liteparse/parser.py
@@ -158,8 +158,12 @@ class LiteParse:
         """
         Generate screenshots of document pages.
 
+        Supports PDFs natively. Non-PDF formats (DOCX, XLSX, images, etc.) are
+        automatically converted to PDF before rendering when the required system
+        tools are installed. Plain-text formats cannot be rendered.
+
         Args:
-            file_path: Path to the document file.
+            file_path: Path to the document file (PDF, DOCX, images, etc.).
             page_numbers: Specific page numbers to screenshot (1-indexed).
                           If None, screenshots all pages.
 


### PR DESCRIPTION
Closes #214 

## Summary

- Restore v1 screenshot format conversion in the Rust v2 core: non-PDF inputs (DOCX, XLSX, images, etc.) are converted to PDF before PDFium render, matching `parse()` behavior.
- Add shared `resolve_pdf_input()` and `render_pages_to_png()` used by CLI, Python, and Node bindings.
- Reject plain-text formats with a clear error instead of cryptic PDF load failures.
- **Breaking (Node):** `screenshot()` is now async and accepts `string | Buffer | Uint8Array`.

## Prior art (v1)

This behavior existed in the TypeScript v1 codebase and was intentionally added after a regression:

| Link | Description |
|------|-------------|
| [#85](https://github.com/run-llama/liteparse/issues/85) | Original report: `screenshot()` failed on non-PDF with cryptic PDF errors |
| [#86](https://github.com/run-llama/liteparse/pull/86) | Merged fix (v1.4.1): add format conversion to `screenshot()` |
| [73236c4](https://github.com/run-llama/liteparse/commit/73236c4) | Implementing commit |
| [`logan/liteparse-v1` / `parser.ts`](https://github.com/run-llama/liteparse/blob/logan/liteparse-v1/src/core/parser.ts) | v1 reference implementation |

v2 regressed to pre-1.4.1 PDF-only screenshot loading; this PR restores that established behavior in Rust.

## Changes

| Area | What changed |
|------|----------------|
| **Core** | `resolve_pdf_input()`, `PdfInputGuard`, `LiteParse::screenshot()`, `render_pages_to_png()` |
| **CLI** | `lit screenshot` routes through conversion |
| **Python** | PyO3 + CLI use core screenshot path |
| **Node** | napi `screenshot()` async + Buffer support |
| **Docs/tests** | CLI reference + integration tests |

## Test plan

- [ ] `cargo test -p liteparse --lib --no-default-features`
- [ ] `cargo test -p liteparse --test integration_test --no-default-features`
- [ ] `lit screenshot integration_tests_data/sample.pdf -o ./pages`
- [ ] `lit screenshot integration_tests_data/receipt.png -o ./pages` (ImageMagick)
- [ ] `lit screenshot integration_tests_data/sample3.doc -o ./pages` (LibreOffice)
- [ ] `lit screenshot notes.txt -o ./pages` → *"Cannot screenshot text-based format"*
- [ ] Node: `await parser.screenshot("report.docx")`
- [ ] Python: `parser.screenshot("receipt.png")`