### PR TITLE
fix: add --password to lit extract and lit image-bounds dev tools

### DIFF
--- a/crates/liteparse-python/src/cli.rs
+++ b/crates/liteparse-python/src/cli.rs
@@ -113,6 +113,8 @@ struct ExtractCommand {
     pdf_path: String,
     #[arg(long)]
     page_num: Option<u32>,
+    #[arg(long)]
+    password: Option<String>,
 }
 
 fn parse_output_format(s: &str) -> Result<OutputFormat, String> {
@@ -304,10 +306,10 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
         }
 
         Commands::Extract(cmd) => {
-            extract::extract(&cmd.pdf_path, cmd.page_num)?;
+            extract::extract(&cmd.pdf_path, cmd.page_num, cmd.password.as_deref())?;
         }
         Commands::ImageBounds(cmd) => {
-            render::image_bounds(&cmd.pdf_path, cmd.page_num)?;
+            render::image_bounds(&cmd.pdf_path, cmd.page_num, cmd.password.as_deref())?;
         }
     }
 

--- a/crates/liteparse/src/extract.rs
+++ b/crates/liteparse/src/extract.rs
@@ -6,13 +6,14 @@ use pdfium::{Font, FontType, Library, Page, RectF, TextPage};
 pub fn extract_pages(
     pdf_path: &str,
     page_num: Option<u32>,
+    password: Option<&str>,
 ) -> Result<Vec<LitePage>, LiteParseError> {
     let target_pages: Option<Vec<u32>> = page_num.map(|p| vec![p]);
     extract_pages_from_input(
         &PdfInput::Path(pdf_path.to_string()),
         target_pages.as_deref(),
         usize::MAX,
-        None,
+        password,
     )
 }
 
@@ -81,8 +82,12 @@ pub fn extract_pages_from_input(
 }
 
 /// Extract raw text items and print each page as a JSON-line object to stdout.
-pub fn extract(pdf_path: &str, page_num: Option<u32>) -> Result<(), LiteParseError> {
-    let pages = extract_pages(pdf_path, page_num)?;
+pub fn extract(
+    pdf_path: &str,
+    page_num: Option<u32>,
+    password: Option<&str>,
+) -> Result<(), LiteParseError> {
+    let pages = extract_pages(pdf_path, page_num, password)?;
     for page in &pages {
         println!("{}", serde_json::to_string(page)?);
     }
@@ -974,7 +979,7 @@ mod tests {
 
     #[test]
     fn extract_pages_missing_file_errors() {
-        let res = extract_pages("/nonexistent/path/does-not-exist.pdf", None);
+        let res = extract_pages("/nonexistent/path/does-not-exist.pdf", None, None);
         assert!(res.is_err());
     }
 

--- a/crates/liteparse/src/main.rs
+++ b/crates/liteparse/src/main.rs
@@ -181,6 +181,10 @@ struct ExtractCommand {
     /// Target page number (1-based)
     #[arg(long)]
     page_num: Option<u32>,
+
+    /// Password for encrypted/protected PDFs
+    #[arg(long)]
+    password: Option<String>,
 }
 
 fn parse_output_format(s: &str) -> Result<OutputFormat, String> {
@@ -384,11 +388,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         Commands::Extract(cmd) => {
-            extract::extract(&cmd.pdf_path, cmd.page_num)?;
+            extract::extract(&cmd.pdf_path, cmd.page_num, cmd.password.as_deref())?;
         }
 
         Commands::ImageBounds(cmd) => {
-            render::image_bounds(&cmd.pdf_path, cmd.page_num)?;
+            render::image_bounds(&cmd.pdf_path, cmd.page_num, cmd.password.as_deref())?;
         }
     }
 

--- a/crates/liteparse/src/render.rs
+++ b/crates/liteparse/src/render.rs
@@ -59,9 +59,13 @@ struct ImageBoundsOutput {
 }
 
 /// Extract image bounding boxes and print as JSON to stdout.
-pub fn image_bounds(pdf_path: &str, page_num: Option<u32>) -> Result<(), LiteParseError> {
+pub fn image_bounds(
+    pdf_path: &str,
+    page_num: Option<u32>,
+    password: Option<&str>,
+) -> Result<(), LiteParseError> {
     let lib = Library::init();
-    let document = lib.load_document(pdf_path, None)?;
+    let document = lib.load_document(pdf_path, password)?;
     let page_count = document.page_count();
 
     for page_index in 0..page_count {
@@ -124,7 +128,7 @@ mod tests {
 
     #[test]
     fn test_image_bounds_missing_file_errors() {
-        let r = image_bounds("/nonexistent/path/does_not_exist.pdf", None);
+        let r = image_bounds("/nonexistent/path/does_not_exist.pdf", None, None);
         assert!(r.is_err());
     }
 }


### PR DESCRIPTION
Closes #216 

## Summary

- Add `--password` to `lit extract` and `lit image-bounds` so encrypted PDFs work the same as `lit parse`.
- Thread password through `extract()` / `extract_pages()` → `extract_pages_from_input()` and `image_bounds()` → `load_document()`.
- Update both Rust CLI (`main.rs`) and Python CLI (`liteparse-python/src/cli.rs`).

## Problem

Dev/debug commands could not open password-protected PDFs:

| Command | Before |
|---------|--------|
| `lit parse --password …` | Works |
| `lit extract` | Failed (`password required`), no flag to fix |
| `lit image-bounds` | Same |

Password support already existed in `extract_pages_filtered()`; the dev CLI never exposed or forwarded it.

## Changes

| File | Change |
|------|--------|
| `extract.rs` | `extract()` / `extract_pages()` accept `password: Option<&str>` |
| `render.rs` | `image_bounds()` accepts `password: Option<&str>` |
| `main.rs` | `ExtractCommand` adds `--password` |
| `liteparse-python/cli.rs` | Same for Python `lit` |

## Test plan

- [ ] `cargo check -p liteparse --no-default-features`
- [ ] `cargo check -p liteparse-python --no-default-features`
- [ ] `cargo test -p liteparse --lib --no-default-features missing_file`
- [ ] `lit parse protected.pdf --password <pass> --no-ocr` → success
- [ ] `lit extract --pdf-path protected.pdf --password <pass>` → JSON lines per page
- [ ] `lit image-bounds --pdf-path protected.pdf --password <pass>` → JSON with image bboxes
- [ ] Without `--password` on encrypted PDF → `password required` (unchanged)
- [ ] Wrong password → clear PDFium error