### PR TITLE
feat: Add OCR-only text mode for corrupted native PDF text layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ lit parse document.pdf --target-pages "1-5,10,15-20"
 # Parse without OCR
 lit parse document.pdf --no-ocr
 
+# Use OCR text as the source of truth on pages where OCR runs
+lit parse document.pdf --ocr-text-mode ocr-only
+
 # Parse a remote PDF
 curl -sL https://example.com/report.pdf | lit parse -
 ```

--- a/crates/liteparse-napi/src/types.rs
+++ b/crates/liteparse-napi/src/types.rs
@@ -1,6 +1,6 @@
 use napi_derive::napi;
 
-use liteparse::config::{LiteParseConfig, OutputFormat};
+use liteparse::config::{LiteParseConfig, OcrTextMode, OutputFormat};
 use liteparse::parser::ParseResult;
 use liteparse::types::{ParsedPage, TextItem};
 
@@ -17,6 +17,8 @@ pub struct JsLiteParseConfig {
     pub ocr_enabled: Option<bool>,
     /// HTTP OCR server URL. If set, uses HTTP OCR instead of Tesseract.
     pub ocr_server_url: Option<String>,
+    /// How OCR text is combined with native text: "merge" or "ocr-only".
+    pub ocr_text_mode: Option<String>,
     /// Path to tessdata directory for Tesseract.
     pub tessdata_path: Option<String>,
     /// Maximum number of pages to parse.
@@ -48,6 +50,12 @@ impl JsLiteParseConfig {
         }
         if let Some(v) = self.ocr_server_url {
             cfg.ocr_server_url = Some(v);
+        }
+        if let Some(v) = self.ocr_text_mode {
+            cfg.ocr_text_mode = match v.as_str() {
+                "ocr-only" => OcrTextMode::OcrOnly,
+                _ => OcrTextMode::Merge,
+            };
         }
         if let Some(v) = self.tessdata_path {
             cfg.tessdata_path = Some(v);
@@ -87,6 +95,10 @@ impl JsLiteParseConfig {
             ocr_language: Some(cfg.ocr_language.clone()),
             ocr_enabled: Some(cfg.ocr_enabled),
             ocr_server_url: cfg.ocr_server_url.clone(),
+            ocr_text_mode: Some(match cfg.ocr_text_mode {
+                OcrTextMode::Merge => "merge".to_string(),
+                OcrTextMode::OcrOnly => "ocr-only".to_string(),
+            }),
             tessdata_path: cfg.tessdata_path.clone(),
             max_pages: Some(cfg.max_pages as u32),
             target_pages: cfg.target_pages.clone(),

--- a/crates/liteparse-python/src/cli.rs
+++ b/crates/liteparse-python/src/cli.rs
@@ -1,5 +1,5 @@
-use clap::{Args, Parser, Subcommand};
-use liteparse::config::{LiteParseConfig, OutputFormat};
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use liteparse::config::{LiteParseConfig, OcrTextMode, OutputFormat};
 use liteparse::conversion;
 use liteparse::output::{json, text};
 use liteparse::parser::LiteParse;
@@ -38,6 +38,8 @@ struct ParseCommand {
     ocr_language: String,
     #[arg(long, default_value = None)]
     ocr_server_url: Option<String>,
+    #[arg(long, value_enum, default_value = "merge")]
+    ocr_text_mode: CliOcrTextMode,
     #[arg(long)]
     tessdata_path: Option<String>,
     #[arg(long, default_value = "1000")]
@@ -83,6 +85,8 @@ struct BatchParseCommand {
     ocr_language: String,
     #[arg(long, default_value = None)]
     ocr_server_url: Option<String>,
+    #[arg(long, value_enum, default_value = "merge")]
+    ocr_text_mode: CliOcrTextMode,
     #[arg(long)]
     tessdata_path: Option<String>,
     #[arg(long, default_value = "1000")]
@@ -109,6 +113,21 @@ fn parse_output_format(s: &str) -> Result<OutputFormat, String> {
     }
 }
 
+#[derive(Clone, Debug, ValueEnum)]
+enum CliOcrTextMode {
+    Merge,
+    OcrOnly,
+}
+
+impl From<CliOcrTextMode> for OcrTextMode {
+    fn from(value: CliOcrTextMode) -> Self {
+        match value {
+            CliOcrTextMode::Merge => OcrTextMode::Merge,
+            CliOcrTextMode::OcrOnly => OcrTextMode::OcrOnly,
+        }
+    }
+}
+
 /// Run the CLI with the given args (typically from sys.argv).
 pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse_from(args);
@@ -129,6 +148,7 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                 password: cmd.password,
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
+                ocr_text_mode: cmd.ocr_text_mode.into(),
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {
@@ -206,6 +226,7 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                 password: cmd.password,
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
+                ocr_text_mode: cmd.ocr_text_mode.into(),
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 
-use liteparse::config::{LiteParseConfig, OutputFormat};
+use liteparse::config::{LiteParseConfig, OcrTextMode, OutputFormat};
 use liteparse::types::PdfInput;
 
 mod cli;
@@ -197,6 +197,8 @@ struct PyLiteParseConfig {
     #[pyo3(get)]
     ocr_server_url: Option<String>,
     #[pyo3(get)]
+    ocr_text_mode: String,
+    #[pyo3(get)]
     tessdata_path: Option<String>,
     #[pyo3(get)]
     max_pages: usize,
@@ -232,6 +234,10 @@ impl PyLiteParseConfig {
             ocr_language: cfg.ocr_language.clone(),
             ocr_enabled: cfg.ocr_enabled,
             ocr_server_url: cfg.ocr_server_url.clone(),
+            ocr_text_mode: match cfg.ocr_text_mode {
+                OcrTextMode::Merge => "merge".to_string(),
+                OcrTextMode::OcrOnly => "ocr-only".to_string(),
+            },
             tessdata_path: cfg.tessdata_path.clone(),
             max_pages: cfg.max_pages,
             target_pages: cfg.target_pages.clone(),
@@ -267,6 +273,7 @@ impl LiteParse {
         ocr_language = None,
         ocr_enabled = None,
         ocr_server_url = None,
+        ocr_text_mode = None,
         tessdata_path = None,
         max_pages = None,
         target_pages = None,
@@ -281,6 +288,7 @@ impl LiteParse {
         ocr_language: Option<String>,
         ocr_enabled: Option<bool>,
         ocr_server_url: Option<String>,
+        ocr_text_mode: Option<String>,
         tessdata_path: Option<String>,
         max_pages: Option<usize>,
         target_pages: Option<String>,
@@ -300,6 +308,12 @@ impl LiteParse {
         }
         if let Some(v) = ocr_server_url {
             cfg.ocr_server_url = Some(v);
+        }
+        if let Some(v) = ocr_text_mode {
+            cfg.ocr_text_mode = match v.as_str() {
+                "ocr-only" => OcrTextMode::OcrOnly,
+                _ => OcrTextMode::Merge,
+            };
         }
         if let Some(v) = tessdata_path {
             cfg.tessdata_path = Some(v);

--- a/crates/liteparse-wasm/src/lib.rs
+++ b/crates/liteparse-wasm/src/lib.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
-use liteparse::config::{LiteParseConfig, OutputFormat};
+use liteparse::config::{LiteParseConfig, OcrTextMode, OutputFormat};
 use liteparse::ocr::{OcrEngine, OcrOptions, OcrResult};
 use liteparse::parser::LiteParse as CoreLiteParse;
 use liteparse::search;
@@ -40,6 +40,7 @@ struct JsLiteParseConfig {
     ocr_language: Option<String>,
     ocr_enabled: Option<bool>,
     ocr_server_url: Option<String>,
+    ocr_text_mode: Option<String>,
     tessdata_path: Option<String>,
     max_pages: Option<usize>,
     target_pages: Option<String>,
@@ -61,6 +62,18 @@ impl JsLiteParseConfig {
         }
         if self.ocr_server_url.is_some() {
             cfg.ocr_server_url = self.ocr_server_url;
+        }
+        if let Some(v) = self.ocr_text_mode {
+            cfg.ocr_text_mode = match v.as_str() {
+                "merge" => OcrTextMode::Merge,
+                "ocr-only" => OcrTextMode::OcrOnly,
+                other => {
+                    return Err(JsError::new(&format!(
+                        "invalid ocrTextMode: {} (expected 'merge' or 'ocr-only')",
+                        other
+                    )));
+                }
+            };
         }
         if self.tessdata_path.is_some() {
             cfg.tessdata_path = self.tessdata_path;
@@ -104,6 +117,10 @@ impl JsLiteParseConfig {
             ocr_language: Some(cfg.ocr_language.clone()),
             ocr_enabled: Some(cfg.ocr_enabled),
             ocr_server_url: cfg.ocr_server_url.clone(),
+            ocr_text_mode: Some(match cfg.ocr_text_mode {
+                OcrTextMode::Merge => "merge".into(),
+                OcrTextMode::OcrOnly => "ocr-only".into(),
+            }),
             tessdata_path: cfg.tessdata_path.clone(),
             max_pages: Some(cfg.max_pages),
             target_pages: cfg.target_pages.clone(),

--- a/crates/liteparse/README.md
+++ b/crates/liteparse/README.md
@@ -45,12 +45,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ## Configuration
 
 ```rust
-use liteparse::{LiteParse, LiteParseConfig, OutputFormat};
+use liteparse::{LiteParse, LiteParseConfig, OcrTextMode, OutputFormat};
 
 let config = LiteParseConfig {
     ocr_enabled: true,                    // Enable OCR (default: true)
     ocr_language: "eng".to_string(),      // Tesseract language code
     ocr_server_url: None,                 // HTTP OCR server URL (optional)
+    ocr_text_mode: OcrTextMode::Merge,    // Or OcrTextMode::OcrOnly for OCR'd pages
     tessdata_path: None,                  // Path to tessdata directory (optional)
     max_pages: 1000,                      // Max pages to parse
     target_pages: Some("1-5,10".into()),  // Specific pages (optional)

--- a/crates/liteparse/src/config.rs
+++ b/crates/liteparse/src/config.rs
@@ -9,6 +9,9 @@ pub struct LiteParseConfig {
     pub ocr_enabled: bool,
     /// HTTP OCR server URL (uses Tesseract if not provided)
     pub ocr_server_url: Option<String>,
+    /// How OCR text is combined with native PDF text on pages where OCR runs.
+    #[serde(default)]
+    pub ocr_text_mode: OcrTextMode,
     /// Path to tessdata directory. Falls back to TESSDATA_PREFIX env var if not set.
     pub tessdata_path: Option<String>,
     /// Maximum number of pages to parse.
@@ -29,6 +32,17 @@ pub struct LiteParseConfig {
     pub num_workers: usize,
 }
 
+/// Controls how OCR text is combined with native PDF text on pages where OCR runs.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum OcrTextMode {
+    /// Keep native PDF text and add OCR text that does not overlap it.
+    #[default]
+    Merge,
+    /// Replace native PDF text with OCR text on pages where OCR runs.
+    OcrOnly,
+}
+
 /// Supported output formats.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -43,6 +57,7 @@ impl Default for LiteParseConfig {
             ocr_language: "eng".to_string(),
             ocr_enabled: true,
             ocr_server_url: None,
+            ocr_text_mode: OcrTextMode::Merge,
             tessdata_path: None,
             max_pages: 1000,
             target_pages: None,
@@ -127,6 +142,7 @@ mod tests {
         let c = LiteParseConfig::default();
         assert_eq!(c.ocr_language, "eng");
         assert!(c.ocr_enabled);
+        assert_eq!(c.ocr_text_mode, OcrTextMode::Merge);
         assert_eq!(c.max_pages, 1000);
         assert_eq!(c.dpi, 150.0);
         assert_eq!(c.output_format, OutputFormat::Json);
@@ -149,6 +165,15 @@ mod tests {
         let s = serde_json::to_string(&c).unwrap();
         let back: LiteParseConfig = serde_json::from_str(&s).unwrap();
         assert_eq!(back.ocr_language, c.ocr_language);
+        assert_eq!(back.ocr_text_mode, c.ocr_text_mode);
         assert_eq!(back.output_format, c.output_format);
+    }
+
+    #[test]
+    fn test_ocr_text_mode_kebab_case_serde() {
+        let s = serde_json::to_string(&OcrTextMode::OcrOnly).unwrap();
+        assert_eq!(s, "\"ocr-only\"");
+        let back: OcrTextMode = serde_json::from_str("\"merge\"").unwrap();
+        assert_eq!(back, OcrTextMode::Merge);
     }
 }

--- a/crates/liteparse/src/lib.rs
+++ b/crates/liteparse/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 
 // ── Public API re-exports ──────────────────────────────────────────────
-pub use config::{LiteParseConfig, OutputFormat};
+pub use config::{LiteParseConfig, OcrTextMode, OutputFormat};
 pub use error::LiteParseError;
 pub use parser::{LiteParse, ParseResult, ScreenshotResult};
 pub use search::{SearchOptions, search_items};

--- a/crates/liteparse/src/main.rs
+++ b/crates/liteparse/src/main.rs
@@ -1,5 +1,5 @@
-use clap::{Args, Parser, Subcommand};
-use liteparse::config::{LiteParseConfig, OutputFormat};
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use liteparse::config::{LiteParseConfig, OcrTextMode, OutputFormat};
 use liteparse::conversion;
 use liteparse::extract;
 use liteparse::output::{json, text};
@@ -57,6 +57,10 @@ struct ParseCommand {
     /// HTTP OCR server URL (uses Tesseract if not provided)
     #[arg(long, default_value = None)]
     ocr_server_url: Option<String>,
+
+    /// How to combine native text and OCR text on pages where OCR runs
+    #[arg(long, value_enum, default_value = "merge")]
+    ocr_text_mode: CliOcrTextMode,
 
     /// Path to tessdata directory (overrides TESSDATA_PREFIX env var)
     #[arg(long)]
@@ -141,6 +145,10 @@ struct BatchParseCommand {
     #[arg(long, default_value = None)]
     ocr_server_url: Option<String>,
 
+    /// How to combine native text and OCR text on pages where OCR runs
+    #[arg(long, value_enum, default_value = "merge")]
+    ocr_text_mode: CliOcrTextMode,
+
     /// Path to tessdata directory (overrides TESSDATA_PREFIX env var)
     #[arg(long)]
     tessdata_path: Option<String>,
@@ -193,6 +201,21 @@ fn parse_output_format(s: &str) -> Result<OutputFormat, String> {
     }
 }
 
+#[derive(Clone, Debug, ValueEnum)]
+enum CliOcrTextMode {
+    Merge,
+    OcrOnly,
+}
+
+impl From<CliOcrTextMode> for OcrTextMode {
+    fn from(value: CliOcrTextMode) -> Self {
+        match value {
+            CliOcrTextMode::Merge => OcrTextMode::Merge,
+            CliOcrTextMode::OcrOnly => OcrTextMode::OcrOnly,
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
@@ -213,6 +236,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 password: cmd.password,
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
+                ocr_text_mode: cmd.ocr_text_mode.into(),
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {
@@ -295,6 +319,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 password: cmd.password,
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
+                ocr_text_mode: cmd.ocr_text_mode.into(),
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {

--- a/crates/liteparse/src/ocr_merge.rs
+++ b/crates/liteparse/src/ocr_merge.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::config::OcrTextMode;
 use crate::error::LiteParseError;
 use crate::ocr::{OcrEngine, OcrOptions, OcrResult};
 use crate::types::{Page, TextItem};
@@ -75,6 +76,7 @@ pub(crate) async fn ocr_and_merge_rendered(
     dpi: f32,
     ocr_engine: Arc<dyn OcrEngine>,
     ocr_language: &str,
+    ocr_text_mode: OcrTextMode,
     num_workers: usize,
 ) -> Result<(), LiteParseError> {
     // Phase 1: spawn OCR tasks onto the tokio runtime so they run on
@@ -127,40 +129,66 @@ pub(crate) async fn ocr_and_merge_rendered(
         }
 
         let page = &mut pages[idx];
-        for r in &ocr_results {
-            if r.confidence <= 0.1 {
-                continue;
-            }
+        let ocr_text_items = ocr_results_to_text_items(
+            &ocr_results,
+            scale_factor,
+            match ocr_text_mode {
+                OcrTextMode::Merge => Some(&page.text_items),
+                OcrTextMode::OcrOnly => None,
+            },
+        );
 
-            let ocr_x = r.bbox[0] * scale_factor;
-            let ocr_y = r.bbox[1] * scale_factor;
-            let ocr_w = (r.bbox[2] - r.bbox[0]) * scale_factor;
-            let ocr_h = (r.bbox[3] - r.bbox[1]) * scale_factor;
-
-            if overlaps_existing_text(&page.text_items, ocr_x, ocr_y, ocr_w, ocr_h, 2.0) {
-                continue;
-            }
-
-            let cleaned = clean_ocr_table_artifacts(&r.text);
-            if cleaned.is_empty() {
-                continue;
-            }
-
-            page.text_items.push(TextItem {
-                text: cleaned,
-                x: ocr_x,
-                y: ocr_y,
-                width: ocr_w,
-                height: ocr_h,
-                font_name: Some("OCR".to_string()),
-                font_size: Some(ocr_h),
-                confidence: Some((r.confidence * 1000.0).round() / 1000.0),
-                ..Default::default()
-            });
+        match ocr_text_mode {
+            OcrTextMode::Merge => page.text_items.extend(ocr_text_items),
+            OcrTextMode::OcrOnly => page.text_items = ocr_text_items,
         }
     }
 
     Ok(())
+}
+
+fn ocr_results_to_text_items(
+    ocr_results: &[OcrResult],
+    scale_factor: f32,
+    existing_text_items: Option<&[TextItem]>,
+) -> Vec<TextItem> {
+    let mut text_items = Vec::new();
+
+    for r in ocr_results {
+        if r.confidence <= 0.1 {
+            continue;
+        }
+
+        let ocr_x = r.bbox[0] * scale_factor;
+        let ocr_y = r.bbox[1] * scale_factor;
+        let ocr_w = (r.bbox[2] - r.bbox[0]) * scale_factor;
+        let ocr_h = (r.bbox[3] - r.bbox[1]) * scale_factor;
+
+        if let Some(items) = existing_text_items
+            && overlaps_existing_text(items, ocr_x, ocr_y, ocr_w, ocr_h, 2.0)
+        {
+            continue;
+        }
+
+        let cleaned = clean_ocr_table_artifacts(&r.text);
+        if cleaned.is_empty() {
+            continue;
+        }
+
+        text_items.push(TextItem {
+            text: cleaned,
+            x: ocr_x,
+            y: ocr_y,
+            width: ocr_w,
+            height: ocr_h,
+            font_name: Some("OCR".to_string()),
+            font_size: Some(ocr_h),
+            confidence: Some((r.confidence * 1000.0).round() / 1000.0),
+            ..Default::default()
+        });
+    }
+
+    text_items
 }
 
 /// Check if an OCR bounding box overlaps with any existing text item.
@@ -257,6 +285,35 @@ mod tests {
     fn test_overlaps_existing_text_disjoint() {
         let items = vec![make_item(10.0, 10.0, 20.0, 5.0)];
         assert!(!overlaps_existing_text(&items, 100.0, 100.0, 5.0, 5.0, 2.0));
+    }
+
+    #[test]
+    fn test_ocr_results_to_text_items_merge_skips_existing_overlap() {
+        let existing = vec![make_item(10.0, 10.0, 20.0, 5.0)];
+        let results = vec![OcrResult {
+            text: "OCR text".into(),
+            bbox: [10.0, 10.0, 30.0, 15.0],
+            confidence: 0.9,
+        }];
+
+        let items = ocr_results_to_text_items(&results, 1.0, Some(&existing));
+
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn test_ocr_results_to_text_items_ocr_only_keeps_existing_overlap() {
+        let results = vec![OcrResult {
+            text: "OCR text".into(),
+            bbox: [10.0, 10.0, 30.0, 15.0],
+            confidence: 0.9,
+        }];
+
+        let items = ocr_results_to_text_items(&results, 1.0, None);
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].text, "OCR text");
+        assert_eq!(items[0].font_name.as_deref(), Some("OCR"));
     }
 
     #[test]

--- a/crates/liteparse/src/parser.rs
+++ b/crates/liteparse/src/parser.rs
@@ -175,6 +175,7 @@ impl LiteParse {
                 self.config.dpi,
                 engine,
                 &self.config.ocr_language,
+                self.config.ocr_text_mode,
                 self.config.num_workers,
             )
             .await?;

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -34,6 +34,7 @@ const parser = new LiteParse({
   ocrEnabled: true,              // Enable OCR (default: true)
   ocrLanguage: 'eng',           // Tesseract language code
   ocrServerUrl: undefined,       // HTTP OCR server URL (optional)
+  ocrTextMode: 'merge',          // 'merge' or 'ocr-only' for OCR'd pages
   tessdataPath: undefined,       // Path to tessdata directory (optional)
   maxPages: 1000,                // Max pages to parse
   targetPages: '1-5,10',        // Specific pages (optional)

--- a/packages/node/native.d.ts
+++ b/packages/node/native.d.ts
@@ -10,6 +10,8 @@ export interface JsLiteParseConfig {
   ocrEnabled?: boolean
   /** HTTP OCR server URL. If set, uses HTTP OCR instead of Tesseract. */
   ocrServerUrl?: string
+  /** How OCR text is combined with native text: "merge" or "ocr-only". */
+  ocrTextMode?: string
   /** Path to tessdata directory for Tesseract. */
   tessdataPath?: string
   /** Maximum number of pages to parse. */

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@llamaindex/liteparse",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@llamaindex/liteparse",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0"
@@ -24,11 +24,63 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@llamaindex/liteparse-darwin-arm64": "2.0.0",
-        "@llamaindex/liteparse-linux-arm64-gnu": "2.0.0",
-        "@llamaindex/liteparse-linux-x64-gnu": "2.0.0",
-        "@llamaindex/liteparse-win32-x64-msvc": "2.0.0"
+        "@llamaindex/liteparse-darwin-arm64": "2.0.1",
+        "@llamaindex/liteparse-linux-arm64-gnu": "2.0.1",
+        "@llamaindex/liteparse-linux-x64-gnu": "2.0.1",
+        "@llamaindex/liteparse-win32-x64-msvc": "2.0.1"
       }
+    },
+    "node_modules/@llamaindex/liteparse-darwin-arm64": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.0.1.tgz",
+      "integrity": "sha512-/f8hH6R8CEtc5/2QMQvER4gt3RKgvcM4K6OzCvqlEIiJtyob67RkZhkFA8x2h4dAzgAtqMegQCo1vFHs31IPXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@llamaindex/liteparse-linux-arm64-gnu": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.0.1.tgz",
+      "integrity": "sha512-oir+ZNsDs9aAPG4BmYHTAhQRb+wBVTXvWgPDY+qn6bAJjY4qMIrlVbUPSzRnKCXZ+4nuuj7PJsRxkXHrmxoQ5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@llamaindex/liteparse-linux-x64-gnu": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.0.1.tgz",
+      "integrity": "sha512-cMoAkgMMF9V/Mwy7kkeGMBC0q22xVHGTR27ZYpmh56eQdsLTt7YnjcACNLlD9ULJ5ha7DvKIuS0Bmu+agiJvsg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@llamaindex/liteparse-win32-x64-msvc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.0.1.tgz",
+      "integrity": "sha512-d/CD/Hidf1GL72pQTyy3gKTeJScElDyRZyPDhFzZYHdFBQY/3zRaUfzzdMZGnjhdwMB10uJeuCYux8pKEcW2Kw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@napi-rs/cli": {
       "version": "2.18.4",

--- a/packages/node/src/cli.ts
+++ b/packages/node/src/cli.ts
@@ -19,6 +19,10 @@ program
   .option("--ocr-server-url <url>", "HTTP OCR server URL")
   .option("--no-ocr", "Disable OCR")
   .option("--ocr-language <lang>", "OCR language (default: eng)")
+  .option(
+    "--ocr-text-mode <mode>",
+    "How to combine native text and OCR text: merge|ocr-only",
+  )
   .option("--max-pages <n>", "Max pages to parse", parseInt)
   .option(
     "--target-pages <pages>",
@@ -48,6 +52,8 @@ program
         config.ocrServerUrl = opts.ocrServerUrl as string;
       if (opts.ocr === false) config.ocrEnabled = false;
       if (opts.ocrLanguage) config.ocrLanguage = opts.ocrLanguage as string;
+      if (opts.ocrTextMode)
+        config.ocrTextMode = opts.ocrTextMode as "merge" | "ocr-only";
       if (opts.maxPages) config.maxPages = opts.maxPages as number;
       if (opts.targetPages) config.targetPages = opts.targetPages as string;
       if (opts.dpi) config.dpi = opts.dpi as number;
@@ -164,6 +170,10 @@ program
   .option("--no-ocr", "Disable OCR")
   .option("--ocr-language <lang>", "OCR language (default: eng)")
   .option("--ocr-server-url <url>", "HTTP OCR server URL")
+  .option(
+    "--ocr-text-mode <mode>",
+    "How to combine native text and OCR text: merge|ocr-only",
+  )
   .option("--max-pages <n>", "Max pages to parse per file", parseInt)
   .option("--dpi <dpi>", "Rendering DPI", parseFloat)
   .option("--recursive", "Recursively search input directory")
@@ -185,6 +195,8 @@ program
         if (opts.ocrLanguage) config.ocrLanguage = opts.ocrLanguage as string;
         if (opts.ocrServerUrl)
           config.ocrServerUrl = opts.ocrServerUrl as string;
+        if (opts.ocrTextMode)
+          config.ocrTextMode = opts.ocrTextMode as "merge" | "ocr-only";
         if (opts.maxPages) config.maxPages = opts.maxPages as number;
         if (opts.dpi) config.dpi = opts.dpi as number;
         if (opts.password) config.password = opts.password as string;

--- a/packages/node/src/lib.ts
+++ b/packages/node/src/lib.ts
@@ -13,11 +13,13 @@ import {
 
 export type LiteParseInput = string | Buffer | Uint8Array;
 export type OutputFormat = "json" | "text";
+export type OcrTextMode = "merge" | "ocr-only";
 
 export interface LiteParseConfig {
   ocrLanguage: string;
   ocrEnabled: boolean;
   ocrServerUrl?: string;
+  ocrTextMode: OcrTextMode;
   tessdataPath?: string;
   maxPages: number;
   targetPages?: string;
@@ -73,6 +75,7 @@ export class LiteParse {
       ocrLanguage: userConfig.ocrLanguage,
       ocrEnabled: userConfig.ocrEnabled,
       ocrServerUrl: userConfig.ocrServerUrl,
+      ocrTextMode: userConfig.ocrTextMode,
       tessdataPath: userConfig.tessdataPath,
       maxPages: userConfig.maxPages,
       targetPages: userConfig.targetPages,
@@ -92,6 +95,7 @@ export class LiteParse {
       ocrLanguage: resolved.ocrLanguage ?? "eng",
       ocrEnabled: resolved.ocrEnabled ?? true,
       ocrServerUrl: resolved.ocrServerUrl ?? undefined,
+      ocrTextMode: resolved.ocrTextMode ?? "merge",
       tessdataPath: resolved.tessdataPath ?? undefined,
       maxPages: resolved.maxPages ?? 1000,
       targetPages: resolved.targetPages ?? undefined,

--- a/packages/node/src/native.ts
+++ b/packages/node/src/native.ts
@@ -23,6 +23,7 @@ export interface LiteParseNativeConfig {
   ocrLanguage?: string;
   ocrEnabled?: boolean;
   ocrServerUrl?: string;
+  ocrTextMode?: "merge" | "ocr-only";
   tessdataPath?: string;
   maxPages?: number;
   targetPages?: string;

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -33,6 +33,7 @@ parser = LiteParse(
     ocr_enabled=True,              # Enable OCR (default: True)
     ocr_language="eng",            # Tesseract language code
     ocr_server_url=None,           # HTTP OCR server URL (optional)
+    ocr_text_mode="merge",         # "merge" or "ocr-only" for OCR'd pages
     tessdata_path=None,            # Path to tessdata directory (optional)
     max_pages=1000,                # Max pages to parse
     target_pages="1-5,10",         # Specific pages (optional)

--- a/packages/python/liteparse/parser.py
+++ b/packages/python/liteparse/parser.py
@@ -67,6 +67,7 @@ class LiteParse:
         ocr_enabled: Optional[bool] = None,
         ocr_server_url: Optional[str] = None,
         ocr_language: Optional[str] = None,
+        ocr_text_mode: Optional[str] = None,
         tessdata_path: Optional[str] = None,
         max_pages: Optional[int] = None,
         target_pages: Optional[str] = None,
@@ -84,6 +85,7 @@ class LiteParse:
             ocr_enabled: Whether to enable OCR for scanned documents (default: True)
             ocr_server_url: URL of HTTP OCR server (uses Tesseract if not provided)
             ocr_language: Language code for OCR (e.g., "eng", "fra")
+            ocr_text_mode: How to combine OCR and native text: "merge" or "ocr-only"
             tessdata_path: Path to tessdata directory for Tesseract
             max_pages: Maximum number of pages to parse
             target_pages: Specific pages to parse (e.g., "1-5,10,15-20")
@@ -101,6 +103,8 @@ class LiteParse:
             kwargs["ocr_server_url"] = ocr_server_url
         if ocr_language is not None:
             kwargs["ocr_language"] = ocr_language
+        if ocr_text_mode is not None:
+            kwargs["ocr_text_mode"] = ocr_text_mode
         if tessdata_path is not None:
             kwargs["tessdata_path"] = tessdata_path
         if max_pages is not None:
@@ -206,6 +210,7 @@ class LiteParse:
             ocr_language=cfg.ocr_language,
             ocr_enabled=cfg.ocr_enabled,
             ocr_server_url=cfg.ocr_server_url,
+            ocr_text_mode=cfg.ocr_text_mode,
             tessdata_path=cfg.tessdata_path,
             max_pages=cfg.max_pages,
             target_pages=cfg.target_pages,

--- a/packages/python/liteparse/types.py
+++ b/packages/python/liteparse/types.py
@@ -62,6 +62,7 @@ class LiteParseConfig:
     ocr_language: str
     ocr_enabled: bool
     ocr_server_url: Optional[str]
+    ocr_text_mode: str
     tessdata_path: Optional[str]
     max_pages: int
     target_pages: Optional[str]

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -39,6 +39,7 @@ All optional, camelCase:
 |---|---|---|---|
 | `ocrLanguage` | `string` | `"eng"` | Language code passed to the OCR engine |
 | `ocrEnabled` | `boolean` | `true` | Run OCR on text-sparse pages |
+| `ocrTextMode` | `"merge" \| "ocr-only"` | `"merge"` | How to combine native and OCR text on pages where OCR runs |
 | `maxPages` | `number` | `1000` | Stop after this many pages |
 | `targetPages` | `string` | — | e.g. `"1-5,10,15-20"` |
 | `dpi` | `number` | `150` | Render DPI for OCR / screenshots |


### PR DESCRIPTION
## Summary

Ports the OCR text-combination option from the pre-Rust PR #168 to the current Rust core and bindings.

Adds `ocrTextMode` / `ocr_text_mode` with two modes:

- `merge` (default): keep native PDF text and add non-overlapping OCR text, preserving existing behavior.
- `ocr-only`: on pages where OCR runs, use OCR-derived text items as the source of truth and replace native text items.

This is useful for PDFs with corrupted, hidden, or misleading native text layers where OCR reads the visible page correctly but merge mode would discard overlapping OCR results.

## Behavior

`ocr-only` only changes how text is combined after OCR has already been selected for a page. It does not force OCR to run on every page.

For OCR'd pages in `ocr-only` mode:

- OCR confidence filtering is preserved.
- Native-text overlap filtering is skipped.
- `page.text_items` is replaced with cleaned OCR text items.

## Updated surfaces

- Rust core config and OCR merge path
- Rust CLI: `--ocr-text-mode ocr-only`
- Node native config, TypeScript wrapper, CLI, and lockfile
- Python PyO3 config, Python wrapper, and CLI
- WASM config
- README docs

## Verification

Ran locally:

- `npm install --ignore-scripts` in `packages/node`
- `npm ci --ignore-scripts` in `packages/node`
- `npx tsc` in `packages/node`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --no-default-features`
- `cargo test -p liteparse --no-default-features ocr_text_mode --lib`
- `cargo test -p liteparse --no-default-features ocr_results_to_text_items --lib`
- `cargo check -p liteparse --no-default-features`
- `cargo check -p liteparse-napi --no-default-features`
- `cargo check -p liteparse-python --no-default-features`
- `cargo check -p liteparse-wasm`
- `git diff --check`
