### PR TITLE
fix(projection): snap near-360° rotations to 0 in canonical_rotation

### DIFF
--- a/crates/liteparse/src/projection.rs
+++ b/crates/liteparse/src/projection.rs
@@ -93,7 +93,10 @@ fn canonical_rotation(rotation: f32) -> i32 {
     let mut best = 0.0f32;
     let mut best_delta = f32::INFINITY;
     for c in candidates {
-        let delta = (r - c).abs();
+        // Circular angular distance, so rotations just under 360° are treated
+        // as near 0° (e.g. 359° is 1° from upright, not 89° from 270°).
+        let raw = (r - c).abs();
+        let delta = raw.min(360.0 - raw);
         if delta < best_delta {
             best_delta = delta;
             best = c;
@@ -2724,5 +2727,39 @@ mod tests {
         assert_eq!(parsed.len(), 1);
         assert!(parsed[0].text.is_empty());
         assert!(parsed[0].text_items.is_empty());
+    }
+
+    #[test]
+    fn canonical_rotation_snaps_cardinals_and_near_cardinals() {
+        // Exact cardinals are unchanged.
+        assert_eq!(canonical_rotation(0.0), 0);
+        assert_eq!(canonical_rotation(90.0), 90);
+        assert_eq!(canonical_rotation(180.0), 180);
+        assert_eq!(canonical_rotation(270.0), 270);
+
+        // Small offsets within the 2° tolerance snap to the nearest cardinal.
+        assert_eq!(canonical_rotation(1.0), 0);
+        assert_eq!(canonical_rotation(88.5), 90);
+        assert_eq!(canonical_rotation(271.0), 270);
+    }
+
+    #[test]
+    fn canonical_rotation_snaps_near_360_to_zero() {
+        // Rotations just under 360° are ~upright and must snap to 0, not be
+        // treated as ~270° (regression: linear distance picked 270 for 359°).
+        assert_eq!(canonical_rotation(358.0), 0);
+        assert_eq!(canonical_rotation(359.0), 0);
+        assert_eq!(canonical_rotation(359.5), 0);
+        // rem_euclid normalizes out-of-range / negative inputs first.
+        assert_eq!(canonical_rotation(360.0), 0);
+        assert_eq!(canonical_rotation(-1.0), 0);
+    }
+
+    #[test]
+    fn canonical_rotation_passes_through_non_cardinal_angles() {
+        // Beyond the 2° snap tolerance the rounded raw angle is returned,
+        // including angles near (but not within tolerance of) 360°.
+        assert_eq!(canonical_rotation(45.0), 45);
+        assert_eq!(canonical_rotation(357.0), 357);
     }
 }


### PR DESCRIPTION
## Problem

`canonical_rotation()` snaps a text item's rotation to the nearest cardinal angle (0/90/180/270°) when it is within 2°, otherwise it returns the rounded raw angle. It computes the distance to each candidate with a plain linear `abs()`:

```rust
let candidates = [0.0f32, 90.0, 180.0, 270.0];
let delta = (r - c).abs();
```

This ignores the circular nature of angles, so rotations just under 360° are not recognized as being near 0°. For `r = 359°` the nearest candidate by linear distance is `270` (`|359 - 270| = 89`), `best_delta = 89 > 2`, so the function returns the raw `359` instead of snapping to `0`.

The snap is therefore asymmetric: `1°` snaps to `0`, but `359°` (also 1° from upright) does not. Inputs in `[358°, 360°)` — common for slightly-skewed scans and near-upright text — are reported as a non-cardinal rotation (and `359.5°` even returns an invalid `360`).

## Impact

`canonical_rotation` drives rotation detection and grouping in `projection.rs`:
- `handle_rotation_reading_order` early-returns only when every item is canonical `0`. A near-upright item reported as `359` makes the page take the rotated-reading-order path unnecessarily.
- Items are grouped by their canonical rotation value, so near-upright text at `359°` lands in its own group instead of joining the `0°` items — corrupting reading order for slightly-skewed pages.

## Fix

Use circular angular distance when comparing against each cardinal, so values near 360° are correctly treated as near 0°:

```rust
let raw = (r - c).abs();
let delta = raw.min(360.0 - raw);
```

`best` stays in `{0, 90, 180, 270}`, so no other change is needed. Behavior for angles already handled correctly is unchanged; only the `[358°, 360°)` wraparound zone is fixed.

| input | before | after |
|-------|--------|-------|
| 358°  | 358    | **0** |
| 359°  | 359    | **0** |
| 359.5°| 360    | **0** |
| 357°  | 357    | 357 (unchanged — 3° > tolerance) |
| 1° / 90° / 271° | 0 / 90 / 270 | 0 / 90 / 270 (unchanged) |

## Tests

Added three unit tests in `projection.rs` covering exact cardinals, near-cardinal snapping, the near-360 regression, and non-cardinal pass-through. `cargo fmt --check` and `cargo clippy` clean.
