### PR TITLE
fix(ocr): surface systemic OCR failure instead of silent success (#253)

### DIFF
--- a/crates/liteparse/src/ocr_merge.rs
+++ b/crates/liteparse/src/ocr_merge.rs
@@ -109,15 +109,35 @@ pub(crate) async fn ocr_and_merge_rendered(
     // Phase 3: collect results and merge into pages.
     let scale_factor = 72.0 / dpi;
 
+    // Track OCR task outcomes so we can distinguish a systemic failure (e.g.
+    // missing Tesseract language data, which fails identically on every page)
+    // from incidental per-page failures. Without this, every page logs the same
+    // error and `parse()` still returns "success" with no OCR text.
+    let total_tasks = handles.len();
+    let mut failed_tasks = 0usize;
+    let mut first_error: Option<String> = None;
+
     for (idx, page_number, handle) in handles {
         let ocr_results: Vec<OcrResult> = match handle.await {
             Ok(Ok(results)) => results,
             Ok(Err(e)) => {
-                eprintln!("[ocr] failed for page {}: {}", page_number, e);
+                failed_tasks += 1;
+                // Only log the first failure to avoid flooding stderr with an
+                // identical message for every page.
+                if first_error.is_none() {
+                    let msg = e.to_string();
+                    eprintln!("[ocr] failed for page {}: {}", page_number, msg);
+                    first_error = Some(msg);
+                }
                 continue;
             }
             Err(e) => {
-                eprintln!("[ocr] task panicked for page {}: {}", page_number, e);
+                failed_tasks += 1;
+                if first_error.is_none() {
+                    let msg = e.to_string();
+                    eprintln!("[ocr] task panicked for page {}: {}", page_number, msg);
+                    first_error = Some(msg);
+                }
                 continue;
             }
         };
@@ -158,6 +178,26 @@ pub(crate) async fn ocr_and_merge_rendered(
                 ..Default::default()
             });
         }
+    }
+
+    // If every OCR task failed and there was at least one task, treat it as a
+    // systemic failure (e.g. missing language data / Tesseract init error)
+    // rather than silently returning a document with no OCR text. This surfaces
+    // the root cause to the caller instead of swallowing it page-by-page.
+    if total_tasks > 0 && failed_tasks == total_tasks {
+        let detail = first_error.unwrap_or_else(|| "unknown error".to_string());
+        return Err(LiteParseError::Ocr(format!(
+            "OCR failed for all {} page(s): {}",
+            total_tasks, detail
+        )));
+    }
+
+    // Surface a concise summary for partial failures without flooding stderr.
+    if failed_tasks > 0 {
+        eprintln!(
+            "[ocr] {}/{} page(s) failed OCR; continuing with partial results",
+            failed_tasks, total_tasks
+        );
     }
 
     Ok(())
@@ -277,5 +317,83 @@ mod tests {
     fn test_clean_ocr_keeps_whitespace_trimmed() {
         assert_eq!(clean_ocr_table_artifacts("   "), "");
         assert_eq!(clean_ocr_table_artifacts(" 123 "), "123");
+    }
+
+    // A mock OCR engine that always fails, simulating a systemic error such as
+    // missing Tesseract language data (the root cause behind issue #253).
+    struct FailingEngine;
+    impl OcrEngine for FailingEngine {
+        fn name(&self) -> &str {
+            "failing"
+        }
+        fn recognize<'a, 'b: 'a, 'c: 'a>(
+            &'a self,
+            _image_data: &'c [u8],
+            _width: u32,
+            _height: u32,
+            _options: &'b OcrOptions,
+        ) -> std::pin::Pin<
+            Box<
+                dyn Future<
+                        Output = Result<Vec<OcrResult>, Box<dyn std::error::Error + Send + Sync>>,
+                    > + Send
+                    + '_,
+            >,
+        > {
+            Box::pin(async move { Err("Error opening data file tessdata/eng.traineddata".into()) })
+        }
+    }
+
+    fn make_blank_page(page_number: usize) -> Page {
+        Page {
+            page_number,
+            page_width: 100.0,
+            page_height: 100.0,
+            text_items: Vec::new(),
+        }
+    }
+
+    fn make_rendered(idx: usize) -> RenderedPage {
+        RenderedPage {
+            idx,
+            // 1x1 RGB pixel; the engine never inspects it.
+            rgb_bytes: vec![0u8, 0u8, 0u8],
+            width: 1,
+            height: 1,
+        }
+    }
+
+    // When every OCR task fails (e.g. missing language data), the function must
+    // return an error instead of silently reporting success with no OCR text.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_all_pages_fail_returns_error() {
+        let mut pages = vec![make_blank_page(1), make_blank_page(2)];
+        let rendered = vec![make_rendered(0), make_rendered(1)];
+        let engine: Arc<dyn OcrEngine> = Arc::new(FailingEngine);
+
+        let result = ocr_and_merge_rendered(&mut pages, rendered, 72.0, engine, "eng", 2).await;
+
+        let err = result.expect_err("expected systemic OCR failure to be surfaced");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("OCR failed for all 2 page(s)"),
+            "unexpected error message: {msg}"
+        );
+        assert!(
+            msg.contains("traineddata"),
+            "error should carry the underlying cause: {msg}"
+        );
+    }
+
+    // With no rendered pages there is nothing to OCR; this must remain a no-op
+    // success rather than tripping the all-failed guard.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_no_rendered_pages_is_ok() {
+        let mut pages = vec![make_blank_page(1)];
+        let engine: Arc<dyn OcrEngine> = Arc::new(FailingEngine);
+
+        let result = ocr_and_merge_rendered(&mut pages, Vec::new(), 72.0, engine, "eng", 2).await;
+
+        assert!(result.is_ok(), "empty OCR set should succeed: {result:?}");
     }
 }

--- a/crates/liteparse/src/ocr_merge.rs
+++ b/crates/liteparse/src/ocr_merge.rs
@@ -114,28 +114,24 @@ pub(crate) async fn ocr_and_merge_rendered(
     // from incidental per-page failures. Without this, every page logs the same
     // error and `parse()` still returns "success" with no OCR text.
     //
-    // We additionally track whether any *text-starved* page failed: a page is
-    // rendered for OCR if it is text-starved OR merely contains an image
+    // We additionally track whether any *sparse-text* page failed: a page is
+    // rendered for OCR if it has sparse native text OR merely contains an image
     // (`needs_ocr = text_length < 20 || text_coverage < 0.15 || has_images`).
     // A native-text PDF with a logo on every page is rendered for OCR
     // enrichment but already has all its text. We must only fail loud when OCR
-    // failure actually destroyed a page's *only* text source — i.e. a page that
-    // had essentially no native text — otherwise a broken OCR setup would abort
-    // perfectly good native-text documents.
+    // failure destroyed a sparse page's likely primary text source — otherwise
+    // a broken OCR setup would abort perfectly good native-text documents.
     let total_tasks = handles.len();
     let mut failed_tasks = 0usize;
-    let mut failed_text_starved = false;
+    let mut failed_sparse_text_page = false;
     let mut first_error: Option<String> = None;
-
-    // Matches the `text_length < 20` threshold in `render_pages_for_ocr`.
-    const TEXT_STARVED_LEN: usize = 20;
 
     for (idx, page_number, handle) in handles {
         let ocr_results: Vec<OcrResult> = match handle.await {
             Ok(Ok(results)) => results,
             Ok(Err(e)) => {
                 failed_tasks += 1;
-                failed_text_starved |= page_native_text_len(&pages[idx]) < TEXT_STARVED_LEN;
+                failed_sparse_text_page |= page_has_sparse_native_text(&pages[idx]);
                 // Only log the first failure to avoid flooding stderr with an
                 // identical message for every page.
                 if first_error.is_none() {
@@ -147,7 +143,7 @@ pub(crate) async fn ocr_and_merge_rendered(
             }
             Err(e) => {
                 failed_tasks += 1;
-                failed_text_starved |= page_native_text_len(&pages[idx]) < TEXT_STARVED_LEN;
+                failed_sparse_text_page |= page_has_sparse_native_text(&pages[idx]);
                 if first_error.is_none() {
                     let msg = e.to_string();
                     eprintln!("[ocr] task panicked for page {}: {}", page_number, msg);
@@ -196,14 +192,15 @@ pub(crate) async fn ocr_and_merge_rendered(
     }
 
     // If every OCR task failed *and* at least one of those failures was on a
-    // text-starved page (one that had essentially no native text), treat it as
-    // a systemic failure: that page now has no text at all. Returning an error
-    // surfaces the root cause (e.g. missing language data) instead of silently
-    // emitting an empty page. We deliberately do NOT fail when the only failures
-    // were on pages that already had native text and were merely rendered for
-    // image-based OCR enrichment — a broken OCR setup must not abort an
-    // otherwise-good native-text document.
-    if total_tasks > 0 && failed_tasks == total_tasks && failed_text_starved {
+    // sparse-text page (the same length/coverage predicate that sends pages to
+    // OCR as text-poor in `render_pages_for_ocr`), treat it as a systemic
+    // failure. Returning an error surfaces the root cause (e.g. missing language
+    // data) instead of silently emitting an empty or mostly-empty page. We
+    // deliberately do NOT fail when the only failures were on pages that already
+    // had substantial native text and were merely rendered for image-based OCR
+    // enrichment — a broken OCR setup must not abort an otherwise-good
+    // native-text document.
+    if total_tasks > 0 && failed_tasks == total_tasks && failed_sparse_text_page {
         let detail = first_error.unwrap_or_else(|| "unknown error".to_string());
         return Err(LiteParseError::Ocr(format!(
             "OCR failed for all {} page(s): {}",
@@ -222,9 +219,26 @@ pub(crate) async fn ocr_and_merge_rendered(
     Ok(())
 }
 
-/// Total length of a page's native (already-extracted) text, in bytes.
-fn page_native_text_len(page: &Page) -> usize {
-    page.text_items.iter().map(|item| item.text.len()).sum()
+/// True when the page's native (already-extracted) text is sparse enough that
+/// OCR is likely its primary text source. Mirrors the non-image predicates in
+/// `render_pages_for_ocr` (`text_length < 20 || text_coverage < 0.15`) so the
+/// systemic-failure guard matches the same pages that were rendered because
+/// their native text was insufficient.
+fn page_has_sparse_native_text(page: &Page) -> bool {
+    let text_length: usize = page.text_items.iter().map(|item| item.text.len()).sum();
+    let page_area = page.page_width * page.page_height;
+    let text_bbox_area: f32 = page
+        .text_items
+        .iter()
+        .map(|item| item.width * item.height)
+        .sum();
+    let text_coverage = if page_area > 0.0 {
+        text_bbox_area / page_area
+    } else {
+        0.0
+    };
+
+    text_length < 20 || text_coverage < 0.15
 }
 
 /// Check if an OCR bounding box overlaps with any existing text item.
@@ -387,9 +401,9 @@ mod tests {
         }
     }
 
-    // A page that already has plenty of native text (>= TEXT_STARVED_LEN bytes),
-    // as would be the case for a native-text PDF page that was only rendered for
-    // OCR because it also contains an image.
+    // A page that already has substantial native text coverage, as would be the
+    // case for a native-text PDF page that was only rendered for OCR because it
+    // also contains an image.
     fn make_native_text_page(page_number: usize) -> Page {
         Page {
             page_number,
@@ -400,7 +414,27 @@ mod tests {
                 x: 0.0,
                 y: 0.0,
                 width: 50.0,
-                height: 10.0,
+                height: 50.0,
+                ..Default::default()
+            }],
+        }
+    }
+
+    // A page with >20 bytes of native text but very low page coverage. These
+    // are still text-poor enough that `render_pages_for_ocr` sends them to OCR
+    // (`text_coverage < 0.15`), so a systemic OCR failure should not be silently
+    // swallowed.
+    fn make_low_coverage_text_page(page_number: usize) -> Page {
+        Page {
+            page_number,
+            page_width: 100.0,
+            page_height: 100.0,
+            text_items: vec![TextItem {
+                text: "small native header that is not enough".into(),
+                x: 0.0,
+                y: 0.0,
+                width: 10.0,
+                height: 5.0,
                 ..Default::default()
             }],
         }
@@ -460,10 +494,11 @@ mod tests {
         assert_eq!(pages[1].text_items.len(), 1);
     }
 
-    // When failures span both a text-starved page and a native-text page, the
-    // text-starved page lost its only text source, so we still fail loud.
+    // When failures span both a sparse-text page and a native-text page, the
+    // sparse-text page lost its likely primary text source, so we still fail
+    // loud.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_mixed_failure_with_text_starved_page_returns_error() {
+    async fn test_mixed_failure_with_sparse_text_page_returns_error() {
         let mut pages = vec![make_native_text_page(1), make_blank_page(2)];
         let rendered = vec![make_rendered(0), make_rendered(1)];
         let engine: Arc<dyn OcrEngine> = Arc::new(FailingEngine);
@@ -473,6 +508,24 @@ mod tests {
         let err = result.expect_err("a text-starved page losing all OCR must surface an error");
         assert!(
             err.to_string().contains("OCR failed for all 2 page(s)"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    // Regression guard for the review finding: low-coverage pages are rendered
+    // for OCR even when their native text length is >20 bytes. A systemic OCR
+    // failure on such pages must still surface as an error.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_low_coverage_text_page_failure_returns_error() {
+        let mut pages = vec![make_low_coverage_text_page(1)];
+        let rendered = vec![make_rendered(0)];
+        let engine: Arc<dyn OcrEngine> = Arc::new(FailingEngine);
+
+        let result = ocr_and_merge_rendered(&mut pages, rendered, 72.0, engine, "eng", 2).await;
+
+        let err = result.expect_err("low-coverage text page losing OCR must surface an error");
+        assert!(
+            err.to_string().contains("OCR failed for all 1 page(s)"),
             "unexpected error message: {err}"
         );
     }

--- a/crates/liteparse/src/ocr_merge.rs
+++ b/crates/liteparse/src/ocr_merge.rs
@@ -113,15 +113,29 @@ pub(crate) async fn ocr_and_merge_rendered(
     // missing Tesseract language data, which fails identically on every page)
     // from incidental per-page failures. Without this, every page logs the same
     // error and `parse()` still returns "success" with no OCR text.
+    //
+    // We additionally track whether any *text-starved* page failed: a page is
+    // rendered for OCR if it is text-starved OR merely contains an image
+    // (`needs_ocr = text_length < 20 || text_coverage < 0.15 || has_images`).
+    // A native-text PDF with a logo on every page is rendered for OCR
+    // enrichment but already has all its text. We must only fail loud when OCR
+    // failure actually destroyed a page's *only* text source — i.e. a page that
+    // had essentially no native text — otherwise a broken OCR setup would abort
+    // perfectly good native-text documents.
     let total_tasks = handles.len();
     let mut failed_tasks = 0usize;
+    let mut failed_text_starved = false;
     let mut first_error: Option<String> = None;
+
+    // Matches the `text_length < 20` threshold in `render_pages_for_ocr`.
+    const TEXT_STARVED_LEN: usize = 20;
 
     for (idx, page_number, handle) in handles {
         let ocr_results: Vec<OcrResult> = match handle.await {
             Ok(Ok(results)) => results,
             Ok(Err(e)) => {
                 failed_tasks += 1;
+                failed_text_starved |= page_native_text_len(&pages[idx]) < TEXT_STARVED_LEN;
                 // Only log the first failure to avoid flooding stderr with an
                 // identical message for every page.
                 if first_error.is_none() {
@@ -133,6 +147,7 @@ pub(crate) async fn ocr_and_merge_rendered(
             }
             Err(e) => {
                 failed_tasks += 1;
+                failed_text_starved |= page_native_text_len(&pages[idx]) < TEXT_STARVED_LEN;
                 if first_error.is_none() {
                     let msg = e.to_string();
                     eprintln!("[ocr] task panicked for page {}: {}", page_number, msg);
@@ -180,11 +195,15 @@ pub(crate) async fn ocr_and_merge_rendered(
         }
     }
 
-    // If every OCR task failed and there was at least one task, treat it as a
-    // systemic failure (e.g. missing language data / Tesseract init error)
-    // rather than silently returning a document with no OCR text. This surfaces
-    // the root cause to the caller instead of swallowing it page-by-page.
-    if total_tasks > 0 && failed_tasks == total_tasks {
+    // If every OCR task failed *and* at least one of those failures was on a
+    // text-starved page (one that had essentially no native text), treat it as
+    // a systemic failure: that page now has no text at all. Returning an error
+    // surfaces the root cause (e.g. missing language data) instead of silently
+    // emitting an empty page. We deliberately do NOT fail when the only failures
+    // were on pages that already had native text and were merely rendered for
+    // image-based OCR enrichment — a broken OCR setup must not abort an
+    // otherwise-good native-text document.
+    if total_tasks > 0 && failed_tasks == total_tasks && failed_text_starved {
         let detail = first_error.unwrap_or_else(|| "unknown error".to_string());
         return Err(LiteParseError::Ocr(format!(
             "OCR failed for all {} page(s): {}",
@@ -201,6 +220,11 @@ pub(crate) async fn ocr_and_merge_rendered(
     }
 
     Ok(())
+}
+
+/// Total length of a page's native (already-extracted) text, in bytes.
+fn page_native_text_len(page: &Page) -> usize {
+    page.text_items.iter().map(|item| item.text.len()).sum()
 }
 
 /// Check if an OCR bounding box overlaps with any existing text item.
@@ -363,6 +387,25 @@ mod tests {
         }
     }
 
+    // A page that already has plenty of native text (>= TEXT_STARVED_LEN bytes),
+    // as would be the case for a native-text PDF page that was only rendered for
+    // OCR because it also contains an image.
+    fn make_native_text_page(page_number: usize) -> Page {
+        Page {
+            page_number,
+            page_width: 100.0,
+            page_height: 100.0,
+            text_items: vec![TextItem {
+                text: "this page already has real native text content".into(),
+                x: 0.0,
+                y: 0.0,
+                width: 50.0,
+                height: 10.0,
+                ..Default::default()
+            }],
+        }
+    }
+
     // When every OCR task fails (e.g. missing language data), the function must
     // return an error instead of silently reporting success with no OCR text.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -395,5 +438,42 @@ mod tests {
         let result = ocr_and_merge_rendered(&mut pages, Vec::new(), 72.0, engine, "eng", 2).await;
 
         assert!(result.is_ok(), "empty OCR set should succeed: {result:?}");
+    }
+
+    // Regression guard: when OCR fails but every failing page already had native
+    // text (it was only rendered for image-based enrichment), a broken OCR setup
+    // must NOT abort the parse — the native text is still valid output.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_native_text_pages_not_failed_on_ocr_error() {
+        let mut pages = vec![make_native_text_page(1), make_native_text_page(2)];
+        let rendered = vec![make_rendered(0), make_rendered(1)];
+        let engine: Arc<dyn OcrEngine> = Arc::new(FailingEngine);
+
+        let result = ocr_and_merge_rendered(&mut pages, rendered, 72.0, engine, "eng", 2).await;
+
+        assert!(
+            result.is_ok(),
+            "OCR failure on already-native-text pages must not abort the parse: {result:?}"
+        );
+        // Native text is preserved untouched.
+        assert_eq!(pages[0].text_items.len(), 1);
+        assert_eq!(pages[1].text_items.len(), 1);
+    }
+
+    // When failures span both a text-starved page and a native-text page, the
+    // text-starved page lost its only text source, so we still fail loud.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_mixed_failure_with_text_starved_page_returns_error() {
+        let mut pages = vec![make_native_text_page(1), make_blank_page(2)];
+        let rendered = vec![make_rendered(0), make_rendered(1)];
+        let engine: Arc<dyn OcrEngine> = Arc::new(FailingEngine);
+
+        let result = ocr_and_merge_rendered(&mut pages, rendered, 72.0, engine, "eng", 2).await;
+
+        let err = result.expect_err("a text-starved page losing all OCR must surface an error");
+        assert!(
+            err.to_string().contains("OCR failed for all 2 page(s)"),
+            "unexpected error message: {err}"
+        );
     }
 }

--- a/docs/src/content/docs/liteparse/guides/ocr.md
+++ b/docs/src/content/docs/liteparse/guides/ocr.md
@@ -42,6 +42,26 @@ lit parse document.pdf --tessdata-path /path/to/tessdata
 
 The `tessdata_path` / `tessdataPath` option is also available in the library APIs.
 
+### Troubleshooting: missing language data
+
+If Tesseract can't find its language data, you'll see an error like:
+
+```
+Error opening data file tessdata/eng.traineddata
+Please make sure the TESSDATA_PREFIX environment variable is set to your "tessdata" directory.
+Failed loading language 'eng'
+```
+
+The bundled Tesseract still needs the `.traineddata` file for your language. It is normally downloaded and cached automatically on first use (under `~/.tesseract-rs/tessdata` on Linux, `~/Library/Application Support/tesseract-rs/tessdata` on macOS); if that download didn't happen — e.g. offline, restricted network, or a sandboxed install — OCR cannot run.
+
+To resolve it, do any one of the following:
+
+- Download the language file (e.g. [`eng.traineddata`](https://github.com/tesseract-ocr/tessdata)) and point LiteParse at it with `TESSDATA_PREFIX` or `--tessdata-path` (see [above](#offline--air-gapped-environments)).
+- Use an [HTTP OCR server](#http-ocr-servers) instead of the built-in engine.
+- Disable OCR with `--no-ocr` if you don't need it.
+
+When language data is missing for **every** page, LiteParse now fails with a clear `OCR failed for all N page(s)` error instead of returning a document with silently-empty OCR text — so an unresolved setup surfaces immediately rather than producing partial results that look complete.
+
 ### Disabling OCR
 
 If you don't need OCR (pure native-text PDFs, or you don't care about images), disable it for faster parsing:


### PR DESCRIPTION
## Summary

Fixes the failure mode behind #253: when OCR language data is missing (e.g. `eng.traineddata` not found), liteparse fails in two bad ways instead of reporting the actual problem.

`TesseractOcrEngine::recognize` returns `Err` from `api.init()` for **every** page (the init failure is systemic, not page-specific). The collection loop in `ocr_and_merge_rendered` swallowed each per-page error with `continue` and still returned `Ok(())`. Result:

1. **Error flood** — one identical `Error opening data file tessdata/eng.traineddata` line *per page* (see the 71-page wall of repeated errors in #253).
2. **Silent success** — `parse()` returns success with a document that has **no OCR text** and no signal that anything failed. For automated pipelines this is worse than the noise: empty results that look valid.

## Changes

- **Dedup logging**: log the first OCR failure once, then a single concise summary (`N/M page(s) failed OCR; continuing with partial results`) instead of one line per page.
- **Surface systemic failure**: track task outcomes; if *all* OCR tasks fail, return `LiteParseError::Ocr` carrying the underlying cause instead of silently succeeding. Partial per-page failures stay non-fatal (best-effort merge preserved).
- **Tests**: added unit tests using a mock failing `OcrEngine` — covers all-failed systemic error, empty-input no-op, native-text pages that should remain non-fatal, mixed sparse/native failures, and low-coverage text pages. No tessdata required, so CI doesn't need language data.

## Behavior change note

On systemic OCR failure, `parse()` now returns `Err` rather than `Ok` with empty OCR. This is the intended fix (surfacing the root cause), but it is a behavior change for any caller currently relying on best-effort "succeed with whatever OCR worked".

## Verification

```
cargo fmt -p liteparse --check      # clean
cargo clippy -p liteparse --no-default-features --lib --tests   # no new warnings
cargo test -p liteparse --no-default-features --lib ocr_merge -- --nocapture   # 11 passed (incl. low-coverage regression)
```

Scope: `crates/liteparse/src/ocr_merge.rs` for the fix, plus a Troubleshooting subsection in `docs/.../guides/ocr.md` documenting the missing-language-data failure and resolution. No public API or output-format changes.

## Regression-suite note

CONTRIBUTING mentions PRs run against a document regression suite. The one behavior change here is narrow: `parse()` returns `Err` **only** when every OCR task failed *and* at least one of those failures was on a sparse-native-text page — matching the non-image OCR-rendering predicates (`text_length < 20 || text_coverage < 0.15`). Failures on pages that already had substantial native text and were merely rendered for image-based OCR enrichment stay non-fatal, so a broken/offline OCR setup never aborts an otherwise-good native-text document (thanks @chatgpt-codex-connector for catching both the image-only and low-coverage edge cases). This should be inert for the regression set as long as CI has language data available (so Tesseract `init` succeeds). The only way it turns a fixture red is a document that is *expected* to have all OCR on its sparse-text pages fail yet still produce a valid result; if such a fixture exists, that's the signal to choose the non-breaking variant (keep `Ok`, attach a structured diagnostic) instead. Partial per-page failures are unchanged (still non-fatal, best-effort merge).

Refs #253



