### PR TITLE
fix(deps): bump tar 0.4.45 -> 0.4.46 (GHSA-3pv8-6f4r-ffg2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2408,9 +2408,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
## Summary

Bumps the `tar` crate from 0.4.45 to 0.4.46 to address [GHSA-3pv8-6f4r-ffg2](https://github.com/advisories/GHSA-3pv8-6f4r-ffg2) (PAX header desynchronization). Fixed upstream in tar-rs 0.4.46.

## Impact

`tar` is a build-time dependency of `liteparse-pdfium-sys`, used by [`crates/pdfium-sys/build.rs`](https://github.com/run-llama/liteparse/blob/main/crates/pdfium-sys/build.rs#L164) to unpack the `pdfium-*.tgz` archive downloaded from `bblanchon/pdfium-binaries` releases during `cargo build`. The PAX header desynchronization could cause extracted archive contents to mis-attribute filenames or metadata if a crafted PAX header is encountered. Realistic exploitation here would require an attacker to influence the contents of the `pdfium-binaries` GitHub release artifact (upstream-trust attack); the bump is recommended hygiene rather than an active exploit chain in LiteParse itself.

This finding is explicitly in scope per [`SECURITY.md`](https://github.com/run-llama/liteparse/blob/main/SECURITY.md):

> **In Scope:** Dependency vulnerabilities with known, exploitable CVEs

## Location

- `Cargo.lock` — `tar` package entry (build-dep of `crates/pdfium-sys`)
- Constraint in `crates/pdfium-sys/Cargo.toml`: `tar = "0.4"` — already covers 0.4.46, no `Cargo.toml` change needed

## Fix

Surgical `Cargo.lock` bump: only the `tar` package entry's version and checksum change. No transitive resolver shake, no churn on unrelated crates.

```diff
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
  "xattr",
 ]
```

A naive `cargo update -p tar --precise 0.4.46` causes the resolver to also re-pin several unrelated `windows-sys` dependents (`errno`, `rustix`, `tempfile`, `winapi-util`, `ureq`) from 0.61.2 → 0.52.0. Both versions already coexist in the lockfile so the shake is functionally fine, but it's noise in a security-only patch. This PR avoids that churn by editing just the `tar` entry.

## Detected by

[Aeon](https://github.com/aaronjmars/aeon-aaron) + osv-scanner

- Severity: moderate
- Advisory: [GHSA-3pv8-6f4r-ffg2](https://github.com/advisories/GHSA-3pv8-6f4r-ffg2)
- Affected: `tar < 0.4.46`
- Fixed: `tar 0.4.46`

## Verification

- `cargo fetch --locked` — clean (validates the new 0.4.46 checksum against crates.io and confirms the lockfile is internally consistent)
- `cargo metadata --locked` — exit 0
- Full build / downstream PDF-extraction tests intentionally left to CI: the bump is a patch-version of `tar` satisfying the `= "0.4"` constraint in `crates/pdfium-sys/Cargo.toml`, and `tar`'s public API surface used by `pdfium-sys/build.rs` (`tar::Archive::new` + `archive.unpack`) is unchanged between 0.4.45 and 0.4.46.

## Triage notes (not part of this PR)

The same scanner pass surfaced two other entries in `ocr/easyocr/uv.lock` (`starlette` 0.52.1 + `torch` 2.10.0). Per `SECURITY.md`'s out-of-scope clause ("Issues requiring a server setup… LiteParse does not include or recommend any specific production server deployment"), those belong to the example OCR server image and are not bundled into this fix. If you'd like a separate PR for them, happy to follow up.

Semgrep also flagged 14 `run-shell-injection` matches in `.github/workflows/release-*.yml`. All are `${{ inputs.version }}` interpolations under `workflow_dispatch`-only triggers — write-access required to dispatch — so not externally attacker-controlled. Reported here for transparency, no change requested.

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
