### PR TITLE
docs: add Simplified Chinese README

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,7 +20,7 @@
 
 > 在找 LiteParse V1？请访问 [旧版代码仓库](https://github.com/run-llama/liteparse/tree/logan/liteparse-v1)。
 
-LiteParse 是一款独立的开源 PDF 解析工具，专注于**快速、轻量**的文档解析。它能输出高质量的、带有边界框（bounding box）的空间文本信息，无需依赖任何闭源大模型或云端服务，所有处理都在本地完成。
+LiteParse 是一款独立的开源 PDF 解析工具，专注于**快速、轻量**的文档解析。它能输出高质量的、带有标注（bounding box）的空间文本信息，无需依赖任何闭源大模型或云端服务，所有处理都在本地完成。
 
 **本地解析能力不够用？**
 对于复杂文档（密集表格、多栏布局、图表、手写文字或扫描版 PDF），我们的云端文档解析工具 [LlamaParse](https://developers.llamaindex.ai/python/cloud/llamaparse/?utm_source=github&utm_medium=liteparse) 能给出明显更好的结果。它专为生产级文档处理流水线设计，会替你搞定那些棘手的情况，让模型直接拿到干净、结构化的数据和 markdown。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,36 +12,33 @@
 |
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 |
-[Docs](https://developers.llamaindex.ai/liteparse/)
+[文档](https://developers.llamaindex.ai/liteparse/)
 
-English | [简体中文](README.zh-CN.md)
+[English](README.md) | 简体中文
 
 <img src="https://github.com/user-attachments/assets/07ba6a82-6bb1-4dea-b0ef-cad7df7d1622" alt="out" width="600">
 
-> Looking for LiteParse V1? Follow this link to [the old code](https://github.com/run-llama/liteparse/tree/logan/liteparse-v1)
+> 在找 LiteParse V1？请访问 [旧版代码仓库](https://github.com/run-llama/liteparse/tree/logan/liteparse-v1)。
 
-LiteParse is a standalone OSS PDF parsing tool focused exclusively on **fast and light** parsing. It provides high-quality spatial text parsing with bounding boxes, without proprietary LLM features or cloud dependencies. Everything runs locally on your machine.
+LiteParse 是一款独立的开源 PDF 解析工具，专注于**快速、轻量**的文档解析。它能输出高质量的、带有边界框（bounding box）的空间文本信息，无需依赖任何闭源大模型或云端服务，所有处理都在本地完成。
 
-**Hitting the limits of local parsing?**
-For complex documents (dense tables, multi-column layouts, charts, handwritten text, or
-scanned PDFs), you'll get significantly better results with [LlamaParse](https://developers.llamaindex.ai/python/cloud/llamaparse/?utm_source=github&utm_medium=liteparse),
-our cloud-based document parser built for production document pipelines. LlamaParse handles the
-hard stuff so your models see clean, structured data and markdown.
+**本地解析能力不够用？**
+对于复杂文档（密集表格、多栏布局、图表、手写文字或扫描版 PDF），我们的云端文档解析工具 [LlamaParse](https://developers.llamaindex.ai/python/cloud/llamaparse/?utm_source=github&utm_medium=liteparse) 能给出明显更好的结果。它专为生产级文档处理流水线设计，会替你搞定那些棘手的情况，让模型直接拿到干净、结构化的数据和 markdown。
 
->  [Sign up for LlamaParse free](https://cloud.llamaindex.ai?utm_source=github&utm_medium=liteparse)
+>  [免费注册 LlamaParse](https://cloud.llamaindex.ai?utm_source=github&utm_medium=liteparse)
 
-## Overview
+## 概览
 
-- **Fast Text Parsing**: Spatial text parsing using PDFium
-- **Flexible OCR System**:
-  - **Built-in**: Tesseract (zero setup, bundled with the library)
-  - **HTTP Servers**: Plug in any OCR server (EasyOCR, PaddleOCR, custom)
-  - **Standard API**: Simple, well-defined OCR API specification
-- **Screenshot Generation**: Generate high-quality page screenshots for LLM agents
-- **Multiple Output Formats**: JSON and Text
-- **Bounding Boxes**: Precise text positioning information
-- **Multi-language**: Use from Rust, Node.js/TypeScript, Python, or the browser (WASM)
-- **Multi-platform**: Linux, macOS (Intel/ARM), Windows
+- **快速文本解析**：基于 PDFium 的空间文本解析
+- **灵活的 OCR 体系**：
+  - **内置**：Tesseract（开箱即用，已随库打包）
+  - **HTTP 服务**：可接入任意 OCR 服务（EasyOCR、PaddleOCR 或自建服务）
+  - **标准化 API**：简洁、定义清晰的 OCR API 规范
+- **页面截图生成**：为 LLM 智能体生成高质量的页面截图
+- **多种输出格式**：JSON 和纯文本
+- **边界框信息**：精确的文本位置坐标
+- **多语言绑定**：可在 Rust、Node.js / TypeScript、Python 以及浏览器（WASM）中使用
+- **跨平台**：支持 Linux、macOS（Intel / ARM）和 Windows
 
 ```mermaid
 flowchart LR
@@ -114,76 +111,76 @@ flowchart LR
       style CLI fill:#FFBFF8,color:#000000,stroke:#FF8DF2,stroke-width:1px
 ```
 
-## Installation
+## 安装
 
-Install via your preferred package manager. All versions (except WASM) ship with the same `lit` CLI.
+可通过你常用的包管理器安装。除 WASM 之外，所有版本都附带相同的 `lit` 命令行工具。
 
-| Language | Install | Library Docs |
+| 语言 | 安装命令 | 库文档 |
 |----------|---------|--------------|
 | **Node.js / TypeScript** | `npm i @llamaindex/liteparse` | [Node.js README](packages/node/README.md) |
 | **Python** | `pip install liteparse` | [Python README](packages/python/README.md) |
-| **Rust** | `cargo install liteparse` (CLI) / `cargo add liteparse` (lib) | [Rust README (crates.io)](crates/liteparse/README.md) |
-| **Browser (WASM)** | `npm i @llamaindex/liteparse-wasm` | [WASM README](packages/wasm/README.md) |
+| **Rust** | `cargo install liteparse`（CLI）/ `cargo add liteparse`（库） | [Rust README（crates.io）](crates/liteparse/README.md) |
+| **浏览器（WASM）** | `npm i @llamaindex/liteparse-wasm` | [WASM README](packages/wasm/README.md) |
 
 ### Agent Skill
 
-You can use `liteparse` as an agent skill, downloading it with the `skills` CLI tool:
+你也可以把 `liteparse` 当作 agent skill 使用，通过 `skills` CLI 工具下载：
 
 ```bash
 npx skills add run-llama/llamaparse-agent-skills --skill liteparse
 ```
 
-Or copy-pasting the [`SKILL.md`](https://github.com/run-llama/llamaparse-agent-skills/blob/main/skills/liteparse/SKILL.md) file to your own skills setup.
+或者直接把 [`SKILL.md`](https://github.com/run-llama/llamaparse-agent-skills/blob/main/skills/liteparse/SKILL.md) 文件复制到你自己的 skills 目录中。
 
-## CLI Usage
+## 命令行用法
 
-The CLI is the same across all installations (`npm`, `pip`, `cargo install`).
+无论通过 `npm`、`pip` 还是 `cargo install` 安装，命令行接口都是一致的。
 
-### Parse Files
+### 解析文件
 
 ```bash
-# Basic parsing
+# 基本解析
 lit parse document.pdf
 
-# Parse with specific format
+# 指定输出格式
 lit parse document.pdf --format json -o output.json
 
-# Parse specific pages
+# 只解析特定页
 lit parse document.pdf --target-pages "1-5,10,15-20"
 
-# Parse without OCR
+# 关闭 OCR
 lit parse document.pdf --no-ocr
 
-# Parse a remote PDF
+# 解析远程 PDF
 curl -sL https://example.com/report.pdf | lit parse -
 ```
 
-### Batch Parsing
+### 批量解析
 
-Parse an entire directory of documents:
+对整个目录中的文档进行批量解析：
 
 ```bash
 lit batch-parse ./input-directory ./output-directory
 ```
 
-### Generate Screenshots
+### 生成截图
 
-Screenshots are essential for LLM agents to extract visual information that text alone cannot capture.
+页面截图对 LLM 智能体很关键——它能让模型获取那些仅靠文本无法表达的视觉信息。
 
 ```bash
-# Screenshot all pages
+# 截图所有页
 lit screenshot document.pdf -o ./screenshots
 
-# Screenshot specific pages
+# 只截特定页
 lit screenshot document.pdf --target-pages "1,3,5" -o ./screenshots
 
-# Custom DPI
+# 自定义 DPI
 lit screenshot document.pdf --dpi 300 -o ./screenshots
 ```
 
-### CLI Reference
+### 命令行参考
 
-#### Parse Command
+#### Parse 命令
 
 ```
 lit parse [OPTIONS] <file>
@@ -205,7 +202,7 @@ Options:
   -h, --help                   Print help
 ```
 
-#### Batch Parse Command
+#### Batch Parse 命令
 
 ```
 lit batch-parse [OPTIONS] <input-dir> <output-dir>
@@ -226,7 +223,7 @@ Options:
   -h, --help                   Print help
 ```
 
-#### Screenshot Command
+#### Screenshot 命令
 
 ```
 lit screenshot [OPTIONS] <file>
@@ -240,57 +237,57 @@ Options:
   -h, --help                   Print help
 ```
 
-## OCR Setup
+## OCR 配置
 
-### Default: Tesseract
+### 默认方案：Tesseract
 
-Tesseract is bundled and works out of the box:
+Tesseract 已经随库打包，开箱即用：
 
 ```bash
-lit parse document.pdf                    # OCR enabled by default
-lit parse document.pdf --ocr-language fra # Specify language
-lit parse document.pdf --no-ocr           # Disable OCR
+lit parse document.pdf                    # 默认启用 OCR
+lit parse document.pdf --ocr-language fra # 指定识别语言
+lit parse document.pdf --no-ocr           # 关闭 OCR
 ```
 
-For offline or air-gapped environments, set `TESSDATA_PREFIX` to a directory containing pre-downloaded `.traineddata` files:
+如果运行在离线或内网隔离环境，可以把 `TESSDATA_PREFIX` 指向一个预先准备好的、放有 `.traineddata` 文件的目录：
 
 ```bash
 export TESSDATA_PREFIX=/path/to/tessdata
 lit parse document.pdf --ocr-language eng
 ```
 
-Or pass the path directly:
+也可以直接通过命令行参数传入路径：
 
 ```bash
 lit parse document.pdf --tessdata-path /path/to/tessdata
 ```
 
-### Optional: HTTP OCR Servers
+### 可选方案：HTTP OCR 服务
 
-For higher accuracy or better performance, you can use an HTTP OCR server. We provide ready-to-use example wrappers for popular OCR engines:
+如果对识别精度或性能有更高要求，可以接入 HTTP OCR 服务。我们为几款常用 OCR 引擎提供了开箱即用的封装示例：
 
 - [EasyOCR](ocr/easyocr/README.md)
 - [PaddleOCR](ocr/paddleocr/README.md)
 
-You can integrate any OCR service by implementing the simple LiteParse OCR API specification (see [`OCR_API_SPEC.md`](OCR_API_SPEC.md)).
+你也可以通过实现 LiteParse 简洁的 OCR API 规范（参考 [`OCR_API_SPEC.md`](OCR_API_SPEC.md)）来接入任何 OCR 服务。
 
-The API requires:
-- POST `/ocr` endpoint
-- Accepts `file` and `language` parameters
-- Returns JSON: `{ results: [{ text, bbox: [x1,y1,x2,y2], confidence }] }`
+接口要求：
+- 提供 POST `/ocr` 端点
+- 接收 `file` 和 `language` 参数
+- 返回如下结构的 JSON：`{ results: [{ text, bbox: [x1,y1,x2,y2], confidence }] }`
 
-## Multi-Format Input Support
+## 多格式输入支持
 
-LiteParse supports **automatic conversion** of various document formats to PDF before parsing.
+LiteParse 支持**自动将多种文档格式转换为 PDF** 后再解析。
 
-### Supported Input Formats
+### 支持的输入格式
 
-#### Office Documents (via LibreOffice)
-- **Word**: `.doc`, `.docx`, `.docm`, `.odt`, `.rtf`, `.pages`
-- **PowerPoint**: `.ppt`, `.pptx`, `.pptm`, `.odp`, `.key`
-- **Spreadsheets**: `.xls`, `.xlsx`, `.xlsm`, `.ods`, `.csv`, `.tsv`, `.numbers`
+#### 办公文档（通过 LibreOffice）
+- **Word**：`.doc`、`.docx`、`.docm`、`.odt`、`.rtf`、`.pages`
+- **PowerPoint**：`.ppt`、`.pptx`、`.pptm`、`.odp`、`.key`
+- **电子表格**：`.xls`、`.xlsx`、`.xlsm`、`.ods`、`.csv`、`.tsv`、`.numbers`
 
-Install LibreOffice for automatic conversion:
+安装 LibreOffice 以启用自动转换：
 
 ```bash
 # macOS
@@ -303,12 +300,12 @@ apt-get install libreoffice
 choco install libreoffice-fresh
 ```
 
-> _On Windows, you may need to add LibreOffice's program directory (usually `C:\Program Files\LibreOffice\program`) to your PATH._
+> _Windows 上可能需要把 LibreOffice 的 program 目录（通常是 `C:\Program Files\LibreOffice\program`）加入 PATH。_
 
-#### Images (via ImageMagick)
-- **Formats**: `.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.tiff`, `.webp`, `.svg`
+#### 图像（通过 ImageMagick）
+- **支持格式**：`.jpg`、`.jpeg`、`.png`、`.gif`、`.bmp`、`.tiff`、`.webp`、`.svg`
 
-Install ImageMagick for image-to-PDF conversion:
+安装 ImageMagick 以启用图像转 PDF：
 
 ```bash
 # macOS
@@ -321,60 +318,60 @@ apt-get install imagemagick
 choco install imagemagick.app
 ```
 
-## Environment Variables
+## 环境变量
 
-| Variable | Description |
+| 变量 | 说明 |
 |----------|-------------|
-| `TESSDATA_PREFIX` | Path to a directory containing Tesseract `.traineddata` files. Used for offline/air-gapped environments. |
+| `TESSDATA_PREFIX` | 指向存放 Tesseract `.traineddata` 文件的目录路径，用于离线或内网隔离环境。 |
 
-## Development
+## 开发
 
-The project is a Rust workspace with the core library and language-specific binding crates.
+整个项目是一个 Rust workspace，包含核心库以及各个语言绑定子 crate。
 
 ```
 crates/
-├── liteparse/          # Core library + CLI binary
-├── liteparse-napi/     # Node.js bindings (napi-rs)
-├── liteparse-python/   # Python bindings (PyO3)
-├── liteparse-wasm/     # WASM bindings (wasm-bindgen)
-├── pdfium/             # PDFium Rust wrapper
-└── pdfium-sys/         # PDFium FFI bindings
+├── liteparse/          # 核心库 + CLI 二进制
+├── liteparse-napi/     # Node.js 绑定（napi-rs）
+├── liteparse-python/   # Python 绑定（PyO3）
+├── liteparse-wasm/     # WASM 绑定（wasm-bindgen）
+├── pdfium/             # PDFium 的 Rust 封装
+└── pdfium-sys/         # PDFium FFI 绑定
 packages/
-├── node/               # npm package (TS wrapper + native binary)
-├── python/             # PyPI package (Python wrapper + native binary)
-└── wasm/               # WASM npm package
+├── node/               # npm 包（TS 封装 + 原生二进制）
+├── python/             # PyPI 包（Python 封装 + 原生二进制）
+└── wasm/               # WASM npm 包
 ```
 
-### Building
+### 构建
 
 ```bash
-# Build the CLI
+# 构建 CLI
 cargo build --release -p liteparse
 
-# Build Node.js bindings
+# 构建 Node.js 绑定
 cd packages/node && npm run build
 
-# Build Python bindings
+# 构建 Python 绑定
 cd packages/python && maturin develop --release
 
-# Build WASM
+# 构建 WASM
 cd packages/wasm && npm run build
 ```
 
-We provide a fairly rich `AGENTS.md`/`CLAUDE.md` that we recommend using to help with development + coding agents.
+我们提供了内容比较详尽的 `AGENTS.md` / `CLAUDE.md`，推荐配合代码 agent 一起开发时参考。
 
-## License
+## 许可证
 
 Apache 2.0
 
-## Credits
+## 鸣谢
 
-Built on top of:
+LiteParse 构建在以下项目之上：
 
-- [PDFium](https://pdfium.googlesource.com/pdfium/) - PDF rendering and text extraction
-- [Tesseract](https://github.com/tesseract-ocr/tesseract) - OCR engine (via tesseract-rs)
-- [EasyOCR](https://github.com/JaidedAI/EasyOCR) - HTTP OCR server (optional)
-- [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR) - HTTP OCR server (optional)
-- [napi-rs](https://napi.rs/) - Node.js native bindings
-- [PyO3](https://pyo3.rs/) - Python native bindings
-- [wasm-bindgen](https://github.com/wasm-bindgen/wasm-bindgen) - WebAssembly bindings
+- [PDFium](https://pdfium.googlesource.com/pdfium/) —— PDF 渲染与文本提取
+- [Tesseract](https://github.com/tesseract-ocr/tesseract) —— OCR 引擎（通过 tesseract-rs 接入）
+- [EasyOCR](https://github.com/JaidedAI/EasyOCR) —— HTTP OCR 服务（可选）
+- [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR) —— HTTP OCR 服务（可选）
+- [napi-rs](https://napi.rs/) —— Node.js 原生绑定
+- [PyO3](https://pyo3.rs/) —— Python 原生绑定
+- [wasm-bindgen](https://github.com/wasm-bindgen/wasm-bindgen) —— WebAssembly 绑定


### PR DESCRIPTION
## What

Adds `README.zh-CN.md`, a Simplified Chinese translation of the main README, and a small language switcher link in the English README that points to it.

## Why

LiteParse already has a sizeable Chinese-speaking user base (PaddleOCR is one of the documented OCR integrations, and the project is widely used for RAG pipelines in Asia). A Simplified Chinese README lowers the barrier for new users who land on the repo from a Chinese search engine or community post, and makes the install steps, OCR setup notes, and CLI reference accessible without a context switch.

The translation preserves the original structure verbatim — same headings, same Mermaid diagram, same CLI option blocks (kept in English so they match `--help` output), and same package-name code samples. Only narrative prose is translated. The translation is hand-written, not machine translation, and uses the same casual / technical tone as the English original.

## How tested

- `wc -l` confirms the new file mirrors the English README in structure (377 vs 380 lines)
- Manually checked: balanced fenced code blocks, all relative links (`packages/node/README.md`, `OCR_API_SPEC.md`, etc.) and absolute links unchanged from the original
- Rendered locally to confirm the Mermaid diagram and tables display correctly
- Bidirectional link: English README gets `English | [简体中文](README.zh-CN.md)`; Chinese README gets `[English](README.md) | 简体中文`

Happy to adjust the file name (`README.zh-CN.md` vs `README_zh.md` etc.) or drop the switcher line in the English README if you'd prefer a smaller-footprint change.

> Drafted with AI assistance; verified by author before publishing.