### PR TITLE
ci: build Linux glibc binaries on ubuntu-22.04 for portability

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -53,12 +53,12 @@ jobs:
             node-arch: darwin-x64
             pdfium-dylib: libpdfium.dylib
 
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             node-arch: linux-x64-gnu
             pdfium-dylib: libpdfium.so
 
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             node-arch: linux-arm64-gnu
             pdfium-dylib: libpdfium.so
@@ -235,10 +235,10 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             artifact: lit-linux-x64
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             artifact: lit-linux-arm64
             use-cross: true
           - target: aarch64-apple-darwin

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -275,10 +275,10 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             artifact: lit-linux-x64
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
+            os: ubuntu-22.04-arm
             artifact: lit-linux-arm64
           - target: aarch64-apple-darwin
             os: macos-latest


### PR DESCRIPTION
The linux-x64-gnu / linux-arm64-gnu .node bindings and the lit cli build on Ubuntu 24.04 runners (ubuntu-latest / ubuntu-24.04-arm), whose glibc 2.39 / GCC 13 toolchain requires GLIBC_2.39 and GLIBCXX_3.4.31. This causes the package to fail to load on any older-glibc distro, e.g. Debian bookworm (glibc 2.36) with version 'GLIBCXX_3.4.31' not found.

This PR drops the runner to ubuntu-22.04 which increases the portability of the package since that runner lowers the binary's requirement to GLIBC_2.34 / GLIBCXX_3.4.29. It might make more sense to do a proper CI matrix builder strategy but this opts for least changes.