### PR TITLE
improve tarball releases + coverage

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -74,21 +74,33 @@ jobs:
   build-binaries:
     needs: validate
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             artifact: lit-linux-x64
+            pdfium-dylib: libpdfium.so
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04-arm
             artifact: lit-linux-arm64
-            use-cross: true
+            pdfium-dylib: libpdfium.so
           - target: aarch64-apple-darwin
             os: macos-latest
             artifact: lit-darwin-arm64
+            pdfium-dylib: libpdfium.dylib
           - target: x86_64-apple-darwin
             os: macos-26-intel
             artifact: lit-darwin-x64
+            pdfium-dylib: libpdfium.dylib
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            artifact: lit-windows-x64
+            pdfium-dylib: pdfium.dll
+          - target: aarch64-pc-windows-msvc
+            os: windows-11-arm
+            artifact: lit-windows-arm64
+            pdfium-dylib: pdfium.dll
 
     runs-on: ${{ matrix.os }}
 
@@ -99,22 +111,20 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install system dependencies (Linux native)
-        if: runner.os == 'Linux' && !matrix.use-cross
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libtesseract-dev libleptonica-dev
 
-      - name: Install cross-compilation tools (Linux ARM64)
-        if: matrix.use-cross
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-
       - name: Install system dependencies (macOS)
         if: runner.os == 'macOS'
         run: brew install tesseract leptonica
+
+      - name: Force Ninja generator (Windows)
+        if: runner.os == 'Windows'
+        run: echo "CMAKE_GENERATOR=Ninja" >> $GITHUB_ENV
+        shell: bash
 
       - uses: actions/cache@v4
         with:
@@ -123,30 +133,53 @@ jobs:
             ~/.cargo/git
             ~/.cache/pdfium-rs
             ~/Library/Caches/pdfium-rs
+            ${{ runner.os == 'Windows' && format('{0}\pdfium-rs', env.LOCALAPPDATA) || '' }}
             target
           key: ${{ runner.os }}-${{ matrix.target }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
-        run: |
-          if [ "${{ matrix.use-cross }}" = "true" ]; then
-            # Cross-compile without tesseract (C cross-deps are hard)
-            cargo build --release --target ${{ matrix.target }} --no-default-features -p liteparse
-          else
-            cargo build --release --target ${{ matrix.target }} -p liteparse
-          fi
+        run: cargo build --release --target ${{ matrix.target }} -p liteparse
 
-      - name: Package binary
+      - name: Stage binary and pdfium (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          mkdir -p staging/${{ matrix.artifact }}
+          cp target/${{ matrix.target }}/release/lit staging/${{ matrix.artifact }}/lit
+          chmod +x staging/${{ matrix.artifact }}/lit
+          bash packages/node/scripts/copy-pdfium.sh staging/${{ matrix.artifact }}
+
+      - name: Stage binary and pdfium (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path "staging/${{ matrix.artifact }}" | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/lit.exe" -Destination "staging/${{ matrix.artifact }}/lit.exe"
+          $cacheBase = "$env:LOCALAPPDATA\pdfium-rs"
+          if (-not (Test-Path $cacheBase)) {
+            $cacheBase = "$env:USERPROFILE\.cache\pdfium-rs"
+          }
+          $dll = Get-ChildItem -Path $cacheBase -Recurse -Filter "pdfium.dll" | Select-Object -First 1
+          if ($dll) {
+            Copy-Item $dll.FullName -Destination "staging/${{ matrix.artifact }}/pdfium.dll"
+            Write-Host "Copied $($dll.FullName) -> staging/${{ matrix.artifact }}/pdfium.dll"
+          } else {
+            Write-Error "Could not find pdfium.dll in cache"
+            exit 1
+          }
+
+      - name: Package tarball
+        shell: bash
         run: |
           mkdir -p dist
-          cp target/${{ matrix.target }}/release/lit dist/${{ matrix.artifact }}
-          chmod +x dist/${{ matrix.artifact }}
-          tar -czf dist/${{ matrix.artifact }}.tar.gz -C dist ${{ matrix.artifact }}
+          tar -czf dist/${{ matrix.artifact }}.tar.gz -C staging ${{ matrix.artifact }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
           path: dist/${{ matrix.artifact }}.tar.gz
+          if-no-files-found: error
 
   github-release:
     needs: [build-binaries, publish-crates]


### PR DESCRIPTION
Previous tarballs were
- shipping without tesseract
- shipping without pdfium
- missing critical builds (i.e. windows)

This PR fixes all 3

NOTE: `lit` must be executed next to the pdfium lib, or the env var `PDFIUM_LIB_PATH` needs to be set, or it needs to be in a standard system search path