### PR TITLE
feat: make table cleaning opt-out by default

### DIFF
--- a/crates/liteparse-napi/src/types.rs
+++ b/crates/liteparse-napi/src/types.rs
@@ -35,6 +35,8 @@ pub struct JsLiteParseConfig {
     pub quiet: Option<bool>,
     /// Number of concurrent OCR workers (default: CPU cores - 1).
     pub num_workers: Option<u32>,
+    /// Whether to auto-remove invalid table artifacts from raw OCR response.
+    pub clean_artifacts: Option<bool>,
 }
 
 impl JsLiteParseConfig {
@@ -79,6 +81,9 @@ impl JsLiteParseConfig {
         if let Some(v) = self.num_workers {
             cfg.num_workers = v as usize;
         }
+        if let Some(v) = self.clean_artifacts {
+            cfg.clean_artifacts = v;
+        }
         cfg
     }
 
@@ -99,6 +104,7 @@ impl JsLiteParseConfig {
             password: cfg.password.clone(),
             quiet: Some(cfg.quiet),
             num_workers: Some(cfg.num_workers as u32),
+            clean_artifacts: Some(cfg.clean_artifacts),
         }
     }
 }

--- a/crates/liteparse-python/src/cli.rs
+++ b/crates/liteparse-python/src/cli.rs
@@ -54,6 +54,8 @@ struct ParseCommand {
     quiet: bool,
     #[arg(long)]
     num_workers: Option<usize>,
+    #[arg(long, default_value = "true")]
+    clean_artifacts: bool,
 }
 
 #[derive(Args, Debug)]
@@ -129,6 +131,7 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                 password: cmd.password,
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
+                clean_artifacts: cmd.clean_artifacts,
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -214,6 +214,8 @@ struct PyLiteParseConfig {
     quiet: bool,
     #[pyo3(get)]
     num_workers: usize,
+    #[pyo3(get)]
+    clean_artifacts: bool,
 }
 
 #[pymethods]
@@ -244,6 +246,7 @@ impl PyLiteParseConfig {
             password: cfg.password.clone(),
             quiet: cfg.quiet,
             num_workers: cfg.num_workers,
+            clean_artifacts: cfg.clean_artifacts,
         }
     }
 }
@@ -276,6 +279,7 @@ impl LiteParse {
         password = None,
         quiet = None,
         num_workers = None,
+        clean_artifacts = None,
     ))]
     fn new(
         ocr_language: Option<String>,
@@ -290,6 +294,7 @@ impl LiteParse {
         password: Option<String>,
         quiet: Option<bool>,
         num_workers: Option<usize>,
+        clean_artifacts: Option<bool>,
     ) -> PyResult<Self> {
         let mut cfg = LiteParseConfig::default();
         if let Some(v) = ocr_language {
@@ -330,6 +335,9 @@ impl LiteParse {
         }
         if let Some(v) = num_workers {
             cfg.num_workers = v;
+        }
+        if let Some(v) = clean_artifacts {
+            cfg.clean_artifacts = v;
         }
 
         let inner = liteparse::parser::LiteParse::new(cfg.clone());

--- a/crates/liteparse-wasm/src/lib.rs
+++ b/crates/liteparse-wasm/src/lib.rs
@@ -48,6 +48,7 @@ struct JsLiteParseConfig {
     preserve_very_small_text: Option<bool>,
     password: Option<String>,
     quiet: Option<bool>,
+    clean_artifacts: Option<bool>,
 }
 
 impl JsLiteParseConfig {
@@ -95,6 +96,9 @@ impl JsLiteParseConfig {
         if let Some(v) = self.quiet {
             cfg.quiet = v;
         }
+        if let Some(v) = self.clean_artifacts {
+            cfg.clean_artifacts = v;
+        }
         cfg.num_workers = 1;
         Ok(cfg)
     }
@@ -115,6 +119,7 @@ impl JsLiteParseConfig {
             preserve_very_small_text: Some(cfg.preserve_very_small_text),
             password: cfg.password.clone(),
             quiet: Some(cfg.quiet),
+            clean_artifacts: Some(cfg.clean_artifacts),
         }
     }
 }

--- a/crates/liteparse/src/config.rs
+++ b/crates/liteparse/src/config.rs
@@ -27,6 +27,8 @@ pub struct LiteParseConfig {
     pub quiet: bool,
     /// Number of concurrent OCR workers. Defaults to (number of CPU cores - 1), minimum 1.
     pub num_workers: usize,
+    /// Whether to auto-remove invalid table artifacts from raw OCR response
+    pub clean_artifacts: bool,
 }
 
 /// Supported output formats.
@@ -52,6 +54,7 @@ impl Default for LiteParseConfig {
             password: None,
             quiet: false,
             num_workers: default_num_workers(),
+            clean_artifacts: true,
         }
     }
 }

--- a/crates/liteparse/src/main.rs
+++ b/crates/liteparse/src/main.rs
@@ -89,6 +89,10 @@ struct ParseCommand {
     /// Number of concurrent OCR workers (default: CPU cores - 1)
     #[arg(long)]
     num_workers: Option<usize>,
+
+    /// Whether to auto-remove invalid table artifacts from raw OCR response
+    #[arg(long, default_value="true")]
+    clean_artifacts: bool,
 }
 
 #[derive(Args, Debug)]
@@ -213,6 +217,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 password: cmd.password,
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
+                clean_artifacts: cmd.clean_artifacts,
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {

--- a/crates/liteparse/src/main.rs
+++ b/crates/liteparse/src/main.rs
@@ -91,7 +91,7 @@ struct ParseCommand {
     num_workers: Option<usize>,
 
     /// Whether to auto-remove invalid table artifacts from raw OCR response
-    #[arg(long, default_value="true")]
+    #[arg(long, default_value = "true")]
     clean_artifacts: bool,
 }
 

--- a/crates/liteparse/src/ocr_merge.rs
+++ b/crates/liteparse/src/ocr_merge.rs
@@ -87,6 +87,7 @@ pub(crate) async fn ocr_and_merge_rendered(
     ocr_engine: Arc<dyn OcrEngine>,
     ocr_language: &str,
     num_workers: usize,
+    clean_artifacts: bool,
 ) -> Result<(), LiteParseError> {
     // Phase 1: spawn OCR tasks onto the tokio runtime so they run on
     // separate threads. A semaphore limits concurrency to `num_workers`.
@@ -208,7 +209,12 @@ pub(crate) async fn ocr_and_merge_rendered(
                 continue;
             }
 
-            let cleaned = clean_ocr_table_artifacts(&r.text);
+            let cleaned = if clean_artifacts {
+                clean_ocr_table_artifacts(&r.text)
+            } else {
+                r.text.clone()
+            };
+
             if cleaned.is_empty() {
                 continue;
             }
@@ -541,7 +547,8 @@ mod tests {
         let rendered = vec![make_rendered(0), make_rendered(1)];
         let engine: Arc<dyn OcrEngine> = Arc::new(FailingEngine);
 
-        let result = ocr_and_merge_rendered(&mut pages, rendered, 72.0, engine, "eng", 2).await;
+        let result =
+            ocr_and_merge_rendered(&mut pages, rendered, 72.0, engine, "eng", 2, true).await;
 
         let err = result.expect_err("expected systemic OCR failure to be surfaced");
         let msg = err.to_string();
@@ -562,7 +569,8 @@ mod tests {
         let mut pages = vec![make_blank_page(1)];
         let engine: Arc<dyn OcrEngine> = Arc::new(FailingEngine);
 
-        let result = ocr_and_merge_rendered(&mut pages, Vec::new(), 72.0, engine, "eng", 2).await;
+        let result =
+            ocr_and_merge_rendered(&mut pages, Vec::new(), 72.0, engine, "eng", 2, true).await;
 
         assert!(result.is_ok(), "empty OCR set should succeed: {result:?}");
     }
@@ -576,7 +584,8 @@ mod tests {
         let rendered = vec![make_rendered(0), make_rendered(1)];
         let engine: Arc<dyn OcrEngine> = Arc::new(FailingEngine);
 
-        let result = ocr_and_merge_rendered(&mut pages, rendered, 72.0, engine, "eng", 2).await;
+        let result =
+            ocr_and_merge_rendered(&mut pages, rendered, 72.0, engine, "eng", 2, true).await;
 
         assert!(
             result.is_ok(),
@@ -596,7 +605,8 @@ mod tests {
         let rendered = vec![make_rendered(0), make_rendered(1)];
         let engine: Arc<dyn OcrEngine> = Arc::new(FailingEngine);
 
-        let result = ocr_and_merge_rendered(&mut pages, rendered, 72.0, engine, "eng", 2).await;
+        let result =
+            ocr_and_merge_rendered(&mut pages, rendered, 72.0, engine, "eng", 2, true).await;
 
         let err = result.expect_err("a text-starved page losing all OCR must surface an error");
         assert!(
@@ -614,7 +624,8 @@ mod tests {
         let rendered = vec![make_rendered(0)];
         let engine: Arc<dyn OcrEngine> = Arc::new(FailingEngine);
 
-        let result = ocr_and_merge_rendered(&mut pages, rendered, 72.0, engine, "eng", 2).await;
+        let result =
+            ocr_and_merge_rendered(&mut pages, rendered, 72.0, engine, "eng", 2, true).await;
 
         let err = result.expect_err("low-coverage text page losing OCR must surface an error");
         assert!(

--- a/crates/liteparse/src/parser.rs
+++ b/crates/liteparse/src/parser.rs
@@ -176,6 +176,7 @@ impl LiteParse {
                 engine,
                 &self.config.ocr_language,
                 self.config.num_workers,
+                self.config.clean_artifacts,
             )
             .await?;
         }

--- a/packages/node/src/cli.ts
+++ b/packages/node/src/cli.ts
@@ -30,6 +30,7 @@ program
   .option("--config <file>", "JSON config file path")
   .option("-q, --quiet", "Suppress progress output")
   .option("--num-workers <n>", "Number of concurrent OCR workers", parseInt)
+  .option("--no-clean-artifacts", "Disable auto-removal of OCR table artifacts")
   .action(async (file: string, opts: Record<string, unknown>) => {
     try {
       const config: Partial<LiteParseConfig> = {};
@@ -55,6 +56,7 @@ program
       if (opts.password) config.password = opts.password as string;
       if (opts.quiet) config.quiet = true;
       if (opts.numWorkers) config.numWorkers = opts.numWorkers as number;
+      if (opts.cleanArtifacts === false) config.cleanArtifacts = false;
 
       // Default CLI output to text (library defaults to json)
       if (!config.outputFormat) config.outputFormat = "text";

--- a/packages/node/src/lib.ts
+++ b/packages/node/src/lib.ts
@@ -27,6 +27,7 @@ export interface LiteParseConfig {
   password?: string;
   quiet: boolean;
   numWorkers: number;
+  cleanArtifacts: boolean;
 }
 
 export interface TextItem {
@@ -82,6 +83,7 @@ export class LiteParse {
       password: userConfig.password,
       quiet: userConfig.quiet,
       numWorkers: userConfig.numWorkers,
+      cleanArtifacts: userConfig.cleanArtifacts,
     };
 
     this._native = new native.LiteParse(nativeConfig);
@@ -101,6 +103,7 @@ export class LiteParse {
       password: resolved.password ?? undefined,
       quiet: resolved.quiet ?? false,
       numWorkers: resolved.numWorkers ?? 1,
+      cleanArtifacts: resolved.cleanArtifacts ?? true,
     };
   }
 

--- a/packages/node/src/native.ts
+++ b/packages/node/src/native.ts
@@ -32,6 +32,7 @@ export interface LiteParseNativeConfig {
   password?: string;
   quiet?: boolean;
   numWorkers?: number;
+  cleanArtifacts?: boolean;
 }
 
 export interface NativeTextItem {

--- a/packages/python/liteparse/parser.py
+++ b/packages/python/liteparse/parser.py
@@ -76,6 +76,7 @@ class LiteParse:
         password: Optional[str] = None,
         quiet: Optional[bool] = None,
         num_workers: Optional[int] = None,
+        clean_artifacts: Optional[bool] = None,
     ):
         """
         Initialize LiteParse parser.
@@ -93,6 +94,7 @@ class LiteParse:
             password: Password for encrypted/protected documents
             quiet: Suppress progress output
             num_workers: Number of concurrent OCR workers (default: CPU cores - 1)
+            clean_artifacts: Whether to auto-remove invalid table artifacts from OCR (default: True)
         """
         kwargs = {}
         if ocr_enabled is not None:
@@ -119,6 +121,8 @@ class LiteParse:
             kwargs["quiet"] = quiet
         if num_workers is not None:
             kwargs["num_workers"] = num_workers
+        if clean_artifacts is not None:
+            kwargs["clean_artifacts"] = clean_artifacts
 
         self._native = _NativeLiteParse(**kwargs)
 
@@ -215,6 +219,7 @@ class LiteParse:
             password=cfg.password,
             quiet=cfg.quiet,
             num_workers=cfg.num_workers,
+            clean_artifacts=cfg.clean_artifacts,
         )
 
     def __repr__(self) -> str:

--- a/packages/python/liteparse/types.py
+++ b/packages/python/liteparse/types.py
@@ -71,6 +71,7 @@ class LiteParseConfig:
     password: Optional[str]
     quiet: bool
     num_workers: int
+    clean_artifacts: bool
 
 
 class ParseError(Exception):


### PR DESCRIPTION
# description
Depending on the ocr provider configured in the`HttpOcrEngine`, partial table extractions are possible/likely. For example, consider tables with multi-row cell merges which don't render nicely in markdown. 

Rather than discarding these partial extractions, many RAG pipelines would still benefit from the unstructured text. 

This PR simply adds a new argument to the `LiteParseConfig` (and corresponding bindings) which determines whether or not `clean_ocr_table_artifacts` gets invoked. 