### PR TITLE
perf(ocr): drop redundant RGBA buffer in OCR page render

### DIFF
--- a/crates/liteparse/src/ocr_merge.rs
+++ b/crates/liteparse/src/ocr_merge.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use crate::error::LiteParseError;
 use crate::ocr::{OcrEngine, OcrOptions, OcrResult};
 use crate::types::{Page, TextItem};
-use image::{ImageBuffer, Rgba};
 use pdfium::Document;
 
 /// Owned page bitmap prepared for OCR. Indices refer to positions in the `pages` slice.
@@ -60,14 +59,9 @@ pub(crate) fn render_pages_for_ocr(
         let bitmap = page_obj.render(dpi)?;
         let width = bitmap.width() as u32;
         let height = bitmap.height() as u32;
-        let rgba = bitmap.to_rgba();
-
-        let img: ImageBuffer<Rgba<u8>, Vec<u8>> = ImageBuffer::from_raw(width, height, rgba)
-            .ok_or(LiteParseError::Other(
-                "failed to create image buffer".into(),
-            ))?;
-        let rgb_img = image::DynamicImage::ImageRgba8(img).to_rgb8();
-        let rgb_bytes = rgb_img.into_raw();
+        // RGB is what OCR consumes; converting straight from BGRA avoids an
+        // intermediate full-frame RGBA buffer per page.
+        let rgb_bytes = bitmap.to_rgb();
 
         rendered.push(RenderedPage {
             idx,

--- a/crates/pdfium/src/bitmap.rs
+++ b/crates/pdfium/src/bitmap.rs
@@ -92,6 +92,28 @@ impl Bitmap {
 
         rgba
     }
+
+    /// Convert the BGRA buffer to tightly-packed RGB in a new Vec, dropping the
+    /// alpha channel (pages render onto opaque white, so alpha is constant 255).
+    pub fn to_rgb(&self) -> Vec<u8> {
+        let width = self.width() as usize;
+        let height = self.height() as usize;
+        let stride = self.stride() as usize;
+        let src = self.buffer();
+        let mut rgb = Vec::with_capacity(width * height * 3);
+
+        for y in 0..height {
+            let row = &src[y * stride..y * stride + width * 4];
+            for pixel in row.chunks_exact(4) {
+                // BGRA -> RGB (drop A)
+                rgb.push(pixel[2]); // R
+                rgb.push(pixel[1]); // G
+                rgb.push(pixel[0]); // B
+            }
+        }
+
+        rgb
+    }
 }
 
 impl Drop for Bitmap {


### PR DESCRIPTION
## Description

OCR page rendering went BGRA -> RGBA -> RGB, allocating a second full-frame buffer per page via the image crate. Pages are composited onto an opaque white background, so alpha is a constant 255 and carries no information, and both OCR engines consume tightly-packed RGB. This as far as I understand spikes the peak memory usage of the OCR processing step for no gain.

This PR adds Bitmap::to_rgb() to convert BGRA -> RGB in a single pass and use it in render_pages_for_ocr, removing the intermediate buffer.

The output for the same pdf is identical and based on profiling. This change lowers the peak memory pressure (RSS) on large scanned/image-only PDFs.

I tested using [this pdf](https://sam.gov/api/prod/opps/v3/opportunities/resources/files/587090a4b0d143678c31b75991302e41/download) which resulted in a ~23% drop:


|  | Before (main) | After (to_rgb)
-- | -- | --
Peak RSS | 3.42 GiB (3.67 GB) | 2.61 GiB (2.80 GB)


## Repro

Release build with peak RSS via
`/usr/bin/time -l` ("maximum resident set size"). `--num-workers 9` is the
default (cores−1 on a 10-core machine).

```
cargo build --release -p liteparse --bin lit --features tesseract

/usr/bin/time -l ./target/release/lit parse "Appendix+H+-+Bldg+332+-+Interior+Photos.pdf" \
  --num-workers 9 \
  --dpi 150 \
  --tessdata-path <dir-with-eng.traineddata> \
  -o out.txt
```

