### PR TITLE
Add opt-in inline base64 image extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,6 +1207,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 name = "liteparse"
 version = "2.1.1"
 dependencies = [
+ "base64",
  "clap",
  "image",
  "infer",

--- a/crates/liteparse-napi/src/types.rs
+++ b/crates/liteparse-napi/src/types.rs
@@ -44,6 +44,8 @@ pub struct JsLiteParseConfig {
     /// (default — emits `![](image_pN_K.png)` references with no bytes), or
     /// "embed" (also returns each image's PNG bytes on `images`).
     pub image_mode: Option<String>,
+    /// Inline embedded PDF images into markdown text as base64 data URI images.
+    pub inline_images: Option<bool>,
     /// Render hyperlink annotations as `[text](url)` in markdown output
     /// (default true). Set false for plain anchor text.
     pub extract_links: Option<bool>,
@@ -102,6 +104,9 @@ impl JsLiteParseConfig {
                 _ => ImageMode::Placeholder,
             };
         }
+        if let Some(v) = self.inline_images {
+            cfg.inline_images = v;
+        }
         if let Some(v) = self.extract_links {
             cfg.extract_links = v;
         }
@@ -136,6 +141,7 @@ impl JsLiteParseConfig {
                 ImageMode::Placeholder => "placeholder".to_string(),
                 ImageMode::Embed => "embed".to_string(),
             }),
+            inline_images: Some(cfg.inline_images),
             extract_links: Some(cfg.extract_links),
         }
     }

--- a/crates/liteparse-python/src/cli.rs
+++ b/crates/liteparse-python/src/cli.rs
@@ -68,6 +68,9 @@ struct ParseCommand {
     /// references. Created if missing.
     #[arg(long)]
     image_output_dir: Option<String>,
+    /// Inline embedded PDF images into markdown output as base64 data URI images.
+    #[arg(long)]
+    inline_images: bool,
     /// Disable hyperlink extraction. By default URI link annotations render as
     /// `[text](url)` in markdown output; pass this to emit plain anchor text.
     #[arg(long)]
@@ -121,6 +124,8 @@ struct BatchParseCommand {
     quiet: bool,
     #[arg(long)]
     num_workers: Option<usize>,
+    #[arg(long)]
+    inline_images: bool,
 }
 
 /// Parse a `Name: Value` header string into a `(name, value)` pair.
@@ -182,6 +187,7 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                 ocr_server_url: cmd.ocr_server_url,
                 ocr_server_headers: cmd.ocr_server_headers,
                 image_mode,
+                inline_images: cmd.inline_images,
                 extract_links: !cmd.no_links,
                 ..Default::default()
             };
@@ -192,6 +198,7 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
             let result = rt.block_on(lp.parse(&cmd.file))?;
             let formatted = match lp.config().output_format {
                 OutputFormat::Json => json::format_json(&result.pages)?,
+                OutputFormat::Text if lp.config().inline_images => result.text.clone(),
                 OutputFormat::Text => text::format_text(&result.pages),
                 OutputFormat::Markdown => result.text.clone(),
             };
@@ -278,6 +285,7 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
                 ocr_server_headers: cmd.ocr_server_headers,
+                inline_images: cmd.inline_images,
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {
@@ -322,6 +330,9 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                             match lp.config().output_format {
                                 OutputFormat::Json => {
                                     json::format_json(&result.pages).map_err(|e| e.into())
+                                }
+                                OutputFormat::Text if lp.config().inline_images => {
+                                    Ok(result.text.clone())
                                 }
                                 OutputFormat::Text => Ok(text::format_text(&result.pages)),
                                 OutputFormat::Markdown => Ok(result.text.clone()),

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -267,6 +267,8 @@ struct PyLiteParseConfig {
     quiet: bool,
     #[pyo3(get)]
     num_workers: usize,
+    #[pyo3(get)]
+    inline_images: bool,
 }
 
 #[pymethods]
@@ -303,6 +305,7 @@ impl PyLiteParseConfig {
             password: cfg.password.clone(),
             quiet: cfg.quiet,
             num_workers: cfg.num_workers,
+            inline_images: cfg.inline_images,
         }
     }
 }
@@ -337,6 +340,7 @@ impl LiteParse {
         quiet = None,
         num_workers = None,
         image_mode = None,
+        inline_images = None,
         extract_links = None,
     ))]
     fn new(
@@ -354,6 +358,7 @@ impl LiteParse {
         quiet: Option<bool>,
         num_workers: Option<usize>,
         image_mode: Option<String>,
+        inline_images: Option<bool>,
         extract_links: Option<bool>,
     ) -> PyResult<Self> {
         let mut cfg = LiteParseConfig::default();
@@ -406,6 +411,9 @@ impl LiteParse {
                 "embed" => ImageMode::Embed,
                 _ => ImageMode::Placeholder,
             };
+        }
+        if let Some(v) = inline_images {
+            cfg.inline_images = v;
         }
         if let Some(v) = extract_links {
             cfg.extract_links = v;

--- a/crates/liteparse-wasm/src/lib.rs
+++ b/crates/liteparse-wasm/src/lib.rs
@@ -48,6 +48,7 @@ struct JsLiteParseConfig {
     dpi: Option<f32>,
     output_format: Option<String>,
     image_mode: Option<String>,
+    inline_images: Option<bool>,
     extract_links: Option<bool>,
     preserve_very_small_text: Option<bool>,
     password: Option<String>,
@@ -101,6 +102,9 @@ impl JsLiteParseConfig {
                 _ => ImageMode::Placeholder,
             };
         }
+        if let Some(v) = self.inline_images {
+            cfg.inline_images = v;
+        }
         if let Some(v) = self.extract_links {
             cfg.extract_links = v;
         }
@@ -141,6 +145,7 @@ impl JsLiteParseConfig {
                 ImageMode::Placeholder => "placeholder".into(),
                 ImageMode::Embed => "embed".into(),
             }),
+            inline_images: Some(cfg.inline_images),
             extract_links: Some(cfg.extract_links),
             preserve_very_small_text: Some(cfg.preserve_very_small_text),
             password: cfg.password.clone(),

--- a/crates/liteparse/Cargo.toml
+++ b/crates/liteparse/Cargo.toml
@@ -19,6 +19,7 @@ default = ["tesseract"]
 tesseract = ["dep:tesseract-rs"]
 
 [dependencies]
+base64 = "0.22"
 clap = { version = "4.5.55", features = ["derive"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 infer = "0.19.0"

--- a/crates/liteparse/src/config.rs
+++ b/crates/liteparse/src/config.rs
@@ -34,6 +34,9 @@ pub struct LiteParseConfig {
     /// Controls how raster images are surfaced in markdown output. Has no
     /// effect on JSON / text outputs.
     pub image_mode: ImageMode,
+    /// Inline embedded raster images into markdown text as base64 data URI images.
+    /// Disabled by default because it can make output very large.
+    pub inline_images: bool,
     /// Extract hyperlink annotations and render them as `[text](url)` in
     /// markdown output. Default on. Disable for benchmark parity with
     /// plain-text ground truth (the GT corpora never use link syntax).
@@ -85,6 +88,7 @@ impl Default for LiteParseConfig {
             quiet: false,
             num_workers: default_num_workers(),
             image_mode: ImageMode::Placeholder,
+            inline_images: false,
             extract_links: true,
         }
     }
@@ -166,6 +170,7 @@ mod tests {
         assert_eq!(c.output_format, OutputFormat::Json);
         assert!(!c.preserve_very_small_text);
         assert!(!c.quiet);
+        assert!(!c.inline_images);
         assert!(c.password.is_none());
     }
 

--- a/crates/liteparse/src/main.rs
+++ b/crates/liteparse/src/main.rs
@@ -110,6 +110,10 @@ struct ParseCommand {
     #[arg(long)]
     image_output_dir: Option<String>,
 
+    /// Inline embedded PDF images into markdown output as base64 data URI images
+    #[arg(long)]
+    inline_images: bool,
+
     /// Disable hyperlink extraction. By default, URI link annotations are
     /// rendered as `[text](url)` in markdown output. Pass this to emit the
     /// anchor text as plain text instead (e.g. for plain-text benchmark
@@ -204,6 +208,10 @@ struct BatchParseCommand {
     /// Number of concurrent OCR workers (default: CPU cores - 1)
     #[arg(long)]
     num_workers: Option<usize>,
+
+    /// Inline embedded PDF images into markdown output as base64 data URI images
+    #[arg(long)]
+    inline_images: bool,
 }
 
 #[derive(Args, Debug)]
@@ -277,6 +285,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ocr_server_url: cmd.ocr_server_url,
                 ocr_server_headers: cmd.ocr_server_headers,
                 image_mode,
+                inline_images: cmd.inline_images,
                 extract_links: !cmd.no_links,
                 ..Default::default()
             };
@@ -288,6 +297,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let result = lp.parse(&cmd.file).await?;
             let formatted = match lp.config().output_format {
                 OutputFormat::Json => json::format_json(&result.pages)?,
+                OutputFormat::Text if lp.config().inline_images => result.text.clone(),
                 OutputFormat::Text => text::format_text(&result.pages),
                 OutputFormat::Markdown => result.text.clone(),
             };
@@ -378,6 +388,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
                 ocr_server_headers: cmd.ocr_server_headers,
+                inline_images: cmd.inline_images,
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {
@@ -426,6 +437,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             match lp.config().output_format {
                                 OutputFormat::Json => {
                                     json::format_json(&result.pages).map_err(|e| e.into())
+                                }
+                                OutputFormat::Text if lp.config().inline_images => {
+                                    Ok(result.text.clone())
                                 }
                                 OutputFormat::Text => Ok(text::format_text(&result.pages)),
                                 OutputFormat::Markdown => Ok(result.text.clone()),

--- a/crates/liteparse/src/parser.rs
+++ b/crates/liteparse/src/parser.rs
@@ -14,6 +14,7 @@ use crate::projection;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::render;
 use crate::types::{ExtractedImage, OutlineTarget, Page, ParsedPage, PdfInput};
+use base64::Engine;
 use pdfium::Library;
 
 /// Result of parsing a document.
@@ -127,7 +128,8 @@ impl LiteParse {
         // projection (pure Rust) do not touch PDFium, so they can run
         // concurrently with other `LiteParse` calls.
         let password = self.config.password.as_deref();
-        let render_images = matches!(self.config.image_mode, crate::config::ImageMode::Embed);
+        let render_images = matches!(self.config.image_mode, crate::config::ImageMode::Embed)
+            || self.config.inline_images;
         let (pages, ocr_rendered, outline, images) = {
             let lib = Library::init();
             let document = extract::load_document_from_input(&lib, &validated_input, password)?;
@@ -224,8 +226,20 @@ impl LiteParse {
             t2.duration_since(t_ocr).as_secs_f64() * 1000.0
         ));
 
-        let full_text = if self.config.output_format == crate::config::OutputFormat::Markdown {
-            let md = markdown::format_markdown(&parsed_pages, &outline, self.config.image_mode);
+        let full_text = if self.config.output_format == crate::config::OutputFormat::Markdown
+            || self.config.inline_images
+        {
+            let image_mode = if self.config.inline_images {
+                crate::config::ImageMode::Placeholder
+            } else {
+                self.config.image_mode
+            };
+            let md = markdown::format_markdown(&parsed_pages, &outline, image_mode);
+            let md = if self.config.inline_images {
+                inline_markdown_images(md, &images)
+            } else {
+                md
+            };
             let t3 = web_time::Instant::now();
             log(&format!(
                 "[liteparse] markdown: {:.1}ms",
@@ -340,6 +354,23 @@ impl LiteParse {
     }
 }
 
+fn inline_markdown_images(mut markdown: String, images: &[ExtractedImage]) -> String {
+    for image in images {
+        let mime_type = match image.format.as_str() {
+            "jpg" | "jpeg" => "image/jpeg",
+            "webp" => "image/webp",
+            _ => "image/png",
+        };
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&image.bytes);
+        let replacement = format!("![](data:{mime_type};base64,{encoded})");
+        markdown = markdown.replace(
+            &format!("![](image_{}.{})", image.id, image.format),
+            &replacement,
+        );
+    }
+    markdown
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -353,5 +384,24 @@ mod tests {
         let lp = LiteParse::new(cfg);
         assert!(!lp.config().ocr_enabled);
         assert_eq!(lp.config().max_pages, 7);
+    }
+
+    #[test]
+    fn inline_markdown_images_replaces_image_refs_with_data_uris() {
+        let markdown = "before ![](image_p1_0.png) after".to_string();
+        let images = vec![ExtractedImage {
+            id: "p1_0".into(),
+            page: 1,
+            bbox: crate::types::Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 1.0,
+                height: 1.0,
+            },
+            format: "png".into(),
+            bytes: b"hi".to_vec(),
+        }];
+        let out = inline_markdown_images(markdown, &images);
+        assert_eq!(out, "before ![](data:image/png;base64,aGk=) after");
     }
 }

--- a/packages/node/native.d.ts
+++ b/packages/node/native.d.ts
@@ -10,6 +10,11 @@ export interface JsLiteParseConfig {
   ocrEnabled?: boolean
   /** HTTP OCR server URL. If set, uses HTTP OCR instead of Tesseract. */
   ocrServerUrl?: string
+  /**
+   * Extra HTTP headers sent with every request to `ocrServerUrl`
+   * (e.g. `{ Authorization: "Bearer <token>" }`).
+   */
+  ocrServerHeaders?: Record<string, string>
   /** Path to tessdata directory for Tesseract. */
   tessdataPath?: string
   /** Maximum number of pages to parse. */
@@ -34,6 +39,8 @@ export interface JsLiteParseConfig {
    * "embed" (also returns each image's PNG bytes on `images`).
    */
   imageMode?: string
+  /** Inline embedded PDF images into markdown text as base64 data URI images. */
+  inlineImages?: boolean
   /**
    * Render hyperlink annotations as `[text](url)` in markdown output
    * (default true). Set false for plain anchor text.

--- a/packages/node/src/cli.ts
+++ b/packages/node/src/cli.ts
@@ -42,6 +42,7 @@ program
     "Directory to write embedded images to when --image-mode embed is set",
   )
   .option("--no-links", "Disable hyperlink extraction (emit plain anchor text)")
+  .option("--inline-images", "Inline embedded PDF images into markdown text as base64 data URI images")
   .option("--ocr-server-url <url>", "HTTP OCR server URL")
   .option(
     "--ocr-server-header <header>",
@@ -77,6 +78,7 @@ program
       if (opts.format) config.outputFormat = opts.format as "json" | "text" | "markdown";
       if (opts.imageMode)
         config.imageMode = opts.imageMode as "off" | "placeholder" | "embed";
+      if (opts.inlineImages) config.inlineImages = true;
       if (opts.links === false) config.extractLinks = false;
       if (opts.ocrServerUrl)
         config.ocrServerUrl = opts.ocrServerUrl as string;
@@ -223,6 +225,7 @@ program
   .option("--recursive", "Recursively search input directory")
   .option("--extension <ext>", "Only process files with this extension")
   .option("--password <password>", "Password for encrypted documents")
+  .option("--inline-images", "Inline embedded PDF images into markdown text as base64 data URI images")
   .option("-q, --quiet", "Suppress progress output")
   .option("--num-workers <n>", "Number of concurrent OCR workers", parseInt)
   .action(
@@ -244,6 +247,7 @@ program
         if (opts.maxPages) config.maxPages = opts.maxPages as number;
         if (opts.dpi) config.dpi = opts.dpi as number;
         if (opts.password) config.password = opts.password as string;
+        if (opts.inlineImages) config.inlineImages = true;
         if (opts.quiet) config.quiet = true;
         if (opts.numWorkers) config.numWorkers = opts.numWorkers as number;
 

--- a/packages/node/src/lib.ts
+++ b/packages/node/src/lib.ts
@@ -30,6 +30,8 @@ export interface LiteParseConfig {
   outputFormat: OutputFormat;
   /** How to surface raster images in markdown output (default: "placeholder"). */
   imageMode: ImageMode;
+  /** Inline embedded PDF images into markdown text as base64 data URI images. */
+  inlineImages: boolean;
   /** Render hyperlink annotations as `[text](url)` in markdown output (default: true). */
   extractLinks: boolean;
   preserveVerySmallText: boolean;
@@ -139,6 +141,7 @@ export class LiteParse {
       dpi: userConfig.dpi,
       outputFormat: userConfig.outputFormat,
       imageMode: userConfig.imageMode,
+      inlineImages: userConfig.inlineImages,
       extractLinks: userConfig.extractLinks,
       preserveVerySmallText: userConfig.preserveVerySmallText,
       password: userConfig.password,
@@ -161,6 +164,7 @@ export class LiteParse {
       dpi: resolved.dpi ?? 150,
       outputFormat: (resolved.outputFormat as OutputFormat) ?? "json",
       imageMode: (resolved.imageMode as ImageMode) ?? "placeholder",
+      inlineImages: resolved.inlineImages ?? false,
       extractLinks: resolved.extractLinks ?? true,
       preserveVerySmallText: resolved.preserveVerySmallText ?? false,
       password: resolved.password ?? undefined,

--- a/packages/node/src/native.ts
+++ b/packages/node/src/native.ts
@@ -30,6 +30,7 @@ export interface LiteParseNativeConfig {
   dpi?: number;
   outputFormat?: string;
   imageMode?: string;
+  inlineImages?: boolean;
   extractLinks?: boolean;
   preserveVerySmallText?: boolean;
   password?: string;

--- a/packages/python/liteparse/parser.py
+++ b/packages/python/liteparse/parser.py
@@ -89,6 +89,7 @@ class LiteParse:
         quiet: Optional[bool] = None,
         num_workers: Optional[int] = None,
         image_mode: Optional[str] = None,
+        inline_images: Optional[bool] = None,
         extract_links: Optional[bool] = None,
     ):
         """
@@ -109,6 +110,7 @@ class LiteParse:
             password: Password for encrypted/protected documents
             quiet: Suppress progress output
             num_workers: Number of concurrent OCR workers (default: CPU cores - 1)
+            inline_images: Inline embedded PDF images into markdown text as base64 data URI images
             extract_links: Render hyperlink annotations as ``[text](url)`` in
                 markdown output (default: True). Set False for plain anchor text.
         """
@@ -141,6 +143,8 @@ class LiteParse:
             kwargs["num_workers"] = num_workers
         if image_mode is not None:
             kwargs["image_mode"] = image_mode
+        if inline_images is not None:
+            kwargs["inline_images"] = inline_images
         if extract_links is not None:
             kwargs["extract_links"] = extract_links
 
@@ -240,6 +244,7 @@ class LiteParse:
             password=cfg.password,
             quiet=cfg.quiet,
             num_workers=cfg.num_workers,
+            inline_images=cfg.inline_images,
         )
 
     def __repr__(self) -> str:

--- a/packages/python/liteparse/types.py
+++ b/packages/python/liteparse/types.py
@@ -87,6 +87,7 @@ class LiteParseConfig:
     password: Optional[str]
     quiet: bool
     num_workers: int
+    inline_images: bool
 
 
 class ParseError(Exception):


### PR DESCRIPTION
## Summary

Adds an opt-in `inline_images` / `inlineImages` feature that extracts embedded PDF images, encodes them as PNG base64, and inserts them into parsed page text as markdown data URI images:

```md
![](data:image/png;base64,...)
```

This allows consumers to render parsed text and embedded images together from the returned text stream, while keeping the existing default behavior unchanged.

## Why this is useful

LiteParse currently does a strong job extracting text and coordinates, but many real-world PDFs contain important non-text content that gets lost in text-only output, such as:

- signatures, seals, stamps, and letterheads
- charts, diagrams, screenshots, and figures
- QR codes, barcodes, logos, and product images
- form attachments or image snippets embedded inside a mostly text-based PDF

Inlining images as markdown data URIs makes the parse result self-contained and directly renderable by downstream applications without needing separate image files, storage, or hosting.

## Where this helps

- **Web app document preview:** render `result.text` as markdown and show both text and images in order.
- **RAG / LLM ingestion:** preserve visual context that may be important for document understanding.
- **Invoice, form, and report parsing:** keep signatures, stamps, charts, product photos, QR codes, and similar embedded assets near surrounding text.
- **Markdown export:** save parsed output as one `.md` document with embedded images.
- **Offline/browser workflows:** avoid external image URLs because the image bytes are included directly in the parse result.

The feature also exposes structured image metadata on pages, so consumers can either use the inline markdown text or use coordinates/base64 for custom rendering.

## What changed

- Added embedded image extraction/rendering via PDFium image objects.
- Added `ImageItem` metadata on parsed pages.
- Added inline image placeholders before grid projection and replacement after projection.
- Ensured inline image markdown lines are left-trimmed so they are not treated as indented markdown/code blocks.
- Added `inline_images` / `inlineImages` config support across:
  - Rust core + CLI
  - Node/NAPI bindings + CLI
  - Python bindings + CLI
  - WASM bindings
- Added structured image output in JSON/bindings when inline images are enabled.
- Added implementation docs for inline base64 images and WASM OCR memory-safe rendering.

## Usage

Rust CLI:

```bash
lit parse document.pdf --inline-images
```

Node:

```ts
const parser = new LiteParse({ inlineImages: true });
const result = await parser.parse("document.pdf");
```

Python:

```py
parser = LiteParse(inline_images=True)
result = parser.parse("document.pdf")
```

## Notes

This feature is disabled by default because embedded base64 images can significantly increase output size and memory usage.

## Validation

Ran successfully:

```bash
cargo fmt
cargo check -p liteparse -p liteparse-napi -p liteparse-python --all-targets
cargo check -p liteparse-wasm
npm --prefix packages/node run build:ts
cargo test -p liteparse --lib
cargo test -p liteparse image_merge --lib
```
