### PR TITLE
feat: add docker-compose for EasyOCR server

### DIFF
--- a/ocr/easyocr/docker-compose.yml
+++ b/ocr/easyocr/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  easyocr:
+    build: .
+    container_name: easyocr
+    ports:
+      - "8828:8828"
+    volumes:
+      # Cache EasyOCR models to avoid re-downloading on restart
+      - easyocr_models:/root/.EasyOCR
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8828/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+volumes:
+  easyocr_models:


### PR DESCRIPTION
Makes it easy to run the EasyOCR server with a single command.

### Usage:

**Spin up the server:**
```bash
docker compose -f ocr/easyocr/docker-compose.yml up -d
```

**Test with curl:**
```bash
curl -X POST http://localhost:8828/ocr -F "file=@./integration_tests_data/receipt.png" -F "language=en"
```

**Test with lit:**
```bash
lit parse --ocr-server-url http://localhost:8828/ocr document.pdf
```
- Runs on ARM64 and amd64
- EasyOCR models cached in named Docker volume
- Health check on /health, restart unless stopped