### PR TITLE
Add opt-in vector chart ASCII detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,6 +1207,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 name = "liteparse"
 version = "2.0.6"
 dependencies = [
+ "base64",
  "clap",
  "image",
  "infer",

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Options:
       --preserve-small-text    Keep very small text
       --password <password>    Password for encrypted documents
       --num-workers <n>        Concurrent OCR workers [default: CPU cores - 1]
+      --inline-images          Inline embedded PDF images as base64 markdown images
   -q, --quiet                  Suppress progress output
   -h, --help                   Print help
 ```
@@ -222,6 +223,7 @@ Options:
       --extension <ext>        Only process files with this extension (e.g., ".pdf")
       --password <password>    Password for encrypted documents
       --num-workers <n>        Concurrent OCR workers
+      --inline-images          Inline embedded PDF images as base64 markdown images
   -q, --quiet                  Suppress progress output
   -h, --help                   Print help
 ```

--- a/crates/liteparse-napi/src/types.rs
+++ b/crates/liteparse-napi/src/types.rs
@@ -2,7 +2,7 @@ use napi_derive::napi;
 
 use liteparse::config::{LiteParseConfig, OutputFormat};
 use liteparse::parser::ParseResult;
-use liteparse::types::{ImageItem, ParsedPage, TextItem};
+use liteparse::types::{ChartItem, ChartType, ImageItem, ParsedPage, TextItem};
 
 // ---------------------------------------------------------------------------
 // Config
@@ -37,6 +37,10 @@ pub struct JsLiteParseConfig {
     pub num_workers: Option<u32>,
     /// Inline embedded PDF images into text as base64 markdown data URI images.
     pub inline_images: Option<bool>,
+    /// Detect supported vector charts and render them as ASCII charts.
+    pub detect_charts: Option<bool>,
+    /// DPI for chart detection rendering.
+    pub chart_detection_dpi: Option<f64>,
 }
 
 impl JsLiteParseConfig {
@@ -84,6 +88,12 @@ impl JsLiteParseConfig {
         if let Some(v) = self.inline_images {
             cfg.inline_images = v;
         }
+        if let Some(v) = self.detect_charts {
+            cfg.detect_charts = v;
+        }
+        if let Some(v) = self.chart_detection_dpi {
+            cfg.chart_detection_dpi = v as f32;
+        }
         cfg
     }
 
@@ -105,6 +115,8 @@ impl JsLiteParseConfig {
             quiet: Some(cfg.quiet),
             num_workers: Some(cfg.num_workers as u32),
             inline_images: Some(cfg.inline_images),
+            detect_charts: Some(cfg.detect_charts),
+            chart_detection_dpi: Some(cfg.chart_detection_dpi as f64),
         }
     }
 }
@@ -184,6 +196,50 @@ impl JsImageItem {
 }
 
 // ---------------------------------------------------------------------------
+// ChartItem
+// ---------------------------------------------------------------------------
+
+#[napi(object)]
+#[derive(Clone)]
+pub struct JsChartItem {
+    pub chart_type: String,
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub ascii: String,
+    pub series: Vec<String>,
+    pub groups: Vec<String>,
+    pub values: Vec<Vec<f64>>,
+}
+
+impl JsChartItem {
+    pub fn from_rust(item: &ChartItem) -> Self {
+        Self {
+            chart_type: match &item.chart_type {
+                ChartType::Bar => "bar",
+                ChartType::Line => "line",
+                ChartType::Pie => "pie",
+                ChartType::Radar => "radar",
+            }
+            .to_string(),
+            x: item.x as f64,
+            y: item.y as f64,
+            width: item.width as f64,
+            height: item.height as f64,
+            ascii: item.ascii.clone(),
+            series: item.series.clone(),
+            groups: item.groups.clone(),
+            values: item
+                .values
+                .iter()
+                .map(|row| row.iter().map(|v| *v as f64).collect())
+                .collect(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // ParsedPage
 // ---------------------------------------------------------------------------
 
@@ -196,6 +252,7 @@ pub struct JsParsedPage {
     pub text: String,
     pub text_items: Vec<JsTextItem>,
     pub images: Vec<JsImageItem>,
+    pub charts: Vec<JsChartItem>,
 }
 
 impl JsParsedPage {
@@ -207,6 +264,7 @@ impl JsParsedPage {
             text: page.text.clone(),
             text_items: page.text_items.iter().map(JsTextItem::from_rust).collect(),
             images: page.images.iter().map(JsImageItem::from_rust).collect(),
+            charts: page.charts.iter().map(JsChartItem::from_rust).collect(),
         }
     }
 }

--- a/crates/liteparse-napi/src/types.rs
+++ b/crates/liteparse-napi/src/types.rs
@@ -2,7 +2,7 @@ use napi_derive::napi;
 
 use liteparse::config::{LiteParseConfig, OutputFormat};
 use liteparse::parser::ParseResult;
-use liteparse::types::{ParsedPage, TextItem};
+use liteparse::types::{ImageItem, ParsedPage, TextItem};
 
 // ---------------------------------------------------------------------------
 // Config
@@ -35,6 +35,8 @@ pub struct JsLiteParseConfig {
     pub quiet: Option<bool>,
     /// Number of concurrent OCR workers (default: CPU cores - 1).
     pub num_workers: Option<u32>,
+    /// Inline embedded PDF images into text as base64 markdown data URI images.
+    pub inline_images: Option<bool>,
 }
 
 impl JsLiteParseConfig {
@@ -79,6 +81,9 @@ impl JsLiteParseConfig {
         if let Some(v) = self.num_workers {
             cfg.num_workers = v as usize;
         }
+        if let Some(v) = self.inline_images {
+            cfg.inline_images = v;
+        }
         cfg
     }
 
@@ -99,6 +104,7 @@ impl JsLiteParseConfig {
             password: cfg.password.clone(),
             quiet: Some(cfg.quiet),
             num_workers: Some(cfg.num_workers as u32),
+            inline_images: Some(cfg.inline_images),
         }
     }
 }
@@ -150,6 +156,34 @@ impl JsTextItem {
 }
 
 // ---------------------------------------------------------------------------
+// ImageItem
+// ---------------------------------------------------------------------------
+
+#[napi(object)]
+#[derive(Clone)]
+pub struct JsImageItem {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub mime_type: String,
+    pub base64: String,
+}
+
+impl JsImageItem {
+    pub fn from_rust(item: &ImageItem) -> Self {
+        Self {
+            x: item.x as f64,
+            y: item.y as f64,
+            width: item.width as f64,
+            height: item.height as f64,
+            mime_type: item.mime_type.clone(),
+            base64: item.base64.clone(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // ParsedPage
 // ---------------------------------------------------------------------------
 
@@ -161,6 +195,7 @@ pub struct JsParsedPage {
     pub height: f64,
     pub text: String,
     pub text_items: Vec<JsTextItem>,
+    pub images: Vec<JsImageItem>,
 }
 
 impl JsParsedPage {
@@ -171,6 +206,7 @@ impl JsParsedPage {
             height: page.page_height as f64,
             text: page.text.clone(),
             text_items: page.text_items.iter().map(JsTextItem::from_rust).collect(),
+            images: page.images.iter().map(JsImageItem::from_rust).collect(),
         }
     }
 }

--- a/crates/liteparse-python/src/cli.rs
+++ b/crates/liteparse-python/src/cli.rs
@@ -54,6 +54,8 @@ struct ParseCommand {
     quiet: bool,
     #[arg(long)]
     num_workers: Option<usize>,
+    #[arg(long)]
+    inline_images: bool,
 }
 
 #[derive(Args, Debug)]
@@ -99,6 +101,8 @@ struct BatchParseCommand {
     quiet: bool,
     #[arg(long)]
     num_workers: Option<usize>,
+    #[arg(long)]
+    inline_images: bool,
 }
 
 fn parse_output_format(s: &str) -> Result<OutputFormat, String> {
@@ -129,6 +133,7 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                 password: cmd.password,
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
+                inline_images: cmd.inline_images,
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {
@@ -206,6 +211,7 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                 password: cmd.password,
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
+                inline_images: cmd.inline_images,
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {

--- a/crates/liteparse-python/src/cli.rs
+++ b/crates/liteparse-python/src/cli.rs
@@ -56,6 +56,10 @@ struct ParseCommand {
     num_workers: Option<usize>,
     #[arg(long)]
     inline_images: bool,
+    #[arg(long)]
+    detect_charts: bool,
+    #[arg(long, default_value = "100")]
+    chart_detection_dpi: f32,
 }
 
 #[derive(Args, Debug)]
@@ -103,6 +107,10 @@ struct BatchParseCommand {
     num_workers: Option<usize>,
     #[arg(long)]
     inline_images: bool,
+    #[arg(long)]
+    detect_charts: bool,
+    #[arg(long, default_value = "100")]
+    chart_detection_dpi: f32,
 }
 
 fn parse_output_format(s: &str) -> Result<OutputFormat, String> {
@@ -134,6 +142,8 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
                 inline_images: cmd.inline_images,
+                detect_charts: cmd.detect_charts,
+                chart_detection_dpi: cmd.chart_detection_dpi,
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {
@@ -212,6 +222,8 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
                 inline_images: cmd.inline_images,
+                detect_charts: cmd.detect_charts,
+                chart_detection_dpi: cmd.chart_detection_dpi,
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -214,6 +214,8 @@ struct PyLiteParseConfig {
     quiet: bool,
     #[pyo3(get)]
     num_workers: usize,
+    #[pyo3(get)]
+    inline_images: bool,
 }
 
 #[pymethods]
@@ -244,6 +246,7 @@ impl PyLiteParseConfig {
             password: cfg.password.clone(),
             quiet: cfg.quiet,
             num_workers: cfg.num_workers,
+            inline_images: cfg.inline_images,
         }
     }
 }
@@ -276,6 +279,7 @@ impl LiteParse {
         password = None,
         quiet = None,
         num_workers = None,
+        inline_images = None,
     ))]
     fn new(
         ocr_language: Option<String>,
@@ -290,6 +294,7 @@ impl LiteParse {
         password: Option<String>,
         quiet: Option<bool>,
         num_workers: Option<usize>,
+        inline_images: Option<bool>,
     ) -> PyResult<Self> {
         let mut cfg = LiteParseConfig::default();
         if let Some(v) = ocr_language {
@@ -330,6 +335,9 @@ impl LiteParse {
         }
         if let Some(v) = num_workers {
             cfg.num_workers = v;
+        }
+        if let Some(v) = inline_images {
+            cfg.inline_images = v;
         }
 
         let inner = liteparse::parser::LiteParse::new(cfg.clone());

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -216,6 +216,10 @@ struct PyLiteParseConfig {
     num_workers: usize,
     #[pyo3(get)]
     inline_images: bool,
+    #[pyo3(get)]
+    detect_charts: bool,
+    #[pyo3(get)]
+    chart_detection_dpi: f32,
 }
 
 #[pymethods]
@@ -247,6 +251,8 @@ impl PyLiteParseConfig {
             quiet: cfg.quiet,
             num_workers: cfg.num_workers,
             inline_images: cfg.inline_images,
+            detect_charts: cfg.detect_charts,
+            chart_detection_dpi: cfg.chart_detection_dpi,
         }
     }
 }
@@ -280,6 +286,8 @@ impl LiteParse {
         quiet = None,
         num_workers = None,
         inline_images = None,
+        detect_charts = None,
+        chart_detection_dpi = None,
     ))]
     fn new(
         ocr_language: Option<String>,
@@ -295,6 +303,8 @@ impl LiteParse {
         quiet: Option<bool>,
         num_workers: Option<usize>,
         inline_images: Option<bool>,
+        detect_charts: Option<bool>,
+        chart_detection_dpi: Option<f32>,
     ) -> PyResult<Self> {
         let mut cfg = LiteParseConfig::default();
         if let Some(v) = ocr_language {
@@ -338,6 +348,12 @@ impl LiteParse {
         }
         if let Some(v) = inline_images {
             cfg.inline_images = v;
+        }
+        if let Some(v) = detect_charts {
+            cfg.detect_charts = v;
+        }
+        if let Some(v) = chart_detection_dpi {
+            cfg.chart_detection_dpi = v;
         }
 
         let inner = liteparse::parser::LiteParse::new(cfg.clone());

--- a/crates/liteparse-wasm/src/lib.rs
+++ b/crates/liteparse-wasm/src/lib.rs
@@ -48,6 +48,7 @@ struct JsLiteParseConfig {
     preserve_very_small_text: Option<bool>,
     password: Option<String>,
     quiet: Option<bool>,
+    inline_images: Option<bool>,
 }
 
 impl JsLiteParseConfig {
@@ -95,6 +96,9 @@ impl JsLiteParseConfig {
         if let Some(v) = self.quiet {
             cfg.quiet = v;
         }
+        if let Some(v) = self.inline_images {
+            cfg.inline_images = v;
+        }
         cfg.num_workers = 1;
         Ok(cfg)
     }
@@ -115,6 +119,7 @@ impl JsLiteParseConfig {
             preserve_very_small_text: Some(cfg.preserve_very_small_text),
             password: cfg.password.clone(),
             quiet: Some(cfg.quiet),
+            inline_images: Some(cfg.inline_images),
         }
     }
 }
@@ -141,12 +146,24 @@ struct JsTextItem<'a> {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+struct JsImageItem<'a> {
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    mime_type: &'a str,
+    base64: &'a str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct JsParsedPage<'a> {
     page_num: usize,
     width: f32,
     height: f32,
     text: &'a str,
     text_items: Vec<JsTextItem<'a>>,
+    images: Vec<JsImageItem<'a>>,
 }
 
 #[derive(Serialize)]
@@ -325,6 +342,18 @@ impl LiteParse {
                         font_name: i.font_name.as_deref(),
                         font_size: i.font_size,
                         confidence: i.confidence,
+                    })
+                    .collect(),
+                images: p
+                    .images
+                    .iter()
+                    .map(|i| JsImageItem {
+                        x: i.x,
+                        y: i.y,
+                        width: i.width,
+                        height: i.height,
+                        mime_type: &i.mime_type,
+                        base64: &i.base64,
                     })
                     .collect(),
             })

--- a/crates/liteparse-wasm/src/lib.rs
+++ b/crates/liteparse-wasm/src/lib.rs
@@ -18,7 +18,7 @@ use liteparse::config::{LiteParseConfig, OutputFormat};
 use liteparse::ocr::{OcrEngine, OcrOptions, OcrResult};
 use liteparse::parser::LiteParse as CoreLiteParse;
 use liteparse::search;
-use liteparse::types::PdfInput;
+use liteparse::types::{ChartType, PdfInput};
 
 // ---------------------------------------------------------------------------
 // Setup
@@ -49,6 +49,8 @@ struct JsLiteParseConfig {
     password: Option<String>,
     quiet: Option<bool>,
     inline_images: Option<bool>,
+    detect_charts: Option<bool>,
+    chart_detection_dpi: Option<f32>,
 }
 
 impl JsLiteParseConfig {
@@ -99,6 +101,12 @@ impl JsLiteParseConfig {
         if let Some(v) = self.inline_images {
             cfg.inline_images = v;
         }
+        if let Some(v) = self.detect_charts {
+            cfg.detect_charts = v;
+        }
+        if let Some(v) = self.chart_detection_dpi {
+            cfg.chart_detection_dpi = v;
+        }
         cfg.num_workers = 1;
         Ok(cfg)
     }
@@ -120,6 +128,8 @@ impl JsLiteParseConfig {
             password: cfg.password.clone(),
             quiet: Some(cfg.quiet),
             inline_images: Some(cfg.inline_images),
+            detect_charts: Some(cfg.detect_charts),
+            chart_detection_dpi: Some(cfg.chart_detection_dpi),
         }
     }
 }
@@ -157,6 +167,20 @@ struct JsImageItem<'a> {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+struct JsChartItem<'a> {
+    chart_type: &'a str,
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    ascii: &'a str,
+    series: &'a [String],
+    groups: &'a [String],
+    values: &'a [Vec<f32>],
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct JsParsedPage<'a> {
     page_num: usize,
     width: f32,
@@ -164,6 +188,7 @@ struct JsParsedPage<'a> {
     text: &'a str,
     text_items: Vec<JsTextItem<'a>>,
     images: Vec<JsImageItem<'a>>,
+    charts: Vec<JsChartItem<'a>>,
 }
 
 #[derive(Serialize)]
@@ -354,6 +379,26 @@ impl LiteParse {
                         height: i.height,
                         mime_type: &i.mime_type,
                         base64: &i.base64,
+                    })
+                    .collect(),
+                charts: p
+                    .charts
+                    .iter()
+                    .map(|c| JsChartItem {
+                        chart_type: match &c.chart_type {
+                            ChartType::Bar => "bar",
+                            ChartType::Line => "line",
+                            ChartType::Pie => "pie",
+                            ChartType::Radar => "radar",
+                        },
+                        x: c.x,
+                        y: c.y,
+                        width: c.width,
+                        height: c.height,
+                        ascii: &c.ascii,
+                        series: &c.series,
+                        groups: &c.groups,
+                        values: &c.values,
                     })
                     .collect(),
             })

--- a/crates/liteparse/Cargo.toml
+++ b/crates/liteparse/Cargo.toml
@@ -19,6 +19,7 @@ default = ["tesseract"]
 tesseract = ["dep:tesseract-rs"]
 
 [dependencies]
+base64 = "0.22"
 clap = { version = "4.5.55", features = ["derive"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 infer = "0.19.0"

--- a/crates/liteparse/README.md
+++ b/crates/liteparse/README.md
@@ -59,6 +59,7 @@ let config = LiteParseConfig {
     preserve_very_small_text: false,      // Keep tiny text
     password: None,                       // Password for protected documents
     quiet: false,                         // Suppress progress output
+    inline_images: false,                 // Inline embedded images as base64 markdown images
     ..Default::default()
 };
 

--- a/crates/liteparse/src/chart.rs
+++ b/crates/liteparse/src/chart.rs
@@ -1,0 +1,730 @@
+use crate::error::LiteParseError;
+use crate::types::{ChartItem, ChartType, Page, ParsedPage, TextItem};
+use pdfium::Document;
+use std::collections::VecDeque;
+
+const BAR_CHAR: char = '█';
+const EMPTY_COLOR_KEY: u8 = u8::MAX;
+
+#[derive(Debug, Clone)]
+pub(crate) struct PageCharts {
+    pub page_number: usize,
+    pub charts: Vec<ChartItem>,
+}
+
+#[derive(Debug, Clone)]
+struct Component {
+    x1: usize,
+    y1: usize,
+    x2: usize,
+    y2: usize,
+    area: usize,
+    color_key: u8,
+}
+
+impl Component {
+    fn width(&self) -> usize {
+        self.x2 - self.x1 + 1
+    }
+
+    fn height(&self) -> usize {
+        self.y2 - self.y1 + 1
+    }
+
+    fn cx(&self) -> f32 {
+        (self.x1 + self.x2) as f32 / 2.0
+    }
+}
+
+/// Detect simple vector bar charts on already-extracted pages.
+///
+/// The detector is deliberately conservative: unsupported/low-confidence
+/// visuals are ignored silently so normal parsed text is not degraded.
+pub(crate) fn detect_charts_for_pages(
+    document: &Document,
+    pages: &[Page],
+    dpi: f32,
+) -> Result<Vec<PageCharts>, LiteParseError> {
+    let mut out = Vec::new();
+    for page in pages {
+        let pdf_page = document.page((page.page_number - 1) as i32)?;
+        let bitmap = pdf_page.render(dpi)?;
+        if let Some(chart) = detect_bar_chart(page, &bitmap) {
+            out.push(PageCharts {
+                page_number: page.page_number,
+                charts: vec![chart],
+            });
+        }
+    }
+    Ok(out)
+}
+
+pub(crate) fn apply_charts_to_parsed_pages(parsed_pages: &mut [ParsedPage], charts: &[PageCharts]) {
+    for page_charts in charts {
+        let Some(page) = parsed_pages
+            .iter_mut()
+            .find(|page| page.page_number == page_charts.page_number)
+        else {
+            continue;
+        };
+
+        for chart in &page_charts.charts {
+            let Some(replaced) = replace_chart_outline(&page.text, chart) else {
+                // Important fallback: do not append unsupported/uncertain chart text.
+                continue;
+            };
+            page.text = replaced;
+            page.charts.push(chart.clone());
+        }
+    }
+}
+
+fn detect_bar_chart(page: &Page, bitmap: &pdfium::Bitmap) -> Option<ChartItem> {
+    let width = bitmap.width().max(0) as usize;
+    let height = bitmap.height().max(0) as usize;
+    if width == 0 || height == 0 || page.page_width <= 0.0 || page.page_height <= 0.0 {
+        return None;
+    }
+
+    let scale_x = width as f32 / page.page_width;
+    let scale_y = height as f32 / page.page_height;
+    let color_keys = build_color_key_map(bitmap);
+    let components = connected_components(&color_keys, width, height);
+    let bars = filter_bar_components(components, width, height);
+    if bars.len() < 2 {
+        return None;
+    }
+
+    let clusters = cluster_bars(&bars);
+    if clusters.len() < 2
+        || clusters.iter().any(|cluster| cluster.is_empty())
+        || !has_consistent_bar_groups(&clusters)
+        || !has_common_baseline(&bars, height)
+    {
+        return None;
+    }
+
+    let (axis_a, axis_b, max_tick) = fit_y_axis(&page.text_items, &bars, scale_x, scale_y)?;
+    if axis_a >= 0.0 || max_tick <= 0.0 {
+        return None;
+    }
+
+    let (groups, series) = extract_labels(&page.text_items, &bars, &clusters, scale_x, scale_y);
+    if groups.len() != clusters.len() || groups.iter().all(|label| label.starts_with("Group ")) {
+        return None;
+    }
+
+    let series_count = clusters.iter().map(Vec::len).max().unwrap_or(0);
+    if series_count == 0 {
+        return None;
+    }
+
+    let mut values = Vec::with_capacity(clusters.len());
+    for cluster in &clusters {
+        let mut row = Vec::new();
+        for bar in cluster {
+            row.push((axis_a * bar.y1 as f32 + axis_b).max(0.0));
+        }
+        values.push(row);
+    }
+
+    let max_value = values
+        .iter()
+        .flatten()
+        .copied()
+        .fold(max_tick, f32::max)
+        .max(1.0);
+    let ascii = build_ascii_chart(&groups, &series, &values, max_value);
+
+    let x1 = bars.iter().map(|bar| bar.x1).min().unwrap_or(0) as f32 / scale_x;
+    let y1 = bars.iter().map(|bar| bar.y1).min().unwrap_or(0) as f32 / scale_y;
+    let x2 = bars.iter().map(|bar| bar.x2).max().unwrap_or(0) as f32 / scale_x;
+    let y2 = bars.iter().map(|bar| bar.y2).max().unwrap_or(0) as f32 / scale_y;
+
+    Some(ChartItem {
+        page_number: page.page_number,
+        chart_type: ChartType::Bar,
+        x: x1,
+        y: y1,
+        width: (x2 - x1).max(0.0),
+        height: (y2 - y1).max(0.0),
+        ascii,
+        series,
+        groups,
+        values,
+        max_value,
+    })
+}
+
+fn build_color_key_map(bitmap: &pdfium::Bitmap) -> Vec<u8> {
+    let width = bitmap.width().max(0) as usize;
+    let height = bitmap.height().max(0) as usize;
+    let stride = bitmap.stride().max(0) as usize;
+    let buffer = bitmap.buffer();
+    let mut keys = vec![EMPTY_COLOR_KEY; width * height];
+
+    for y in 0..height {
+        let row_start = y * stride;
+        for x in 0..width {
+            let offset = row_start + x * 4;
+            if offset + 2 >= buffer.len() {
+                continue;
+            }
+            // PDFium bitmap is BGRA.
+            let b = buffer[offset];
+            let g = buffer[offset + 1];
+            let r = buffer[offset + 2];
+            if is_saturated_color(r, g, b) {
+                keys[y * width + x] = hue_bucket(r, g, b);
+            }
+        }
+    }
+
+    keys
+}
+
+fn is_saturated_color(r: u8, g: u8, b: u8) -> bool {
+    let max = r.max(g).max(b);
+    let min = r.min(g).min(b);
+    max > 80 && max - min > 50 && !(r < 80 && g < 80 && b < 80)
+}
+
+fn hue_bucket(r: u8, g: u8, b: u8) -> u8 {
+    let r = r as f32 / 255.0;
+    let g = g as f32 / 255.0;
+    let b = b as f32 / 255.0;
+    let max = r.max(g).max(b);
+    let min = r.min(g).min(b);
+    let delta = max - min;
+    if delta <= f32::EPSILON {
+        return 0;
+    }
+
+    let hue = if (max - r).abs() <= f32::EPSILON {
+        ((g - b) / delta).rem_euclid(6.0)
+    } else if (max - g).abs() <= f32::EPSILON {
+        (b - r) / delta + 2.0
+    } else {
+        (r - g) / delta + 4.0
+    };
+    ((hue * 6.0).round() as i32).rem_euclid(36) as u8
+}
+
+fn connected_components(keys: &[u8], width: usize, height: usize) -> Vec<Component> {
+    let mut seen = vec![false; keys.len()];
+    let mut out = Vec::new();
+
+    for idx in 0..keys.len() {
+        let key = keys[idx];
+        if key == EMPTY_COLOR_KEY || seen[idx] {
+            continue;
+        }
+
+        seen[idx] = true;
+        let mut queue = VecDeque::from([idx]);
+        let mut x1 = width;
+        let mut y1 = height;
+        let mut x2 = 0usize;
+        let mut y2 = 0usize;
+        let mut area = 0usize;
+
+        while let Some(cur) = queue.pop_front() {
+            area += 1;
+            let x = cur % width;
+            let y = cur / width;
+            x1 = x1.min(x);
+            y1 = y1.min(y);
+            x2 = x2.max(x);
+            y2 = y2.max(y);
+
+            let mut push_neighbor = |next: usize| {
+                if !seen[next] && keys[next] == key {
+                    seen[next] = true;
+                    queue.push_back(next);
+                }
+            };
+
+            if x > 0 {
+                push_neighbor(cur - 1);
+            }
+            if x + 1 < width {
+                push_neighbor(cur + 1);
+            }
+            if y > 0 {
+                push_neighbor(cur - width);
+            }
+            if y + 1 < height {
+                push_neighbor(cur + width);
+            }
+        }
+
+        out.push(Component {
+            x1,
+            y1,
+            x2,
+            y2,
+            area,
+            color_key: key,
+        });
+    }
+
+    out
+}
+
+fn filter_bar_components(
+    components: Vec<Component>,
+    width: usize,
+    height: usize,
+) -> Vec<Component> {
+    let min_area = ((width * height) as f32 * 0.00012).max(120.0) as usize;
+    let min_height = (height as f32 * 0.015).max(12.0) as usize;
+    let min_width = (width as f32 * 0.006).max(5.0) as usize;
+
+    let mut bars: Vec<_> = components
+        .into_iter()
+        .filter(|c| {
+            c.area >= min_area
+                && c.height() >= min_height
+                && c.width() >= min_width
+                && c.height() > c.width()
+        })
+        .collect();
+    bars.sort_by(|a, b| {
+        a.cx()
+            .total_cmp(&b.cx())
+            .then(a.color_key.cmp(&b.color_key))
+    });
+    bars
+}
+
+fn cluster_bars(bars: &[Component]) -> Vec<Vec<Component>> {
+    if bars.is_empty() {
+        return Vec::new();
+    }
+
+    let mut widths: Vec<f32> = bars.iter().map(|bar| bar.width() as f32).collect();
+    widths.sort_by(f32::total_cmp);
+    let median_width = widths[widths.len() / 2];
+    let threshold = (median_width * 1.9).max(28.0);
+
+    let mut clusters: Vec<Vec<Component>> = Vec::new();
+    for bar in bars.iter().cloned() {
+        let same_cluster = clusters
+            .last()
+            .and_then(|cluster| cluster.last())
+            .is_some_and(|prev| bar.cx() - prev.cx() <= threshold);
+        if same_cluster {
+            clusters.last_mut().unwrap().push(bar);
+        } else {
+            clusters.push(vec![bar]);
+        }
+    }
+
+    clusters
+}
+
+fn has_consistent_bar_groups(clusters: &[Vec<Component>]) -> bool {
+    if clusters.len() < 2
+        || clusters
+            .iter()
+            .any(|cluster| cluster.is_empty() || cluster.len() > 8)
+    {
+        return false;
+    }
+
+    let counts: Vec<usize> = clusters.iter().map(Vec::len).collect();
+    let min = counts.iter().copied().min().unwrap_or(0);
+    let max = counts.iter().copied().max().unwrap_or(0);
+    max.saturating_sub(min) <= 1
+}
+
+fn has_common_baseline(bars: &[Component], page_height_px: usize) -> bool {
+    if bars.len() < 2 {
+        return false;
+    }
+
+    let mut bottoms: Vec<usize> = bars.iter().map(|bar| bar.y2).collect();
+    bottoms.sort_unstable();
+    let median_bottom = bottoms[bottoms.len() / 2];
+    let tolerance = ((page_height_px as f32) * 0.025).max(8.0) as usize;
+
+    bottoms
+        .iter()
+        .filter(|bottom| bottom.abs_diff(median_bottom) <= tolerance)
+        .count()
+        * 2
+        >= bottoms.len()
+}
+
+fn fit_y_axis(
+    text_items: &[TextItem],
+    bars: &[Component],
+    scale_x: f32,
+    scale_y: f32,
+) -> Option<(f32, f32, f32)> {
+    let chart_x1 = bars.iter().map(|bar| bar.x1).min()? as f32;
+    let chart_y1 = bars.iter().map(|bar| bar.y1).min()? as f32;
+    let chart_y2 = bars.iter().map(|bar| bar.y2).max()? as f32;
+
+    let mut ticks = Vec::new();
+    for item in text_items {
+        let text = item.text.trim();
+        let Ok(value) = text.parse::<f32>() else {
+            continue;
+        };
+        if !value.is_finite() || value < 0.0 {
+            continue;
+        }
+        let cx = (item.x + item.width / 2.0) * scale_x;
+        let cy = (item.y + item.height / 2.0) * scale_y;
+        if cx < chart_x1 - 8.0 && cy >= chart_y1 - 180.0 && cy <= chart_y2 + 80.0 {
+            ticks.push((value, cy));
+        }
+    }
+
+    if ticks.len() < 2 {
+        return None;
+    }
+
+    let n = ticks.len() as f32;
+    let sum_y: f32 = ticks.iter().map(|(_, y)| *y).sum();
+    let sum_v: f32 = ticks.iter().map(|(v, _)| *v).sum();
+    let sum_yy: f32 = ticks.iter().map(|(_, y)| y * y).sum();
+    let sum_yv: f32 = ticks.iter().map(|(v, y)| v * y).sum();
+    let denom = n * sum_yy - sum_y * sum_y;
+    if denom.abs() <= f32::EPSILON {
+        return None;
+    }
+
+    let a = (n * sum_yv - sum_y * sum_v) / denom;
+    let b = (sum_v - a * sum_y) / n;
+    let max_tick = ticks.iter().map(|(v, _)| *v).fold(0.0, f32::max);
+    Some((a, b, max_tick))
+}
+
+fn extract_labels(
+    text_items: &[TextItem],
+    bars: &[Component],
+    clusters: &[Vec<Component>],
+    scale_x: f32,
+    scale_y: f32,
+) -> (Vec<String>, Vec<String>) {
+    let chart_x1 = bars.iter().map(|bar| bar.x1).min().unwrap_or(0) as f32;
+    let chart_x2 = bars.iter().map(|bar| bar.x2).max().unwrap_or(0) as f32;
+    let chart_y1 = bars.iter().map(|bar| bar.y1).min().unwrap_or(0) as f32;
+    let chart_y2 = bars.iter().map(|bar| bar.y2).max().unwrap_or(0) as f32;
+
+    let mut group_candidates: Vec<(f32, String)> = Vec::new();
+    let mut legend_candidates: Vec<(f32, String)> = Vec::new();
+
+    for item in text_items {
+        let label = item.text.trim();
+        if label.is_empty() || label.parse::<f32>().is_ok() {
+            continue;
+        }
+        let cx = (item.x + item.width / 2.0) * scale_x;
+        let cy = (item.y + item.height / 2.0) * scale_y;
+
+        if cx >= chart_x1 - 120.0
+            && cx <= chart_x2 + 120.0
+            && cy >= chart_y2
+            && cy <= chart_y2 + 110.0
+        {
+            group_candidates.push((cx, label.to_string()));
+        }
+        if cx > chart_x2 + 35.0 && cy >= chart_y1 - 110.0 && cy <= chart_y2 + 110.0 {
+            legend_candidates.push((cy, label.to_string()));
+        }
+    }
+
+    group_candidates.sort_by(|a, b| a.0.total_cmp(&b.0));
+    group_candidates.dedup_by(|a, b| a.1 == b.1);
+
+    let mut groups = Vec::with_capacity(clusters.len());
+    for (idx, cluster) in clusters.iter().enumerate() {
+        let center = cluster.iter().map(Component::cx).sum::<f32>() / cluster.len() as f32;
+        let label = group_candidates
+            .iter()
+            .min_by(|a, b| (a.0 - center).abs().total_cmp(&(b.0 - center).abs()))
+            .map(|(_, label)| label.clone())
+            .unwrap_or_else(|| format!("Group {}", idx + 1));
+        groups.push(label);
+    }
+
+    legend_candidates.sort_by(|a, b| a.0.total_cmp(&b.0));
+    legend_candidates.dedup_by(|a, b| a.1 == b.1);
+    let series_count = clusters.iter().map(Vec::len).max().unwrap_or(0);
+    let mut series: Vec<String> = legend_candidates
+        .into_iter()
+        .take(series_count)
+        .map(|(_, label)| label)
+        .collect();
+    while series.len() < series_count {
+        series.push(format!("Series {}", series.len() + 1));
+    }
+
+    (groups, series)
+}
+
+fn build_ascii_chart(
+    groups: &[String],
+    series: &[String],
+    values: &[Vec<f32>],
+    max_value: f32,
+) -> String {
+    let height = max_value.round().clamp(8.0, 20.0) as usize;
+    let group_w = (series.len() + 4).max(8);
+    let plot_w = group_w * groups.len();
+    let mut canvas = vec![vec![' '; plot_w]; height];
+
+    for (group_idx, row) in values.iter().enumerate() {
+        let base_x = group_idx * group_w + 2;
+        for (series_idx, value) in row.iter().enumerate() {
+            let bar_h = ((*value / max_value) * height as f32)
+                .round()
+                .clamp(1.0, height as f32) as usize;
+            let x = base_x + series_idx;
+            if x >= plot_w {
+                continue;
+            }
+            for y in height - bar_h..height {
+                canvas[y][x] = BAR_CHAR;
+            }
+        }
+    }
+
+    let mut lines = Vec::new();
+    lines.push(format!("       +{}+", "-".repeat(plot_w)));
+    for (y, row) in canvas.iter().enumerate() {
+        let value = max_value * (height - y) as f32 / height as f32;
+        let tick = if y == 0 || y == height - 1 || y % 2 == 0 {
+            format!("{value:>4.0}")
+        } else {
+            "    ".to_string()
+        };
+        lines.push(format!("{tick}   |{}|", row.iter().collect::<String>()));
+    }
+    lines.push(format!("   0   +{}+", "-".repeat(plot_w)));
+    lines.push(format!(
+        "       {}",
+        groups
+            .iter()
+            .map(|label| format!("{label:^group_w$}"))
+            .collect::<String>()
+            .trim_end()
+    ));
+    if !series.is_empty() {
+        lines.push(format!(
+            "       Bars in each group, left-to-right: {}",
+            series.join(" | ")
+        ));
+    }
+    lines.push(String::new());
+    lines.push("Values:".to_string());
+    for (group, row) in groups.iter().zip(values) {
+        let parts = series
+            .iter()
+            .zip(row)
+            .map(|(series, value)| format!("{series}={value:.1}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        lines.push(format!("  {group}: {parts}"));
+    }
+
+    lines.join("\n")
+}
+
+fn replace_chart_outline(page_text: &str, chart: &ChartItem) -> Option<String> {
+    let lines: Vec<&str> = page_text.lines().collect();
+    if lines.is_empty() || chart.groups.is_empty() {
+        return None;
+    }
+
+    let min_labels = chart.groups.len().min(3);
+    let row_line_idx = lines.iter().position(|line| {
+        chart
+            .groups
+            .iter()
+            .take(min_labels)
+            .filter(|label| line.contains(label.as_str()))
+            .count()
+            >= min_labels.min(2)
+    })?;
+
+    let max_tick = if chart.max_value.fract().abs() < 0.05 {
+        format!("{:.0}", chart.max_value)
+    } else {
+        format!("{:.1}", chart.max_value)
+    };
+
+    let search_start = row_line_idx.saturating_sub(24);
+    let mut start_idx = None;
+    for idx in (search_start..=row_line_idx).rev() {
+        let line = lines[idx];
+        if contains_number_token(line, &max_tick) {
+            start_idx = Some(idx);
+        }
+    }
+
+    let start_idx = start_idx.or_else(|| {
+        (search_start..=row_line_idx).find(|idx| {
+            lines[*idx]
+                .split_whitespace()
+                .any(|part| part.parse::<f32>().is_ok())
+        })
+    })?;
+
+    if row_line_idx <= start_idx {
+        return None;
+    }
+
+    let mut out = Vec::new();
+    out.extend_from_slice(&lines[..start_idx]);
+    out.extend(chart.ascii.lines());
+    out.extend_from_slice(&lines[row_line_idx + 1..]);
+    Some(out.join("\n") + "\n")
+}
+
+fn contains_number_token(line: &str, token: &str) -> bool {
+    line.split_whitespace().any(|part| part == token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn component(x1: usize, y1: usize, x2: usize, y2: usize) -> Component {
+        Component {
+            x1,
+            y1,
+            x2,
+            y2,
+            area: (x2 - x1 + 1) * (y2 - y1 + 1),
+            color_key: 0,
+        }
+    }
+
+    #[test]
+    fn saturated_color_detects_colored_bars_not_grey() {
+        assert!(is_saturated_color(50, 120, 220));
+        assert!(!is_saturated_color(200, 200, 200));
+        assert!(!is_saturated_color(20, 20, 20));
+    }
+
+    #[test]
+    fn ascii_chart_uses_block_bars() {
+        let ascii = build_ascii_chart(
+            &["A".into(), "B".into()],
+            &["S1".into(), "S2".into()],
+            &[vec![3.0, 6.0], vec![8.0, 2.0]],
+            10.0,
+        );
+        assert!(ascii.contains(BAR_CHAR));
+        assert!(ascii.contains("Bars in each group, left-to-right: S1 | S2"));
+    }
+
+    #[test]
+    fn replace_chart_outline_replaces_axis_block() {
+        let chart = ChartItem {
+            page_number: 1,
+            chart_type: ChartType::Bar,
+            x: 0.0,
+            y: 0.0,
+            width: 10.0,
+            height: 10.0,
+            ascii: "bar".into(),
+            series: vec!["Column 1".into()],
+            groups: vec!["Row 1".into(), "Row 2".into()],
+            values: vec![vec![1.0], vec![2.0]],
+            max_value: 12.0,
+        };
+        let text = "before\n  12\n   6 Column 1\n   0\n  Row 1 Row 2\nafter";
+        let replaced = replace_chart_outline(text, &chart).unwrap();
+        assert!(replaced.contains("bar"));
+        assert!(!replaced.contains("  Row 1 Row 2"));
+        assert!(replaced.contains("before"));
+        assert!(replaced.contains("after"));
+    }
+
+    #[test]
+    fn replace_chart_outline_returns_none_without_group_labels() {
+        let chart = ChartItem {
+            page_number: 1,
+            chart_type: ChartType::Bar,
+            x: 0.0,
+            y: 0.0,
+            width: 10.0,
+            height: 10.0,
+            ascii: "bar".into(),
+            series: vec!["Column 1".into()],
+            groups: vec!["Row 1".into(), "Row 2".into()],
+            values: vec![vec![1.0], vec![2.0]],
+            max_value: 12.0,
+        };
+        assert!(replace_chart_outline("plain text\nwithout chart", &chart).is_none());
+    }
+
+    #[test]
+    fn bar_group_confidence_accepts_consistent_grouped_bars() {
+        let clusters = vec![
+            vec![component(10, 10, 15, 100), component(18, 40, 23, 100)],
+            vec![component(50, 20, 55, 100), component(58, 35, 63, 100)],
+            vec![component(90, 30, 95, 100), component(98, 45, 103, 100)],
+        ];
+        assert!(has_consistent_bar_groups(&clusters));
+        assert!(has_common_baseline(
+            &clusters.into_iter().flatten().collect::<Vec<_>>(),
+            200
+        ));
+    }
+
+    #[test]
+    fn bar_group_confidence_rejects_scattered_visuals() {
+        let clusters = vec![
+            vec![component(10, 10, 15, 80)],
+            vec![component(50, 20, 55, 140), component(58, 35, 63, 140)],
+            vec![
+                component(90, 30, 95, 190),
+                component(98, 45, 103, 190),
+                component(106, 55, 111, 190),
+                component(114, 65, 119, 190),
+            ],
+        ];
+        assert!(!has_consistent_bar_groups(&clusters));
+
+        let no_common_baseline = vec![
+            component(10, 10, 15, 70),
+            component(30, 10, 35, 100),
+            component(50, 10, 55, 130),
+            component(70, 10, 75, 170),
+        ];
+        assert!(!has_common_baseline(&no_common_baseline, 200));
+    }
+
+    #[test]
+    fn fit_y_axis_uses_numeric_tick_positions() {
+        let bars = vec![component(200, 100, 210, 200), component(240, 150, 250, 200)];
+        let text_items = vec![
+            TextItem {
+                text: "10".into(),
+                x: 100.0,
+                y: 95.0,
+                width: 10.0,
+                height: 10.0,
+                ..Default::default()
+            },
+            TextItem {
+                text: "0".into(),
+                x: 100.0,
+                y: 195.0,
+                width: 10.0,
+                height: 10.0,
+                ..Default::default()
+            },
+        ];
+        let (a, b, max_tick) = fit_y_axis(&text_items, &bars, 1.0, 1.0).unwrap();
+        assert!((max_tick - 10.0).abs() < 0.01);
+        assert!((a * 100.0 + b - 10.0).abs() < 0.01);
+        assert!((a * 200.0 + b).abs() < 0.01);
+    }
+}

--- a/crates/liteparse/src/config.rs
+++ b/crates/liteparse/src/config.rs
@@ -30,6 +30,11 @@ pub struct LiteParseConfig {
     /// Inline embedded PDF images into page text as markdown data URI images.
     /// Disabled by default because it can make text/JSON output very large.
     pub inline_images: bool,
+    /// Detect supported vector charts and replace their text-only outlines with ASCII charts.
+    /// Disabled by default because it requires page rendering and is heuristic.
+    pub detect_charts: bool,
+    /// DPI used for chart detection rendering. Lower than OCR DPI by default for speed.
+    pub chart_detection_dpi: f32,
 }
 
 /// Supported output formats.
@@ -56,6 +61,8 @@ impl Default for LiteParseConfig {
             quiet: false,
             num_workers: default_num_workers(),
             inline_images: false,
+            detect_charts: false,
+            chart_detection_dpi: 100.0,
         }
     }
 }
@@ -137,6 +144,8 @@ mod tests {
         assert!(!c.preserve_very_small_text);
         assert!(!c.quiet);
         assert!(!c.inline_images);
+        assert!(!c.detect_charts);
+        assert_eq!(c.chart_detection_dpi, 100.0);
         assert!(c.password.is_none());
     }
 

--- a/crates/liteparse/src/config.rs
+++ b/crates/liteparse/src/config.rs
@@ -27,6 +27,9 @@ pub struct LiteParseConfig {
     pub quiet: bool,
     /// Number of concurrent OCR workers. Defaults to (number of CPU cores - 1), minimum 1.
     pub num_workers: usize,
+    /// Inline embedded PDF images into page text as markdown data URI images.
+    /// Disabled by default because it can make text/JSON output very large.
+    pub inline_images: bool,
 }
 
 /// Supported output formats.
@@ -52,6 +55,7 @@ impl Default for LiteParseConfig {
             password: None,
             quiet: false,
             num_workers: default_num_workers(),
+            inline_images: false,
         }
     }
 }
@@ -132,6 +136,7 @@ mod tests {
         assert_eq!(c.output_format, OutputFormat::Json);
         assert!(!c.preserve_very_small_text);
         assert!(!c.quiet);
+        assert!(!c.inline_images);
         assert!(c.password.is_none());
     }
 

--- a/crates/liteparse/src/extract.rs
+++ b/crates/liteparse/src/extract.rs
@@ -62,6 +62,7 @@ pub(crate) fn extract_pages_from_document(
             page_width: page.width(),
             page_height: page.height(),
             text_items,
+            images: Vec::new(),
         });
     }
 

--- a/crates/liteparse/src/image_merge.rs
+++ b/crates/liteparse/src/image_merge.rs
@@ -1,0 +1,146 @@
+use base64::Engine as _;
+use image::ImageEncoder;
+
+use crate::error::LiteParseError;
+use crate::types::{ImageItem, Page, TextItem};
+
+const MIN_IMAGE_SIZE_PT: f32 = 25.0;
+const MAX_PAGE_COVERAGE: f32 = 0.9;
+const IMAGE_PLACEHOLDER_FONT: &str = "IMAGE";
+
+/// Extract embedded PDF images into parsed pages.
+pub(crate) fn extract_images_into_pages(
+    document: &pdfium::Document,
+    pages: &mut [Page],
+) -> Result<(), LiteParseError> {
+    for page in pages {
+        let pdf_page = document.page((page.page_number - 1) as i32)?;
+        let image_objects = pdf_page.image_objects(MIN_IMAGE_SIZE_PT, MAX_PAGE_COVERAGE);
+
+        for (image_idx, info) in image_objects.into_iter().enumerate() {
+            let bitmap = pdf_page.render_image_object(info.image_obj_index)?;
+            if bitmap.width() <= 0 || bitmap.height() <= 0 {
+                continue;
+            }
+            let width = bitmap.width() as u32;
+            let height = bitmap.height() as u32;
+            let rgba = bitmap.to_rgba();
+            let png_bytes = encode_png(&rgba, width, height)?;
+            let base64 = base64::engine::general_purpose::STANDARD.encode(png_bytes);
+            let placeholder = image_placeholder(page.page_number, image_idx);
+
+            page.images.push(ImageItem {
+                x: info.bounds.x,
+                y: info.bounds.y,
+                width: info.bounds.width,
+                height: info.bounds.height,
+                mime_type: "image/png".to_string(),
+                base64,
+                placeholder: Some(placeholder.clone()),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Add short synthetic text placeholders so grid projection can place images
+/// in page text. Call this after OCR merging so placeholders do not suppress
+/// OCR text that overlaps image bounds.
+pub(crate) fn add_inline_image_placeholders(pages: &mut [Page]) {
+    for page in pages {
+        for image in &page.images {
+            let Some(placeholder) = &image.placeholder else {
+                continue;
+            };
+            page.text_items.push(TextItem {
+                text: placeholder.clone(),
+                x: image.x,
+                y: image.y,
+                // Use a normal text-sized synthetic box so the placeholder
+                // does not skew grid median character/line sizing.
+                width: placeholder.chars().count() as f32 * 6.0,
+                height: 12.0,
+                font_name: Some(IMAGE_PLACEHOLDER_FONT.to_string()),
+                font_size: Some(12.0),
+                ..Default::default()
+            });
+        }
+    }
+}
+
+pub(crate) fn is_inline_image_placeholder(item: &TextItem) -> bool {
+    item.font_name.as_deref() == Some(IMAGE_PLACEHOLDER_FONT)
+        && item.text.starts_with("[[LITEPARSE_IMAGE_")
+        && item.text.ends_with("]]")
+}
+
+pub(crate) fn replace_image_placeholders(mut text: String, images: &[ImageItem]) -> String {
+    for image in images {
+        if let Some(placeholder) = &image.placeholder {
+            let markdown = format!("![](data:{};base64,{})", image.mime_type, image.base64);
+            text = text.replace(placeholder, &markdown);
+        }
+    }
+
+    // Grid projection may indent the synthetic image placeholder based on its
+    // x coordinate. Inline image data URI lines should not keep that leading
+    // whitespace because consumers may treat it as preformatted markdown/code.
+    text.lines()
+        .map(|line| {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("![](data:image/") {
+                trimmed
+            } else {
+                line
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn image_placeholder(page_number: usize, image_idx: usize) -> String {
+    format!("[[LITEPARSE_IMAGE_{}_{}]]", page_number, image_idx)
+}
+
+fn encode_png(rgba: &[u8], width: u32, height: u32) -> Result<Vec<u8>, LiteParseError> {
+    let mut png_buf = Vec::new();
+    let encoder = image::codecs::png::PngEncoder::new(&mut png_buf);
+    encoder.write_image(rgba, width, height, image::ColorType::Rgba8.into())?;
+    Ok(png_buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_replace_image_placeholders_uses_empty_alt_markdown() {
+        let images = vec![ImageItem {
+            mime_type: "image/png".into(),
+            base64: "abc123".into(),
+            placeholder: Some("[[LITEPARSE_IMAGE_1_0]]".into()),
+            ..Default::default()
+        }];
+
+        let text =
+            replace_image_placeholders("before [[LITEPARSE_IMAGE_1_0]] after".into(), &images);
+        assert_eq!(text, "before ![](data:image/png;base64,abc123) after");
+    }
+
+    #[test]
+    fn test_replace_image_placeholders_trims_leading_spaces_on_image_lines() {
+        let images = vec![ImageItem {
+            mime_type: "image/png".into(),
+            base64: "abc123".into(),
+            placeholder: Some("[[LITEPARSE_IMAGE_1_0]]".into()),
+            ..Default::default()
+        }];
+
+        let text = replace_image_placeholders(
+            "before\n    [[LITEPARSE_IMAGE_1_0]]\nafter".into(),
+            &images,
+        );
+        assert_eq!(text, "before\n![](data:image/png;base64,abc123)\nafter");
+    }
+}

--- a/crates/liteparse/src/lib.rs
+++ b/crates/liteparse/src/lib.rs
@@ -9,7 +9,7 @@ pub use config::{LiteParseConfig, OutputFormat};
 pub use error::LiteParseError;
 pub use parser::{LiteParse, ParseResult, ScreenshotResult};
 pub use search::{SearchOptions, search_items};
-pub use types::{ParsedPage, TextItem};
+pub use types::{ImageItem, ParsedPage, TextItem};
 
 // ── Modules with user-facing types (visible in docs) ───────────────────
 pub mod config;
@@ -24,6 +24,8 @@ pub mod types;
 pub mod conversion;
 #[doc(hidden)]
 pub mod extract;
+#[doc(hidden)]
+pub mod image_merge;
 #[doc(hidden)]
 pub mod ocr;
 #[doc(hidden)]

--- a/crates/liteparse/src/lib.rs
+++ b/crates/liteparse/src/lib.rs
@@ -9,7 +9,7 @@ pub use config::{LiteParseConfig, OutputFormat};
 pub use error::LiteParseError;
 pub use parser::{LiteParse, ParseResult, ScreenshotResult};
 pub use search::{SearchOptions, search_items};
-pub use types::{ImageItem, ParsedPage, TextItem};
+pub use types::{ChartItem, ChartType, ImageItem, ParsedPage, TextItem};
 
 // ── Modules with user-facing types (visible in docs) ───────────────────
 pub mod config;
@@ -19,6 +19,8 @@ pub mod search;
 pub mod types;
 
 // ── Internal modules (available for binding crates, hidden from docs) ──
+#[doc(hidden)]
+pub mod chart;
 #[cfg(not(target_arch = "wasm32"))]
 #[doc(hidden)]
 pub mod conversion;

--- a/crates/liteparse/src/main.rs
+++ b/crates/liteparse/src/main.rs
@@ -89,6 +89,10 @@ struct ParseCommand {
     /// Number of concurrent OCR workers (default: CPU cores - 1)
     #[arg(long)]
     num_workers: Option<usize>,
+
+    /// Inline embedded PDF images into text as base64 markdown data URI images
+    #[arg(long)]
+    inline_images: bool,
 }
 
 #[derive(Args, Debug)]
@@ -172,6 +176,10 @@ struct BatchParseCommand {
     /// Number of concurrent OCR workers (default: CPU cores - 1)
     #[arg(long)]
     num_workers: Option<usize>,
+
+    /// Inline embedded PDF images into text as base64 markdown data URI images
+    #[arg(long)]
+    inline_images: bool,
 }
 
 #[derive(Args, Debug)]
@@ -213,6 +221,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 password: cmd.password,
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
+                inline_images: cmd.inline_images,
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {
@@ -295,6 +304,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 password: cmd.password,
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
+                inline_images: cmd.inline_images,
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {

--- a/crates/liteparse/src/main.rs
+++ b/crates/liteparse/src/main.rs
@@ -93,6 +93,14 @@ struct ParseCommand {
     /// Inline embedded PDF images into text as base64 markdown data URI images
     #[arg(long)]
     inline_images: bool,
+
+    /// Detect supported vector charts and render them as ASCII charts
+    #[arg(long)]
+    detect_charts: bool,
+
+    /// DPI for chart detection rendering
+    #[arg(long, default_value = "100")]
+    chart_detection_dpi: f32,
 }
 
 #[derive(Args, Debug)]
@@ -180,6 +188,14 @@ struct BatchParseCommand {
     /// Inline embedded PDF images into text as base64 markdown data URI images
     #[arg(long)]
     inline_images: bool,
+
+    /// Detect supported vector charts and render them as ASCII charts
+    #[arg(long)]
+    detect_charts: bool,
+
+    /// DPI for chart detection rendering
+    #[arg(long, default_value = "100")]
+    chart_detection_dpi: f32,
 }
 
 #[derive(Args, Debug)]
@@ -222,6 +238,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
                 inline_images: cmd.inline_images,
+                detect_charts: cmd.detect_charts,
+                chart_detection_dpi: cmd.chart_detection_dpi,
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {
@@ -305,6 +323,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
                 inline_images: cmd.inline_images,
+                detect_charts: cmd.detect_charts,
+                chart_detection_dpi: cmd.chart_detection_dpi,
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {

--- a/crates/liteparse/src/ocr_merge.rs
+++ b/crates/liteparse/src/ocr_merge.rs
@@ -481,6 +481,7 @@ mod tests {
             page_width: 100.0,
             page_height: 100.0,
             text_items: Vec::new(),
+            images: Vec::new(),
         }
     }
 
@@ -510,6 +511,7 @@ mod tests {
                 height: 50.0,
                 ..Default::default()
             }],
+            images: Vec::new(),
         }
     }
 
@@ -530,6 +532,7 @@ mod tests {
                 height: 5.0,
                 ..Default::default()
             }],
+            images: Vec::new(),
         }
     }
 

--- a/crates/liteparse/src/output/json.rs
+++ b/crates/liteparse/src/output/json.rs
@@ -2,6 +2,16 @@ use crate::types::ParsedPage;
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
+pub(crate) struct JsonImageItem {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+    pub mime_type: String,
+    pub base64: String,
+}
+
+#[derive(Debug, Serialize)]
 pub(crate) struct JsonTextItem {
     pub text: String,
     pub x: f32,
@@ -23,6 +33,8 @@ pub(crate) struct JsonPage {
     pub height: f32,
     pub text: String,
     pub text_items: Vec<JsonTextItem>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub images: Vec<JsonImageItem>,
 }
 
 #[derive(Debug, Serialize)]
@@ -52,6 +64,18 @@ pub(crate) fn build_json(pages: &[ParsedPage]) -> ParseResultJson {
                         font_name: item.font_name.clone(),
                         font_size: item.font_size,
                         confidence: item.confidence.or(Some(1.0)),
+                    })
+                    .collect(),
+                images: page
+                    .images
+                    .iter()
+                    .map(|image| JsonImageItem {
+                        x: image.x,
+                        y: image.y,
+                        width: image.width,
+                        height: image.height,
+                        mime_type: image.mime_type.clone(),
+                        base64: image.base64.clone(),
                     })
                     .collect(),
             })
@@ -91,6 +115,7 @@ mod tests {
             page_height: 792.0,
             text: "txt".into(),
             text_items: items,
+            images: vec![],
         }
     }
 

--- a/crates/liteparse/src/output/json.rs
+++ b/crates/liteparse/src/output/json.rs
@@ -1,4 +1,4 @@
-use crate::types::ParsedPage;
+use crate::types::{ChartType, ParsedPage};
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
@@ -27,6 +27,19 @@ pub(crate) struct JsonTextItem {
 }
 
 #[derive(Debug, Serialize)]
+pub(crate) struct JsonChartItem {
+    pub chart_type: ChartType,
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+    pub ascii: String,
+    pub series: Vec<String>,
+    pub groups: Vec<String>,
+    pub values: Vec<Vec<f32>>,
+}
+
+#[derive(Debug, Serialize)]
 pub(crate) struct JsonPage {
     pub page: usize,
     pub width: f32,
@@ -35,6 +48,8 @@ pub(crate) struct JsonPage {
     pub text_items: Vec<JsonTextItem>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub images: Vec<JsonImageItem>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub charts: Vec<JsonChartItem>,
 }
 
 #[derive(Debug, Serialize)]
@@ -78,6 +93,21 @@ pub(crate) fn build_json(pages: &[ParsedPage]) -> ParseResultJson {
                         base64: image.base64.clone(),
                     })
                     .collect(),
+                charts: page
+                    .charts
+                    .iter()
+                    .map(|chart| JsonChartItem {
+                        chart_type: chart.chart_type.clone(),
+                        x: chart.x,
+                        y: chart.y,
+                        width: chart.width,
+                        height: chart.height,
+                        ascii: chart.ascii.clone(),
+                        series: chart.series.clone(),
+                        groups: chart.groups.clone(),
+                        values: chart.values.clone(),
+                    })
+                    .collect(),
             })
             .collect(),
     }
@@ -116,6 +146,7 @@ mod tests {
             text: "txt".into(),
             text_items: items,
             images: vec![],
+            charts: vec![],
         }
     }
 

--- a/crates/liteparse/src/output/text.rs
+++ b/crates/liteparse/src/output/text.rs
@@ -20,6 +20,7 @@ mod tests {
             page_height: 0.0,
             text: text.into(),
             text_items: vec![],
+            images: vec![],
         }
     }
 

--- a/crates/liteparse/src/output/text.rs
+++ b/crates/liteparse/src/output/text.rs
@@ -21,6 +21,7 @@ mod tests {
             text: text.into(),
             text_items: vec![],
             images: vec![],
+            charts: vec![],
         }
     }
 

--- a/crates/liteparse/src/parser.rs
+++ b/crates/liteparse/src/parser.rs
@@ -3,6 +3,7 @@ use crate::config::{LiteParseConfig, parse_target_pages};
 use crate::conversion;
 use crate::error::LiteParseError;
 use crate::extract;
+use crate::image_merge;
 use crate::ocr::OcrEngine;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::ocr::http_simple::HttpOcrEngine;
@@ -97,11 +98,12 @@ impl LiteParse {
             .transpose()
             .map_err(|e| format!("invalid --target-pages: {}", e))?;
 
-        // Extract text (and pre-render OCR pages in one PDF load when OCR is on).
+        // Extract text. Keep the PDF document open when OCR or inline image
+        // extraction needs rendering from the same loaded document.
         let password = self.config.password.as_deref();
-        let (mut pages, ocr_rendered) = if self.config.ocr_enabled {
+        let (mut pages, ocr_rendered) = if self.config.ocr_enabled || self.config.inline_images {
             let document = extract::load_document_from_input(&validated_input, password)?;
-            let pages = extract::extract_pages_from_document(
+            let mut pages = extract::extract_pages_from_document(
                 &document,
                 target_pages.as_deref(),
                 self.config.max_pages,
@@ -112,15 +114,33 @@ impl LiteParse {
                 t_extract.duration_since(t0).as_secs_f64() * 1000.0,
                 pages.len()
             ));
-            let rendered = ocr_merge::render_pages_for_ocr(&document, &pages, self.config.dpi)?;
-            log(&format!(
-                "[liteparse] ocr render: {:.1}ms ({} pages)",
-                web_time::Instant::now()
-                    .duration_since(t_extract)
-                    .as_secs_f64()
-                    * 1000.0,
-                rendered.len()
-            ));
+
+            if self.config.inline_images {
+                let t_images = web_time::Instant::now();
+                image_merge::extract_images_into_pages(&document, &mut pages)?;
+                log(&format!(
+                    "[liteparse] images: {:.1}ms",
+                    web_time::Instant::now()
+                        .duration_since(t_images)
+                        .as_secs_f64()
+                        * 1000.0
+                ));
+            }
+
+            let rendered = if self.config.ocr_enabled {
+                let rendered = ocr_merge::render_pages_for_ocr(&document, &pages, self.config.dpi)?;
+                log(&format!(
+                    "[liteparse] ocr render: {:.1}ms ({} pages)",
+                    web_time::Instant::now()
+                        .duration_since(t_extract)
+                        .as_secs_f64()
+                        * 1000.0,
+                    rendered.len()
+                ));
+                rendered
+            } else {
+                Vec::new()
+            };
             (pages, rendered)
         } else {
             let pages = extract::extract_pages_from_input(
@@ -184,6 +204,10 @@ impl LiteParse {
             "[liteparse] ocr: {:.1}ms",
             t_ocr.duration_since(t1).as_secs_f64() * 1000.0
         ));
+
+        if self.config.inline_images {
+            image_merge::add_inline_image_placeholders(&mut pages);
+        }
 
         // Grid projection
         let parsed_pages = projection::project_pages_to_grid(pages);

--- a/crates/liteparse/src/parser.rs
+++ b/crates/liteparse/src/parser.rs
@@ -1,3 +1,4 @@
+use crate::chart;
 use crate::config::{LiteParseConfig, parse_target_pages};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::conversion;
@@ -101,61 +102,83 @@ impl LiteParse {
         // Extract text. Keep the PDF document open when OCR or inline image
         // extraction needs rendering from the same loaded document.
         let password = self.config.password.as_deref();
-        let (mut pages, ocr_rendered) = if self.config.ocr_enabled || self.config.inline_images {
-            let document = extract::load_document_from_input(&validated_input, password)?;
-            let mut pages = extract::extract_pages_from_document(
-                &document,
-                target_pages.as_deref(),
-                self.config.max_pages,
-            )?;
-            let t_extract = web_time::Instant::now();
-            log(&format!(
-                "[liteparse] extract: {:.1}ms ({} pages)",
-                t_extract.duration_since(t0).as_secs_f64() * 1000.0,
-                pages.len()
-            ));
-
-            if self.config.inline_images {
-                let t_images = web_time::Instant::now();
-                image_merge::extract_images_into_pages(&document, &mut pages)?;
+        let (mut pages, ocr_rendered, detected_charts) =
+            if self.config.ocr_enabled || self.config.inline_images || self.config.detect_charts {
+                let document = extract::load_document_from_input(&validated_input, password)?;
+                let mut pages = extract::extract_pages_from_document(
+                    &document,
+                    target_pages.as_deref(),
+                    self.config.max_pages,
+                )?;
+                let t_extract = web_time::Instant::now();
                 log(&format!(
-                    "[liteparse] images: {:.1}ms",
-                    web_time::Instant::now()
-                        .duration_since(t_images)
-                        .as_secs_f64()
-                        * 1000.0
+                    "[liteparse] extract: {:.1}ms ({} pages)",
+                    t_extract.duration_since(t0).as_secs_f64() * 1000.0,
+                    pages.len()
                 ));
-            }
 
-            let rendered = if self.config.ocr_enabled {
-                let rendered = ocr_merge::render_pages_for_ocr(&document, &pages, self.config.dpi)?;
-                log(&format!(
-                    "[liteparse] ocr render: {:.1}ms ({} pages)",
-                    web_time::Instant::now()
-                        .duration_since(t_extract)
-                        .as_secs_f64()
-                        * 1000.0,
-                    rendered.len()
-                ));
-                rendered
+                if self.config.inline_images {
+                    let t_images = web_time::Instant::now();
+                    image_merge::extract_images_into_pages(&document, &mut pages)?;
+                    log(&format!(
+                        "[liteparse] images: {:.1}ms",
+                        web_time::Instant::now()
+                            .duration_since(t_images)
+                            .as_secs_f64()
+                            * 1000.0
+                    ));
+                }
+
+                let detected_charts = if self.config.detect_charts {
+                    let t_charts = web_time::Instant::now();
+                    let charts = chart::detect_charts_for_pages(
+                        &document,
+                        &pages,
+                        self.config.chart_detection_dpi,
+                    )?;
+                    log(&format!(
+                        "[liteparse] charts: {:.1}ms ({} pages)",
+                        web_time::Instant::now()
+                            .duration_since(t_charts)
+                            .as_secs_f64()
+                            * 1000.0,
+                        charts.len()
+                    ));
+                    charts
+                } else {
+                    Vec::new()
+                };
+
+                let rendered = if self.config.ocr_enabled {
+                    let rendered =
+                        ocr_merge::render_pages_for_ocr(&document, &pages, self.config.dpi)?;
+                    log(&format!(
+                        "[liteparse] ocr render: {:.1}ms ({} pages)",
+                        web_time::Instant::now()
+                            .duration_since(t_extract)
+                            .as_secs_f64()
+                            * 1000.0,
+                        rendered.len()
+                    ));
+                    rendered
+                } else {
+                    Vec::new()
+                };
+                (pages, rendered, detected_charts)
             } else {
-                Vec::new()
+                let pages = extract::extract_pages_from_input(
+                    &validated_input,
+                    target_pages.as_deref(),
+                    self.config.max_pages,
+                    password,
+                )?;
+                log(&format!(
+                    "[liteparse] extract: {:.1}ms ({} pages)",
+                    web_time::Instant::now().duration_since(t0).as_secs_f64() * 1000.0,
+                    pages.len()
+                ));
+                (pages, Vec::new(), Vec::new())
             };
-            (pages, rendered)
-        } else {
-            let pages = extract::extract_pages_from_input(
-                &validated_input,
-                target_pages.as_deref(),
-                self.config.max_pages,
-                password,
-            )?;
-            log(&format!(
-                "[liteparse] extract: {:.1}ms ({} pages)",
-                web_time::Instant::now().duration_since(t0).as_secs_f64() * 1000.0,
-                pages.len()
-            ));
-            (pages, Vec::new())
-        };
         let t1 = web_time::Instant::now();
 
         // OCR pass
@@ -210,7 +233,10 @@ impl LiteParse {
         }
 
         // Grid projection
-        let parsed_pages = projection::project_pages_to_grid(pages);
+        let mut parsed_pages = projection::project_pages_to_grid(pages);
+        if self.config.detect_charts {
+            chart::apply_charts_to_parsed_pages(&mut parsed_pages, &detected_charts);
+        }
         let t2 = web_time::Instant::now();
         log(&format!(
             "[liteparse] project: {:.1}ms",

--- a/crates/liteparse/src/projection.rs
+++ b/crates/liteparse/src/projection.rs
@@ -2698,6 +2698,7 @@ pub fn project_pages_to_grid(pages: Vec<Page>) -> Vec<ParsedPage> {
                     })
                     .collect(),
                 images: page.images,
+                charts: Vec::new(),
             }
         })
         .collect()

--- a/crates/liteparse/src/projection.rs
+++ b/crates/liteparse/src/projection.rs
@@ -1,3 +1,4 @@
+use crate::image_merge;
 use crate::types::*;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
@@ -2678,6 +2679,7 @@ pub fn project_pages_to_grid(pages: Vec<Page>) -> Vec<ParsedPage> {
                 .collect();
 
             let (projected_items, text) = project_to_grid(&page, projection_boxes);
+            let text = image_merge::replace_image_placeholders(text, &page.images);
             ParsedPage {
                 page_number: page.page_number,
                 page_width: page.page_width,
@@ -2685,6 +2687,7 @@ pub fn project_pages_to_grid(pages: Vec<Page>) -> Vec<ParsedPage> {
                 text,
                 text_items: projected_items
                     .into_iter()
+                    .filter(|proj| !image_merge::is_inline_image_placeholder(&proj.item))
                     .map(|proj| TextItem {
                         x: proj.orig_x,
                         y: proj.orig_y,
@@ -2694,6 +2697,7 @@ pub fn project_pages_to_grid(pages: Vec<Page>) -> Vec<ParsedPage> {
                         ..proj.item
                     })
                     .collect(),
+                images: page.images,
             }
         })
         .collect()
@@ -2737,6 +2741,7 @@ mod tests {
             page_width: 612.0,
             page_height: 792.0,
             text_items: Vec::new(),
+            images: Vec::new(),
         };
         let projection_boxes = vec![
             projected_item("", 10.0, 0.0, 10.0),
@@ -2755,6 +2760,7 @@ mod tests {
             page_width: 612.0,
             page_height: 792.0,
             text_items: Vec::new(),
+            images: Vec::new(),
         }];
 
         let parsed = project_pages_to_grid(pages);
@@ -2789,6 +2795,7 @@ mod tests {
                     ..Default::default()
                 },
             ],
+            images: Vec::new(),
         }];
 
         let parsed = project_pages_to_grid(pages);
@@ -2828,6 +2835,7 @@ mod tests {
                     ..Default::default()
                 },
             ],
+            images: Vec::new(),
         }];
 
         let parsed = project_pages_to_grid(pages);

--- a/crates/liteparse/src/types.rs
+++ b/crates/liteparse/src/types.rs
@@ -55,6 +55,19 @@ pub struct TextItem {
     pub confidence: Option<f32>,
 }
 
+/// Represents an embedded image extracted from a PDF page.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ImageItem {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+    pub mime_type: String,
+    pub base64: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub placeholder: Option<String>,
+}
+
 #[doc(hidden)]
 #[derive(Debug, Serialize)]
 pub struct Page {
@@ -62,6 +75,8 @@ pub struct Page {
     pub page_width: f32,
     pub page_height: f32,
     pub text_items: Vec<TextItem>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub images: Vec<ImageItem>,
 }
 
 /// Represents a fully parsed page with projected text layout.
@@ -72,6 +87,8 @@ pub struct ParsedPage {
     pub page_height: f32,
     pub text: String,
     pub text_items: Vec<TextItem>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub images: Vec<ImageItem>,
 }
 
 #[doc(hidden)]
@@ -155,6 +172,7 @@ mod tests {
             page_width: 100.0,
             page_height: 200.0,
             text_items: vec![sample_item()],
+            images: Vec::new(),
         };
         let s = serde_json::to_string(&p).unwrap();
         assert!(s.contains("\"page_number\":1"));

--- a/crates/liteparse/src/types.rs
+++ b/crates/liteparse/src/types.rs
@@ -68,6 +68,32 @@ pub struct ImageItem {
     pub placeholder: Option<String>,
 }
 
+/// Supported chart types for detected visual charts.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ChartType {
+    Bar,
+    Line,
+    Pie,
+    Radar,
+}
+
+/// Represents a detected visual chart and its text/structured representation.
+#[derive(Debug, Clone, Serialize)]
+pub struct ChartItem {
+    pub page_number: usize,
+    pub chart_type: ChartType,
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+    pub ascii: String,
+    pub series: Vec<String>,
+    pub groups: Vec<String>,
+    pub values: Vec<Vec<f32>>,
+    pub max_value: f32,
+}
+
 #[doc(hidden)]
 #[derive(Debug, Serialize)]
 pub struct Page {
@@ -89,6 +115,8 @@ pub struct ParsedPage {
     pub text_items: Vec<TextItem>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub images: Vec<ImageItem>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub charts: Vec<ChartItem>,
 }
 
 #[doc(hidden)]

--- a/crates/pdfium/src/lib.rs
+++ b/crates/pdfium/src/lib.rs
@@ -12,7 +12,7 @@ pub use document::Document;
 pub use error::PdfiumError;
 pub use font::{Font, FontType};
 pub use library::Library;
-pub use page::{ImageBounds, Page, ViewportTransform};
+pub use page::{ImageBounds, ImageObjectInfo, Page, ViewportTransform};
 pub use text_page::{TextChar, TextCharIter, TextPage};
 pub use types::*;
 

--- a/crates/pdfium/src/page.rs
+++ b/crates/pdfium/src/page.rs
@@ -17,6 +17,14 @@ pub struct ImageBounds {
     pub height: f32,
 }
 
+/// Embedded image object metadata, including the image-object index needed
+/// to render the image via [`Page::render_image_object`].
+#[derive(Debug, Clone, Copy)]
+pub struct ImageObjectInfo {
+    pub image_obj_index: usize,
+    pub bounds: ImageBounds,
+}
+
 pub struct Page<'doc> {
     pub(crate) handle: pdfium_sys::FPDF_PAGE,
     pub(crate) doc_handle: pdfium_sys::FPDF_DOCUMENT,
@@ -152,10 +160,22 @@ impl Page<'_> {
     /// Filters out images smaller than `min_size_pt` and images covering more than
     /// `max_page_coverage` fraction of the page.
     pub fn image_bounds(&self, min_size_pt: f32, max_page_coverage: f32) -> Vec<ImageBounds> {
+        self.image_objects(min_size_pt, max_page_coverage)
+            .into_iter()
+            .map(|info| info.bounds)
+            .collect()
+    }
+
+    /// Extract embedded image object metadata on this page.
+    ///
+    /// The returned `image_obj_index` is the index among image objects only,
+    /// matching the index expected by [`Page::render_image_object`].
+    pub fn image_objects(&self, min_size_pt: f32, max_page_coverage: f32) -> Vec<ImageObjectInfo> {
         let page_width = self.width();
         let page_height = self.height();
         let obj_count = unsafe { ffi!(FPDFPage_CountObjects(self.handle)) };
         let mut results = Vec::new();
+        let mut image_idx = 0usize;
 
         for i in 0..obj_count {
             let obj = unsafe { ffi!(FPDFPage_GetObject(self.handle, i)) };
@@ -182,26 +202,29 @@ impl Page<'_> {
                 ))
             };
             if ok == 0 {
+                image_idx += 1;
                 continue;
             }
 
             let w = right - left;
             let h = top - bottom;
 
-            if w < min_size_pt || h < min_size_pt {
-                continue;
+            if w >= min_size_pt
+                && h >= min_size_pt
+                && !(w > page_width * max_page_coverage && h > page_height * max_page_coverage)
+            {
+                // Convert from PDF coords (bottom-left origin) to viewport (top-left origin)
+                results.push(ImageObjectInfo {
+                    image_obj_index: image_idx,
+                    bounds: ImageBounds {
+                        x: left,
+                        y: page_height - top,
+                        width: w,
+                        height: h,
+                    },
+                });
             }
-            if w > page_width * max_page_coverage && h > page_height * max_page_coverage {
-                continue;
-            }
-
-            // Convert from PDF coords (bottom-left origin) to viewport (top-left origin)
-            results.push(ImageBounds {
-                x: left,
-                y: page_height - top,
-                width: w,
-                height: h,
-            });
+            image_idx += 1;
         }
 
         results

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -42,6 +42,7 @@ const parser = new LiteParse({
   password: undefined,           // Password for protected documents
   quiet: false,                  // Suppress progress output
   numWorkers: 4,                 // Concurrent OCR workers
+  inlineImages: false,           // Inline embedded images as base64 markdown images
 });
 ```
 

--- a/packages/node/native.d.ts
+++ b/packages/node/native.d.ts
@@ -30,6 +30,10 @@ export interface JsLiteParseConfig {
   numWorkers?: number
   /** Inline embedded PDF images into text as base64 markdown data URI images. */
   inlineImages?: boolean
+  /** Detect supported vector charts and render them as ASCII charts. */
+  detectCharts?: boolean
+  /** DPI for chart detection rendering. */
+  chartDetectionDpi?: number
 }
 export interface JsTextItem {
   text: string
@@ -49,6 +53,17 @@ export interface JsImageItem {
   mimeType: string
   base64: string
 }
+export interface JsChartItem {
+  chartType: string
+  x: number
+  y: number
+  width: number
+  height: number
+  ascii: string
+  series: Array<string>
+  groups: Array<string>
+  values: Array<Array<number>>
+}
 export interface JsParsedPage {
   pageNum: number
   width: number
@@ -56,6 +71,7 @@ export interface JsParsedPage {
   text: string
   textItems: Array<JsTextItem>
   images: Array<JsImageItem>
+  charts: Array<JsChartItem>
 }
 export interface JsParseResult {
   pages: Array<JsParsedPage>

--- a/packages/node/native.d.ts
+++ b/packages/node/native.d.ts
@@ -26,6 +26,10 @@ export interface JsLiteParseConfig {
   password?: string
   /** Suppress progress output. */
   quiet?: boolean
+  /** Number of concurrent OCR workers (default: CPU cores - 1). */
+  numWorkers?: number
+  /** Inline embedded PDF images into text as base64 markdown data URI images. */
+  inlineImages?: boolean
 }
 export interface JsTextItem {
   text: string
@@ -37,12 +41,21 @@ export interface JsTextItem {
   fontSize?: number
   confidence?: number
 }
+export interface JsImageItem {
+  x: number
+  y: number
+  width: number
+  height: number
+  mimeType: string
+  base64: string
+}
 export interface JsParsedPage {
   pageNum: number
   width: number
   height: number
   text: string
   textItems: Array<JsTextItem>
+  images: Array<JsImageItem>
 }
 export interface JsParseResult {
   pages: Array<JsParsedPage>
@@ -54,6 +67,8 @@ export interface JsScreenshotResult {
   height: number
   imageBuffer: Buffer
 }
+/** Search text items for phrase matches, returning merged items with combined bounding boxes. */
+export declare function searchItems(items: Array<JsTextItem>, phrase: string, caseSensitive?: boolean | undefined | null): Array<JsTextItem>
 /** Main LiteParse parser class. */
 export declare class LiteParse {
   /**
@@ -63,7 +78,12 @@ export declare class LiteParse {
   constructor(config?: JsLiteParseConfig | undefined | null)
   /** Parse a document. Accepts a file path (string) or raw PDF bytes (Buffer). */
   parse(input: string | Buffer): Promise<JsParseResult>
-  /** Take screenshots of document pages. Returns PNG image buffers. */
+  /**
+   * Take screenshots of document pages. Returns PNG image buffers.
+   *
+   * Non-PDF files are automatically converted to PDF before rendering when
+   * LibreOffice/ImageMagick are available.
+   */
   screenshot(input: string | Buffer, pageNumbers?: Array<number> | undefined | null): Promise<Array<JsScreenshotResult>>
   /** Get the current configuration. */
   get config(): JsLiteParseConfig

--- a/packages/node/src/cli.ts
+++ b/packages/node/src/cli.ts
@@ -8,7 +8,7 @@ import { join, relative, parse as parsePath } from "node:path";
 program
   .name("liteparse")
   .description("Fast, lightweight PDF and document parsing")
-  .version("2.0.0");
+  .version("2.0.6");
 
 program
   .command("parse")
@@ -30,6 +30,7 @@ program
   .option("--config <file>", "JSON config file path")
   .option("-q, --quiet", "Suppress progress output")
   .option("--num-workers <n>", "Number of concurrent OCR workers", parseInt)
+  .option("--inline-images", "Inline embedded PDF images into text as base64 markdown images")
   .action(async (file: string, opts: Record<string, unknown>) => {
     try {
       const config: Partial<LiteParseConfig> = {};
@@ -55,6 +56,7 @@ program
       if (opts.password) config.password = opts.password as string;
       if (opts.quiet) config.quiet = true;
       if (opts.numWorkers) config.numWorkers = opts.numWorkers as number;
+      if (opts.inlineImages) config.inlineImages = true;
 
       // Default CLI output to text (library defaults to json)
       if (!config.outputFormat) config.outputFormat = "text";
@@ -72,6 +74,7 @@ program
                   height: p.height,
                   text: p.text,
                   textItems: p.textItems,
+                  images: p.images,
                 })),
               },
               null,
@@ -171,6 +174,7 @@ program
   .option("--password <password>", "Password for encrypted documents")
   .option("-q, --quiet", "Suppress progress output")
   .option("--num-workers <n>", "Number of concurrent OCR workers", parseInt)
+  .option("--inline-images", "Inline embedded PDF images into text as base64 markdown images")
   .action(
     async (
       inputDir: string,
@@ -190,6 +194,7 @@ program
         if (opts.password) config.password = opts.password as string;
         if (opts.quiet) config.quiet = true;
         if (opts.numWorkers) config.numWorkers = opts.numWorkers as number;
+        if (opts.inlineImages) config.inlineImages = true;
 
         const parser = new LiteParse(config);
         const outExt = format === "json" ? ".json" : ".txt";
@@ -246,6 +251,7 @@ program
                         height: p.height,
                         text: p.text,
                         textItems: p.textItems,
+                        images: p.images,
                       })),
                     },
                     null,

--- a/packages/node/src/cli.ts
+++ b/packages/node/src/cli.ts
@@ -31,6 +31,8 @@ program
   .option("-q, --quiet", "Suppress progress output")
   .option("--num-workers <n>", "Number of concurrent OCR workers", parseInt)
   .option("--inline-images", "Inline embedded PDF images into text as base64 markdown images")
+  .option("--detect-charts", "Detect supported vector charts and render them as ASCII charts")
+  .option("--chart-detection-dpi <dpi>", "DPI for chart detection rendering", parseFloat)
   .action(async (file: string, opts: Record<string, unknown>) => {
     try {
       const config: Partial<LiteParseConfig> = {};
@@ -57,6 +59,8 @@ program
       if (opts.quiet) config.quiet = true;
       if (opts.numWorkers) config.numWorkers = opts.numWorkers as number;
       if (opts.inlineImages) config.inlineImages = true;
+      if (opts.detectCharts) config.detectCharts = true;
+      if (opts.chartDetectionDpi) config.chartDetectionDpi = opts.chartDetectionDpi as number;
 
       // Default CLI output to text (library defaults to json)
       if (!config.outputFormat) config.outputFormat = "text";
@@ -75,6 +79,7 @@ program
                   text: p.text,
                   textItems: p.textItems,
                   images: p.images,
+                  charts: p.charts,
                 })),
               },
               null,
@@ -175,6 +180,8 @@ program
   .option("-q, --quiet", "Suppress progress output")
   .option("--num-workers <n>", "Number of concurrent OCR workers", parseInt)
   .option("--inline-images", "Inline embedded PDF images into text as base64 markdown images")
+  .option("--detect-charts", "Detect supported vector charts and render them as ASCII charts")
+  .option("--chart-detection-dpi <dpi>", "DPI for chart detection rendering", parseFloat)
   .action(
     async (
       inputDir: string,
@@ -195,6 +202,8 @@ program
         if (opts.quiet) config.quiet = true;
         if (opts.numWorkers) config.numWorkers = opts.numWorkers as number;
         if (opts.inlineImages) config.inlineImages = true;
+        if (opts.detectCharts) config.detectCharts = true;
+        if (opts.chartDetectionDpi) config.chartDetectionDpi = opts.chartDetectionDpi as number;
 
         const parser = new LiteParse(config);
         const outExt = format === "json" ? ".json" : ".txt";

--- a/packages/node/src/lib.ts
+++ b/packages/node/src/lib.ts
@@ -3,6 +3,7 @@ import {
   type LiteParseNative,
   type LiteParseNativeConfig,
   type NativeParseResult,
+  type NativeImageItem,
   type NativeParsedPage,
   type NativeTextItem,
 } from "./native.js";
@@ -27,6 +28,7 @@ export interface LiteParseConfig {
   password?: string;
   quiet: boolean;
   numWorkers: number;
+  inlineImages: boolean;
 }
 
 export interface TextItem {
@@ -40,12 +42,22 @@ export interface TextItem {
   confidence?: number;
 }
 
+export interface ImageItem {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  mimeType: string;
+  base64: string;
+}
+
 export interface ParsedPage {
   pageNum: number;
   width: number;
   height: number;
   text: string;
   textItems: TextItem[];
+  images: ImageItem[];
 }
 
 export interface ParseResult {
@@ -82,6 +94,7 @@ export class LiteParse {
       password: userConfig.password,
       quiet: userConfig.quiet,
       numWorkers: userConfig.numWorkers,
+      inlineImages: userConfig.inlineImages,
     };
 
     this._native = new native.LiteParse(nativeConfig);
@@ -101,6 +114,7 @@ export class LiteParse {
       password: resolved.password ?? undefined,
       quiet: resolved.quiet ?? false,
       numWorkers: resolved.numWorkers ?? 1,
+      inlineImages: resolved.inlineImages ?? false,
     };
   }
 
@@ -145,6 +159,18 @@ function toPage(p: NativeParsedPage): ParsedPage {
     height: p.height,
     text: p.text,
     textItems: p.textItems.map(toTextItem),
+    images: (p.images ?? []).map(toImageItem),
+  };
+}
+
+function toImageItem(item: NativeImageItem): ImageItem {
+  return {
+    x: item.x,
+    y: item.y,
+    width: item.width,
+    height: item.height,
+    mimeType: item.mimeType,
+    base64: item.base64,
   };
 }
 

--- a/packages/node/src/lib.ts
+++ b/packages/node/src/lib.ts
@@ -3,6 +3,7 @@ import {
   type LiteParseNative,
   type LiteParseNativeConfig,
   type NativeParseResult,
+  type NativeChartItem,
   type NativeImageItem,
   type NativeParsedPage,
   type NativeTextItem,
@@ -29,6 +30,8 @@ export interface LiteParseConfig {
   quiet: boolean;
   numWorkers: number;
   inlineImages: boolean;
+  detectCharts: boolean;
+  chartDetectionDpi: number;
 }
 
 export interface TextItem {
@@ -51,6 +54,18 @@ export interface ImageItem {
   base64: string;
 }
 
+export interface ChartItem {
+  chartType: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  ascii: string;
+  series: string[];
+  groups: string[];
+  values: number[][];
+}
+
 export interface ParsedPage {
   pageNum: number;
   width: number;
@@ -58,6 +73,7 @@ export interface ParsedPage {
   text: string;
   textItems: TextItem[];
   images: ImageItem[];
+  charts: ChartItem[];
 }
 
 export interface ParseResult {
@@ -95,6 +111,8 @@ export class LiteParse {
       quiet: userConfig.quiet,
       numWorkers: userConfig.numWorkers,
       inlineImages: userConfig.inlineImages,
+      detectCharts: userConfig.detectCharts,
+      chartDetectionDpi: userConfig.chartDetectionDpi,
     };
 
     this._native = new native.LiteParse(nativeConfig);
@@ -115,6 +133,8 @@ export class LiteParse {
       quiet: resolved.quiet ?? false,
       numWorkers: resolved.numWorkers ?? 1,
       inlineImages: resolved.inlineImages ?? false,
+      detectCharts: resolved.detectCharts ?? false,
+      chartDetectionDpi: resolved.chartDetectionDpi ?? 100,
     };
   }
 
@@ -160,6 +180,21 @@ function toPage(p: NativeParsedPage): ParsedPage {
     text: p.text,
     textItems: p.textItems.map(toTextItem),
     images: (p.images ?? []).map(toImageItem),
+    charts: (p.charts ?? []).map(toChartItem),
+  };
+}
+
+function toChartItem(item: NativeChartItem): ChartItem {
+  return {
+    chartType: item.chartType,
+    x: item.x,
+    y: item.y,
+    width: item.width,
+    height: item.height,
+    ascii: item.ascii,
+    series: item.series,
+    groups: item.groups,
+    values: item.values,
   };
 }
 

--- a/packages/node/src/native.ts
+++ b/packages/node/src/native.ts
@@ -33,6 +33,8 @@ export interface LiteParseNativeConfig {
   quiet?: boolean;
   numWorkers?: number;
   inlineImages?: boolean;
+  detectCharts?: boolean;
+  chartDetectionDpi?: number;
 }
 
 export interface NativeTextItem {
@@ -55,6 +57,18 @@ export interface NativeImageItem {
   base64: string;
 }
 
+export interface NativeChartItem {
+  chartType: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  ascii: string;
+  series: string[];
+  groups: string[];
+  values: number[][];
+}
+
 export interface NativeParsedPage {
   pageNum: number;
   width: number;
@@ -62,6 +76,7 @@ export interface NativeParsedPage {
   text: string;
   textItems: NativeTextItem[];
   images: NativeImageItem[];
+  charts: NativeChartItem[];
 }
 
 export interface NativeParseResult {

--- a/packages/node/src/native.ts
+++ b/packages/node/src/native.ts
@@ -32,6 +32,7 @@ export interface LiteParseNativeConfig {
   password?: string;
   quiet?: boolean;
   numWorkers?: number;
+  inlineImages?: boolean;
 }
 
 export interface NativeTextItem {
@@ -45,12 +46,22 @@ export interface NativeTextItem {
   confidence?: number;
 }
 
+export interface NativeImageItem {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  mimeType: string;
+  base64: string;
+}
+
 export interface NativeParsedPage {
   pageNum: number;
   width: number;
   height: number;
   text: string;
   textItems: NativeTextItem[];
+  images: NativeImageItem[];
 }
 
 export interface NativeParseResult {

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -41,6 +41,7 @@ parser = LiteParse(
     password=None,                 # Password for protected documents
     quiet=False,                   # Suppress progress output
     num_workers=4,                 # Concurrent OCR workers
+    inline_images=False,           # Inline embedded images as base64 markdown images
 )
 ```
 

--- a/packages/python/liteparse/parser.py
+++ b/packages/python/liteparse/parser.py
@@ -76,6 +76,7 @@ class LiteParse:
         password: Optional[str] = None,
         quiet: Optional[bool] = None,
         num_workers: Optional[int] = None,
+        inline_images: Optional[bool] = None,
     ):
         """
         Initialize LiteParse parser.
@@ -93,6 +94,7 @@ class LiteParse:
             password: Password for encrypted/protected documents
             quiet: Suppress progress output
             num_workers: Number of concurrent OCR workers (default: CPU cores - 1)
+            inline_images: Inline embedded PDF images into text as base64 markdown images
         """
         kwargs = {}
         if ocr_enabled is not None:
@@ -119,6 +121,8 @@ class LiteParse:
             kwargs["quiet"] = quiet
         if num_workers is not None:
             kwargs["num_workers"] = num_workers
+        if inline_images is not None:
+            kwargs["inline_images"] = inline_images
 
         self._native = _NativeLiteParse(**kwargs)
 
@@ -215,6 +219,7 @@ class LiteParse:
             password=cfg.password,
             quiet=cfg.quiet,
             num_workers=cfg.num_workers,
+            inline_images=cfg.inline_images,
         )
 
     def __repr__(self) -> str:

--- a/packages/python/liteparse/parser.py
+++ b/packages/python/liteparse/parser.py
@@ -77,6 +77,8 @@ class LiteParse:
         quiet: Optional[bool] = None,
         num_workers: Optional[int] = None,
         inline_images: Optional[bool] = None,
+        detect_charts: Optional[bool] = None,
+        chart_detection_dpi: Optional[float] = None,
     ):
         """
         Initialize LiteParse parser.
@@ -95,6 +97,8 @@ class LiteParse:
             quiet: Suppress progress output
             num_workers: Number of concurrent OCR workers (default: CPU cores - 1)
             inline_images: Inline embedded PDF images into text as base64 markdown images
+            detect_charts: Detect supported vector charts and render them as ASCII charts
+            chart_detection_dpi: DPI for chart detection rendering
         """
         kwargs = {}
         if ocr_enabled is not None:
@@ -123,6 +127,10 @@ class LiteParse:
             kwargs["num_workers"] = num_workers
         if inline_images is not None:
             kwargs["inline_images"] = inline_images
+        if detect_charts is not None:
+            kwargs["detect_charts"] = detect_charts
+        if chart_detection_dpi is not None:
+            kwargs["chart_detection_dpi"] = chart_detection_dpi
 
         self._native = _NativeLiteParse(**kwargs)
 
@@ -220,6 +228,8 @@ class LiteParse:
             quiet=cfg.quiet,
             num_workers=cfg.num_workers,
             inline_images=cfg.inline_images,
+            detect_charts=cfg.detect_charts,
+            chart_detection_dpi=cfg.chart_detection_dpi,
         )
 
     def __repr__(self) -> str:

--- a/packages/python/liteparse/types.py
+++ b/packages/python/liteparse/types.py
@@ -72,6 +72,8 @@ class LiteParseConfig:
     quiet: bool
     num_workers: int
     inline_images: bool
+    detect_charts: bool
+    chart_detection_dpi: float
 
 
 class ParseError(Exception):

--- a/packages/python/liteparse/types.py
+++ b/packages/python/liteparse/types.py
@@ -71,6 +71,7 @@ class LiteParseConfig:
     password: Optional[str]
     quiet: bool
     num_workers: int
+    inline_images: bool
 
 
 class ParseError(Exception):

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -46,6 +46,7 @@ All optional, camelCase:
 | `preserveVerySmallText` | `boolean` | `false` | Keep tiny text that's normally filtered |
 | `password` | `string` | — | Password for protected PDFs |
 | `quiet` | `boolean` | `false` | Suppress progress logging |
+| `inlineImages` | `boolean` | `false` | Inline embedded PDF images into text as base64 markdown images |
 | `ocrEngine` | `object` | — | JS-side OCR engine (see below) |
 
 ## OCR in the browser


### PR DESCRIPTION
## Summary

Adds an opt-in chart detection path for simple vector bar charts in PDFs. When enabled, LiteParse renders pages at a lightweight chart-detection DPI, detects grouped vertical bar charts from visual components, infers labels/scale from extracted text items, and replaces the text-only chart outline with an ASCII bar chart.

## Why this is useful

Some PDFs draw charts as vector paths instead of embedded images. Existing text extraction can capture axis/legend labels, but it misses the visual bar values because there is no raster image object to extract. This gives users a readable text representation for supported vector bar charts without requiring OCR or image extraction.

## Behavior

- Disabled by default
- Enabled with `--detect-charts`
- Supports simple vertical/grouped bar charts in v1
- Uses `█` block bars for ASCII output
- Does not insert a `[Detected ...]` heading into page text
- Leaves output unchanged silently for unsupported or low-confidence detections
- Exposes structured chart metadata in JSON/Node/WASM result pages

## API / CLI

Rust CLI:

```bash
lit parse file.pdf --detect-charts
lit parse file.pdf --detect-charts --chart-detection-dpi 100
```

Node:

```ts
const parser = new LiteParse({ detectCharts: true });
```

Python:

```py
parser = LiteParse(detect_charts=True)
```

## Validation

Ran:

```bash
cargo test -p liteparse chart --lib
cargo check -p liteparse -p liteparse-napi -p liteparse-python --all-targets
cargo check -p liteparse-wasm
npm --prefix packages/node run build:ts
```

Manual test with `image-inline-test.pdf` page 1 confirmed:

- default parse remains unchanged
- `--detect-charts` replaces the vector chart outline with ASCII bars
- no detection heading is inserted into page text
- JSON output includes one structured chart item