### PR TITLE
fix: improve default tesseract options

### DIFF
--- a/crates/liteparse/src/ocr/http_simple.rs
+++ b/crates/liteparse/src/ocr/http_simple.rs
@@ -140,6 +140,7 @@ mod tests {
         let e = HttpOcrEngine::new("http://127.0.0.1:1/ocr".into());
         let opts = OcrOptions {
             language: "eng".into(),
+            dpi: 150.0,
         };
         let r = e.recognize(&[0u8; 4], 1, 1, &opts).await;
         assert!(r.is_err());

--- a/crates/liteparse/src/ocr/mod.rs
+++ b/crates/liteparse/src/ocr/mod.rs
@@ -23,6 +23,10 @@ pub struct OcrResult {
 
 pub struct OcrOptions {
     pub language: String,
+    /// Resolution (pixels per inch) the page image was rendered at. OCR engines
+    /// that can't infer DPI from raw pixel buffers (e.g. Tesseract fed RGB bytes)
+    /// use this so their internal point-size estimates are correct.
+    pub dpi: f32,
 }
 
 /// On native targets, `OcrEngine` and its returned futures must be `Send` so
@@ -105,6 +109,7 @@ mod tests {
         assert_eq!(engine.name(), "dummy");
         let opts = OcrOptions {
             language: "eng".into(),
+            dpi: 150.0,
         };
         let r = engine.recognize(&[], 1, 1, &opts).await.unwrap();
         assert_eq!(r.len(), 1);

--- a/crates/liteparse/src/ocr/tesseract.rs
+++ b/crates/liteparse/src/ocr/tesseract.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 
 use super::{OcrEngine, OcrOptions, OcrResult};
-use tesseract_rs::{TessPageIteratorLevel, TesseractAPI};
+use tesseract_rs::{TessPageIteratorLevel, TessPageSegMode, TesseractAPI};
 
 const TESSDATA_BASE_URL: &str = "https://github.com/tesseract-ocr/tessdata_best/raw/main";
 
@@ -70,6 +70,12 @@ impl OcrEngine for TesseractOcrEngine {
             ensure_traineddata(Path::new(&resolved_path), language).await?;
             api.init(&resolved_path, language)?;
 
+            // Match the tesseract CLI's default page segmentation mode (PSM_AUTO,
+            // i.e. 3). The C++ library's own default when SetPageSegMode is never
+            // called is PSM_SINGLE_BLOCK (6), which assumes the image is a single
+            // uniform block of text and performs poorly on full-page layouts.
+            api.set_page_seg_mode(TessPageSegMode::PSM_AUTO)?;
+
             // Set image from raw RGB bytes (3 bytes per pixel)
             let bytes_per_pixel = 3;
             let bytes_per_line = width as i32 * bytes_per_pixel;
@@ -80,6 +86,12 @@ impl OcrEngine for TesseractOcrEngine {
                 bytes_per_pixel,
                 bytes_per_line,
             )?;
+
+            // Tesseract can't infer DPI from a raw RGB buffer (there's no image
+            // header), so it falls back to a guess and warns. Tell it the actual
+            // render resolution so its internal point-size/threshold heuristics are
+            // correct. Must come after set_image, which resets the resolution.
+            api.set_source_resolution(options.dpi.round() as i32)?;
 
             api.recognize()?;
 

--- a/crates/liteparse/src/ocr_merge.rs
+++ b/crates/liteparse/src/ocr_merge.rs
@@ -139,7 +139,7 @@ pub(crate) async fn ocr_and_merge_rendered(
             tokio::spawn(async move {
                 // Park the task (not an OS thread) until a permit is available.
                 let _permit = sem.acquire_owned().await.expect("semaphore closed");
-                let options = OcrOptions { language };
+                let options = OcrOptions { language, dpi };
                 // Offload the (possibly CPU-blocking, e.g. Tesseract) recognize
                 // onto a blocking thread. Because the permit is already held,
                 // at most `num_workers` blocking threads are in use at once,


### PR DESCRIPTION
Fixes https://github.com/run-llama/liteparse/issues/295
Fixes https://github.com/run-llama/liteparse/issues/294
