### PR TITLE
fix(search): return no matches for an empty phrase

### DIFF
--- a/crates/liteparse/src/search.rs
+++ b/crates/liteparse/src/search.rs
@@ -13,6 +13,11 @@ pub struct SearchOptions {
 /// box and the matched text. Font metadata is taken from the first matched item.
 pub fn search_items(items: &[TextItem], options: &SearchOptions) -> Vec<TextItem> {
     let mut results = Vec::new();
+    // An empty phrase matches nothing. Without this guard, `str::contains("")`
+    // is always true, so every item would emit a spurious empty-text match.
+    if options.phrase.is_empty() {
+        return results;
+    }
     let normalize = |s: &str| -> String {
         if options.case_sensitive {
             s.to_string()
@@ -181,6 +186,20 @@ mod tests {
         let items = vec![make_item("foo bar", 0.0, 0.0, 40.0)];
         let opts = SearchOptions {
             phrase: "baz".into(),
+            case_sensitive: false,
+        };
+        assert_eq!(search_items(&items, &opts).len(), 0);
+    }
+
+    #[test]
+    fn empty_phrase_matches_nothing() {
+        let items = vec![
+            make_item("alpha", 0.0, 0.0, 30.0),
+            make_item("beta", 0.0, 20.0, 30.0),
+            make_item("gamma", 0.0, 40.0, 30.0),
+        ];
+        let opts = SearchOptions {
+            phrase: String::new(),
             case_sensitive: false,
         };
         assert_eq!(search_items(&items, &opts).len(), 0);


### PR DESCRIPTION
## Summary

`search_items` had no empty-phrase guard. When `phrase == ""`, the normalized query is also empty and `normalize(&combined).contains(&q)` is unconditionally `true` (`str::contains("")` is always `true`). As a result the function emitted one synthetic, empty-text match for **every** input item instead of returning no matches.

This path is reachable from all three bindings; the WASM `JsSearchOptions::default()` even defaults `phrase` to `""`.

Closes #272

## Fix

Early-return an empty `Vec` when the phrase is empty, before any item iteration:

```rust
pub fn search_items(items: &[TextItem], options: &SearchOptions) -> Vec<TextItem> {
    let mut results = Vec::new();
    // An empty phrase matches nothing. Without this guard, `str::contains("")`
    // is always true, so every item would emit a spurious empty-text match.
    if options.phrase.is_empty() {
        return results;
    }
    // ...
```

## Before / After

Searching three items (`alpha`, `beta`, `gamma`) with an empty phrase:

| | Result |
|---|---|
| **Before** | `3` matches, each with empty `text` (one spurious match per item) |
| **After** | `0` matches |

## Tests

Added `empty_phrase_matches_nothing` to the existing `#[cfg(test)] mod tests` in `search.rs`, asserting an empty phrase over three items yields zero matches. Verified fails-before / passes-after (reverting only the guard makes the new test fail with `left: 3, right: 0`, re-applying it passes).

Real output from `cargo test -p liteparse --lib`:

```
running 216 tests
...
test search::tests::empty_phrase_matches_nothing ... ok
test search::tests::multi_item_phrase ... ok
test search::tests::multiple_matches ... ok
test search::tests::no_match ... ok
test search::tests::single_item_match ... ok
...
test result: ok. 216 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s
```

Lint gates:

```
$ cargo fmt --all -- --check
(no output, exit 0)
```

`cargo clippy -p liteparse --all-targets` compiles cleanly; this change introduces no new warnings (existing warnings are pre-existing and unrelated to the touched lines).

## Notes

- Minimal, single-purpose change confined to `crates/liteparse/src/search.rs` (19 insertions, 0 deletions).
- Prepared with AI assistance (Claude Code), reviewed by the author.
