### PR TITLE
fix(node): restore optionalDependencies so platform binaries install

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@llamaindex/liteparse",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Fast, lightweight PDF and document parsing with spatial text extraction",
   "type": "module",
   "main": "./dist/lib.js",
@@ -53,15 +53,14 @@
     "@types/node": "^22.0.0",
     "typescript": "~5.9.2"
   },
-  "_comment_optionalDependencies": "Renamed from optionalDependencies for local file: consumption — the published 2.0.8 platform packages predate parsePages and would shadow the locally-built .node. Restore this key to optionalDependencies (and bump versions) before publishing.",
-  "optionalDependencies_publishOnly": {
-    "@llamaindex/liteparse-darwin-arm64": "2.1.1",
-    "@llamaindex/liteparse-darwin-x64": "2.1.1",
-    "@llamaindex/liteparse-linux-arm64-gnu": "2.1.1",
-    "@llamaindex/liteparse-linux-x64-gnu": "2.1.1",
-    "@llamaindex/liteparse-win32-arm64-msvc": "2.1.1",
-    "@llamaindex/liteparse-win32-x64-msvc": "2.1.1",
-    "@llamaindex/liteparse-linux-x64-musl": "2.1.1"
+  "optionalDependencies": {
+    "@llamaindex/liteparse-darwin-arm64": "2.1.2",
+    "@llamaindex/liteparse-darwin-x64": "2.1.2",
+    "@llamaindex/liteparse-linux-arm64-gnu": "2.1.2",
+    "@llamaindex/liteparse-linux-x64-gnu": "2.1.2",
+    "@llamaindex/liteparse-win32-arm64-msvc": "2.1.2",
+    "@llamaindex/liteparse-win32-x64-msvc": "2.1.2",
+    "@llamaindex/liteparse-linux-x64-musl": "2.1.2"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary

Fixes #311 — `npm install @llamaindex/liteparse@2.1.1` fails on every platform with:

```
Error: Failed to load native module for darwin-arm64. Ensure the correct optional dependency is installed.
```

## Root cause

`packages/node/package.json` shipped with the `optionalDependencies` field renamed to `optionalDependencies_publishOnly` — a local-dev workaround captured in the now-removed `_comment_optionalDependencies` note (which explicitly said *"Restore this key to optionalDependencies (and bump versions) before publishing"*). That restore step was missed in the 2.1.1 publish, so npm installs only `@llamaindex/liteparse` + `commander` and none of the `@llamaindex/liteparse-<platform>` binary packages. `dist/native.js` then can't `require()` any platform binding and throws.

Reproduced locally on darwin-arm64:

```
$ npm install @llamaindex/liteparse@2.1.1
added 2 packages, and audited 3 packages in 432ms   # <-- should be ~3 (commander + liteparse + 1 platform pkg)
```

## Fix

- Rename `optionalDependencies_publishOnly` back to `optionalDependencies`.
- Drop the stale `_comment_optionalDependencies` workaround note.
- Bump `@llamaindex/liteparse` to `2.1.2` and pin each platform package to `2.1.2` to match.

## Release steps (post-merge)

1. Rebuild and publish each `@llamaindex/liteparse-<triple>@2.1.2`.
2. Publish `@llamaindex/liteparse@2.1.2`.
3. Close #311.

## Follow-up (suggested, not in this PR)

The rename hack is fragile and just bit us. Consider replacing it with either:
- Using `npm install --no-optional` (or workspace `overrides`) during local dev so platform packages don't shadow the locally-built `.node`, keeping `optionalDependencies` set permanently in git; or
- A `prepublishOnly` script that sets the field via `npm pkg set` at publish time, so the source-of-truth in git is always `optionalDependencies`.

## User workaround for 2.1.1

```
npm install @llamaindex/liteparse@2.1.1 @llamaindex/liteparse-darwin-arm64@2.1.1
```