### PR TITLE
fix(config): bound target-pages range expansion to prevent OOM (#269)

### DIFF
--- a/crates/liteparse/src/config.rs
+++ b/crates/liteparse/src/config.rs
@@ -97,6 +97,14 @@ fn default_num_workers() -> usize {
         .unwrap_or(1)
 }
 
+/// Upper bound on the number of pages a `--target-pages` argument may expand
+/// to. Ranges are materialised eagerly into a `Vec<u32>`, so without a cap a
+/// tiny argument like `1-4294967295` would try to allocate ~17 GB and the
+/// process would be OOM-killed before the document is even opened. No real
+/// document approaches this many pages, so the cap only ever rejects nonsense
+/// input.
+const MAX_TARGET_PAGES: u64 = 100_000;
+
 #[doc(hidden)]
 pub fn parse_target_pages(s: &str) -> Result<Vec<u32>, String> {
     let mut pages = Vec::new();
@@ -115,6 +123,15 @@ pub fn parse_target_pages(s: &str) -> Result<Vec<u32>, String> {
             if start > end {
                 return Err(format!("invalid range: {}-{}", start, end));
             }
+            // Reject before expanding so an oversized range can never allocate
+            // gigabytes. `end >= start`, so the span cannot underflow.
+            let span = end as u64 - start as u64 + 1;
+            if pages.len() as u64 + span > MAX_TARGET_PAGES {
+                return Err(format!(
+                    "too many target pages: {}-{} exceeds the limit of {}",
+                    start, end, MAX_TARGET_PAGES
+                ));
+            }
             for p in start..=end {
                 pages.push(p);
             }
@@ -122,6 +139,12 @@ pub fn parse_target_pages(s: &str) -> Result<Vec<u32>, String> {
             let p: u32 = part
                 .parse()
                 .map_err(|_| format!("invalid page number: {}", part))?;
+            if pages.len() as u64 + 1 > MAX_TARGET_PAGES {
+                return Err(format!(
+                    "too many target pages: exceeds the limit of {}",
+                    MAX_TARGET_PAGES
+                ));
+            }
             pages.push(p);
         }
     }
@@ -154,6 +177,19 @@ mod tests {
     #[test]
     fn test_parse_target_pages_single_range() {
         assert_eq!(parse_target_pages("2-2").unwrap(), vec![2]);
+    }
+
+    #[test]
+    fn test_parse_target_pages_rejects_oversized_range() {
+        // The headline OOM repro from #269: a 12-character argument must not
+        // be allowed to expand into a multi-gigabyte allocation.
+        assert!(parse_target_pages("1-4294967295").is_err());
+        assert!(parse_target_pages("0-4294967295").is_err());
+        // The cap is on the total page count, so multiple ranges that
+        // together exceed the limit are rejected too.
+        assert!(parse_target_pages("1-60000,60001-120000").is_err());
+        // A selection within the limit is still parsed normally.
+        assert_eq!(parse_target_pages("1-1000").unwrap().len(), 1000);
     }
 
     #[test]


### PR DESCRIPTION
## What / why

`parse_target_pages` expands an inclusive page range eagerly into a `Vec<u32>` with **no upper bound** and no relation to the document's real page count. A tiny argument string can therefore allocate gigabytes and the process is OOM-killed before the document is even opened.

```rust
// crates/liteparse/src/config.rs (before)
if start > end {
    return Err(format!("invalid range: {}-{}", start, end));
}
for p in start..=end {
    pages.push(p);          // materialises the entire range, unbounded
}
```

Reachable from `lit parse … --target-pages`, `lit screenshot … --target-pages`, and the Python/Node/WASM bindings (they forward `target_pages` verbatim).

Closes #269.

## Reproduction

```bash
lit parse any.pdf --target-pages 1-4294967295
# RSS climbs into the tens of GB and the process is killed before parsing starts.
```

Demonstrated at the unit level (using a safe 200k-page range rather than the 17 GB input) — **before** this change the range is accepted with no error:

```
OLD: 1-200000 -> 200000 elements, no error
```

## Fix

Reject oversized selections **before** any allocation, capping the running total of materialised pages at `MAX_TARGET_PAGES` (100,000):

```rust
let span = end as u64 - start as u64 + 1;
if pages.len() as u64 + span > MAX_TARGET_PAGES {
    return Err(format!(
        "too many target pages: {}-{} exceeds the limit of {}",
        start, end, MAX_TARGET_PAGES
    ));
}
```

The cap is on the running total, not just a single range, so inputs like `1-60000,60001-120000` are rejected too. The same `Result<Vec<u32>, String>` signature is kept, so no call sites change. No real document approaches 100k pages (the default `max_pages` is 1000), so only nonsensical input is ever rejected — happy to move the constant or adjust the limit if you'd prefer a different value.

## Tests

Added `test_parse_target_pages_rejects_oversized_range` next to the existing `parse_target_pages` tests:

```
$ cargo test -p liteparse config::
running 7 tests
... test config::tests::test_parse_target_pages_rejects_oversized_range ... ok
test result: ok. 7 passed; 0 failed
```

`cargo fmt` clean; `cargo clippy -p liteparse` introduces no new warnings.

---

*Prepared with AI assistance (Claude Code); reviewed, built, and tested by a human before submitting.*
