### PR TITLE
feat: add is_complex functionality for routing decisions

### DIFF
--- a/crates/liteparse-napi/src/lib.rs
+++ b/crates/liteparse-napi/src/lib.rs
@@ -3,7 +3,10 @@ use napi_derive::napi;
 
 mod types;
 
-use types::{JsLiteParseConfig, JsPageInput, JsParseResult, JsScreenshotResult, JsTextItem};
+use types::{
+    JsLiteParseConfig, JsPageComplexityStats, JsPageInput, JsParseResult, JsScreenshotResult,
+    JsTextItem,
+};
 
 /// Main LiteParse parser class.
 #[napi]
@@ -57,6 +60,31 @@ impl LiteParse {
         let rust_pages: Vec<_> = pages.iter().map(JsPageInput::to_rust).collect();
         let result = self.inner.parse_from_pages(rust_pages, Vec::new());
         Ok(JsParseResult::from_rust(&result, &self.config))
+    }
+
+    /// Determine per-page complexity. Returns one entry per parsed page with
+    /// signals (text coverage, images, garbled text, vector area) and a
+    /// `needsOcr` verdict — a cheap pre-OCR check to decide whether a document
+    /// needs advanced parsing. Accepts a file path (string) or raw PDF bytes.
+    #[napi]
+    pub async fn is_complex(
+        &self,
+        input: Either<String, Buffer>,
+    ) -> Result<Vec<JsPageComplexityStats>> {
+        use liteparse::types::PdfInput;
+
+        let pdf_input = match input {
+            Either::A(path) => PdfInput::Path(path),
+            Either::B(buf) => PdfInput::Bytes(buf.to_vec()),
+        };
+
+        let stats = self
+            .inner
+            .is_complex(pdf_input)
+            .await
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+
+        Ok(stats.iter().map(JsPageComplexityStats::from_rust).collect())
     }
 
     /// Take screenshots of document pages. Returns PNG image buffers.

--- a/crates/liteparse-napi/src/types.rs
+++ b/crates/liteparse-napi/src/types.rs
@@ -368,10 +368,12 @@ pub struct JsPageComplexityStats {
     pub image_block_count: u32,
     pub image_coverage: f64,
     pub largest_image_coverage: f64,
+    pub full_page_image: bool,
     pub uncovered_vector_area: Option<f64>,
     pub is_garbled: bool,
     pub page_area: f64,
     pub needs_ocr: bool,
+    pub reasons: Vec<String>,
 }
 
 impl JsPageComplexityStats {
@@ -384,10 +386,16 @@ impl JsPageComplexityStats {
             image_block_count: stats.image_block_count as u32,
             image_coverage: stats.image_coverage as f64,
             largest_image_coverage: stats.largest_image_coverage as f64,
+            full_page_image: stats.full_page_image,
             uncovered_vector_area: stats.uncovered_vector_area.map(|v| v as f64),
             is_garbled: stats.is_garbled,
             page_area: stats.page_area as f64,
             needs_ocr: stats.needs_ocr,
+            reasons: stats
+                .reasons
+                .iter()
+                .map(|r| r.as_str().to_string())
+                .collect(),
         }
     }
 }

--- a/crates/liteparse-napi/src/types.rs
+++ b/crates/liteparse-napi/src/types.rs
@@ -358,6 +358,40 @@ pub struct JsScreenshotResult {
     pub image_buffer: napi::bindgen_prelude::Buffer,
 }
 
+#[napi(object)]
+#[derive(Clone)]
+pub struct JsPageComplexityStats {
+    pub page_number: u32,
+    pub text_length: u32,
+    pub text_coverage: f64,
+    pub has_substantial_images: bool,
+    pub image_block_count: u32,
+    pub image_coverage: f64,
+    pub largest_image_coverage: f64,
+    pub uncovered_vector_area: Option<f64>,
+    pub is_garbled: bool,
+    pub page_area: f64,
+    pub needs_ocr: bool,
+}
+
+impl JsPageComplexityStats {
+    pub fn from_rust(stats: &liteparse::ocr_merge::PageComplexityStats) -> Self {
+        Self {
+            page_number: stats.page_number as u32,
+            text_length: stats.text_length as u32,
+            text_coverage: stats.text_coverage as f64,
+            has_substantial_images: stats.has_substantial_images,
+            image_block_count: stats.image_block_count as u32,
+            image_coverage: stats.image_coverage as f64,
+            largest_image_coverage: stats.largest_image_coverage as f64,
+            uncovered_vector_area: stats.uncovered_vector_area.map(|v| v as f64),
+            is_garbled: stats.is_garbled,
+            page_area: stats.page_area as f64,
+            needs_ocr: stats.needs_ocr,
+        }
+    }
+}
+
 impl JsParseResult {
     pub fn from_rust(result: &ParseResult, _config: &LiteParseConfig) -> Self {
         Self {

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -252,6 +252,8 @@ struct PyPageComplexityStats {
     #[pyo3(get)]
     largest_image_coverage: f32,
     #[pyo3(get)]
+    full_page_image: bool,
+    #[pyo3(get)]
     uncovered_vector_area: Option<f32>,
     #[pyo3(get)]
     is_garbled: bool,
@@ -259,6 +261,8 @@ struct PyPageComplexityStats {
     page_area: f32,
     #[pyo3(get)]
     needs_ocr: bool,
+    #[pyo3(get)]
+    reasons: Vec<String>,
 }
 
 #[pymethods]
@@ -281,10 +285,16 @@ impl PyPageComplexityStats {
             image_block_count: stats.image_block_count,
             image_coverage: stats.image_coverage,
             largest_image_coverage: stats.largest_image_coverage,
+            full_page_image: stats.full_page_image,
             uncovered_vector_area: stats.uncovered_vector_area,
             is_garbled: stats.is_garbled,
             page_area: stats.page_area,
             needs_ocr: stats.needs_ocr,
+            reasons: stats
+                .reasons
+                .iter()
+                .map(|r| r.as_str().to_string())
+                .collect(),
         }
     }
 }

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -234,6 +234,61 @@ impl PyScreenshotResult {
     }
 }
 
+#[pyclass(frozen, from_py_object)]
+#[derive(Clone)]
+struct PyPageComplexityStats {
+    #[pyo3(get)]
+    page_number: usize,
+    #[pyo3(get)]
+    text_length: usize,
+    #[pyo3(get)]
+    text_coverage: f32,
+    #[pyo3(get)]
+    has_substantial_images: bool,
+    #[pyo3(get)]
+    image_block_count: usize,
+    #[pyo3(get)]
+    image_coverage: f32,
+    #[pyo3(get)]
+    largest_image_coverage: f32,
+    #[pyo3(get)]
+    uncovered_vector_area: Option<f32>,
+    #[pyo3(get)]
+    is_garbled: bool,
+    #[pyo3(get)]
+    page_area: f32,
+    #[pyo3(get)]
+    needs_ocr: bool,
+}
+
+#[pymethods]
+impl PyPageComplexityStats {
+    fn __repr__(&self) -> String {
+        format!(
+            "PageComplexityStats(page_number={}, text_length={}, text_coverage={:.2}, needs_ocr={})",
+            self.page_number, self.text_length, self.text_coverage, self.needs_ocr
+        )
+    }
+}
+
+impl PyPageComplexityStats {
+    fn from_rust(stats: &liteparse::ocr_merge::PageComplexityStats) -> Self {
+        Self {
+            page_number: stats.page_number,
+            text_length: stats.text_length,
+            text_coverage: stats.text_coverage,
+            has_substantial_images: stats.has_substantial_images,
+            image_block_count: stats.image_block_count,
+            image_coverage: stats.image_coverage,
+            largest_image_coverage: stats.largest_image_coverage,
+            uncovered_vector_area: stats.uncovered_vector_area,
+            is_garbled: stats.is_garbled,
+            page_area: stats.page_area,
+            needs_ocr: stats.needs_ocr,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
@@ -440,6 +495,30 @@ impl LiteParse {
         Ok(PyParseResult::from_rust(result))
     }
 
+    /// Determine per-page complexity for a document at the given path. Returns
+    /// a list of PageComplexityStats — a cheap pre-OCR check with per-page
+    /// signals and a `needs_ocr` verdict.
+    fn is_complex(&self, py: Python<'_>, input: String) -> PyResult<Vec<PyPageComplexityStats>> {
+        let pdf_input = PdfInput::Path(input);
+        let stats = py
+            .detach(|| self.runtime.block_on(self.inner.is_complex(pdf_input)))
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+        Ok(stats.iter().map(PyPageComplexityStats::from_rust).collect())
+    }
+
+    /// Determine per-page complexity for a document from raw bytes.
+    fn is_complex_bytes(
+        &self,
+        py: Python<'_>,
+        data: Vec<u8>,
+    ) -> PyResult<Vec<PyPageComplexityStats>> {
+        let pdf_input = PdfInput::Bytes(data);
+        let stats = py
+            .detach(|| self.runtime.block_on(self.inner.is_complex(pdf_input)))
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+        Ok(stats.iter().map(PyPageComplexityStats::from_rust).collect())
+    }
+
     /// Take screenshots of document pages. Returns a list of ScreenshotResult.
     ///
     /// Non-PDF files are automatically converted to PDF before rendering when
@@ -517,6 +596,7 @@ fn _liteparse(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyParsedPage>()?;
     m.add_class::<PyTextItem>()?;
     m.add_class::<PyScreenshotResult>()?;
+    m.add_class::<PyPageComplexityStats>()?;
     m.add_function(wrap_pyfunction!(run_cli, m)?)?;
     m.add_function(wrap_pyfunction!(search_items, m)?)?;
     Ok(())

--- a/crates/liteparse-wasm/src/lib.rs
+++ b/crates/liteparse-wasm/src/lib.rs
@@ -425,10 +425,12 @@ struct JsPageComplexityStats {
     image_block_count: usize,
     image_coverage: f32,
     largest_image_coverage: f32,
+    full_page_image: bool,
     uncovered_vector_area: Option<f32>,
     is_garbled: bool,
     page_area: f32,
     needs_ocr: bool,
+    reasons: Vec<String>,
 }
 
 impl JsPageComplexityStats {
@@ -441,10 +443,16 @@ impl JsPageComplexityStats {
             image_block_count: stats.image_block_count,
             image_coverage: stats.image_coverage,
             largest_image_coverage: stats.largest_image_coverage,
+            full_page_image: stats.full_page_image,
             uncovered_vector_area: stats.uncovered_vector_area,
             is_garbled: stats.is_garbled,
             page_area: stats.page_area,
             needs_ocr: stats.needs_ocr,
+            reasons: stats
+                .reasons
+                .iter()
+                .map(|r| r.as_str().to_string())
+                .collect(),
         }
     }
 }

--- a/crates/liteparse-wasm/src/lib.rs
+++ b/crates/liteparse-wasm/src/lib.rs
@@ -395,6 +395,58 @@ impl LiteParse {
         serde_wasm_bindgen::to_value(&js_result)
             .map_err(|e| JsError::new(&format!("serialize result failed: {}", e)))
     }
+
+    /// Determine per-page complexity for the given PDF bytes. Returns
+    /// `Promise<PageComplexityStats[]>` — a cheap pre-OCR check with per-page
+    /// signals and a `needsOcr` verdict.
+    #[wasm_bindgen(js_name = isComplex)]
+    pub async fn is_complex(&self, data: Vec<u8>) -> Result<JsValue, JsError> {
+        let stats = self
+            .inner
+            .is_complex(PdfInput::Bytes(data))
+            .await
+            .map_err(|e| JsError::new(&format!("is_complex failed: {}", e)))?;
+
+        let js_stats: Vec<JsPageComplexityStats> =
+            stats.iter().map(JsPageComplexityStats::from_rust).collect();
+
+        serde_wasm_bindgen::to_value(&js_stats)
+            .map_err(|e| JsError::new(&format!("serialize result failed: {}", e)))
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsPageComplexityStats {
+    page_number: usize,
+    text_length: usize,
+    text_coverage: f32,
+    has_substantial_images: bool,
+    image_block_count: usize,
+    image_coverage: f32,
+    largest_image_coverage: f32,
+    uncovered_vector_area: Option<f32>,
+    is_garbled: bool,
+    page_area: f32,
+    needs_ocr: bool,
+}
+
+impl JsPageComplexityStats {
+    fn from_rust(stats: &liteparse::ocr_merge::PageComplexityStats) -> Self {
+        Self {
+            page_number: stats.page_number,
+            text_length: stats.text_length,
+            text_coverage: stats.text_coverage,
+            has_substantial_images: stats.has_substantial_images,
+            image_block_count: stats.image_block_count,
+            image_coverage: stats.image_coverage,
+            largest_image_coverage: stats.largest_image_coverage,
+            uncovered_vector_area: stats.uncovered_vector_area,
+            is_garbled: stats.is_garbled,
+            page_area: stats.page_area,
+            needs_ocr: stats.needs_ocr,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/liteparse/src/main.rs
+++ b/crates/liteparse/src/main.rs
@@ -5,6 +5,7 @@ use liteparse::extract;
 use liteparse::output::{json, text};
 use liteparse::parser::LiteParse;
 use liteparse::render;
+use liteparse::types::PdfInput;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -25,6 +26,8 @@ enum Commands {
     Screenshot(ScreenshotCommand),
     /// Parse multiple documents in batch mode
     BatchParse(BatchParseCommand),
+    /// Check if a document is "complex" enough to require OCR or other advanced parsing
+    IsComplex(IsComplexCommand),
     /// Extract raw text items from a PDF file (no grid projection) [dev tool]
     #[command(hide = true)]
     Extract(ExtractCommand),
@@ -215,6 +218,32 @@ struct ExtractCommand {
     /// Target page number (1-based)
     #[arg(long)]
     page_num: Option<u32>,
+}
+
+#[derive(Args, Debug)]
+struct IsComplexCommand {
+    /// Input file path
+    file: String,
+
+    /// Whether to output the result as JSON (true/false) or plain text (true/false)
+    #[arg(long)]
+    json: bool,
+
+    /// Max pages to parse
+    #[arg(long, default_value = "1000")]
+    max_pages: usize,
+
+    /// Target pages (e.g., "1-5,10,15-20")
+    #[arg(long)]
+    target_pages: Option<String>,
+
+    /// Password for encrypted/protected documents
+    #[arg(long)]
+    password: Option<String>,
+
+    /// Suppress progress output
+    #[arg(short, long)]
+    quiet: bool,
 }
 
 fn parse_output_format(s: &str) -> Result<OutputFormat, String> {
@@ -473,6 +502,59 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         Commands::ImageBounds(cmd) => {
             render::image_bounds(&cmd.pdf_path, cmd.page_num)?;
+        }
+
+        Commands::IsComplex(cmd) => {
+            let config = LiteParseConfig {
+                max_pages: cmd.max_pages,
+                target_pages: cmd.target_pages,
+                password: cmd.password,
+                quiet: cmd.quiet,
+                ..Default::default()
+            };
+            let lp = LiteParse::new(config);
+            let is_complex = lp.is_complex(PdfInput::Path(cmd.file)).await?;
+
+            let complex_pages = is_complex.iter().filter(|c| c.needs_ocr).count();
+
+            if cmd.json {
+                let json = serde_json::to_string(&is_complex)?;
+                println!("{}", json);
+            } else {
+                let verdict = if complex_pages > 0 { "COMPLEX" } else { "SIMPLE" };
+                println!(
+                    "{} — {}/{} page(s) need OCR",
+                    verdict,
+                    complex_pages,
+                    is_complex.len()
+                );
+                println!(
+                    "{:>4}  {:>7}  {:>5}  {:>6}  {:>7}  {:>7}  {:>5}",
+                    "page", "text", "cov", "images", "garbled", "vector", "ocr"
+                );
+                for c in &is_complex {
+                    let vector = match c.uncovered_vector_area {
+                        Some(area) => format!("{:.0}", area),
+                        None => "-".to_string(),
+                    };
+                    println!(
+                        "{:>4}  {:>7}  {:>5.2}  {:>6}  {:>7}  {:>7}  {:>5}",
+                        c.page_number,
+                        c.text_length,
+                        c.text_coverage,
+                        if c.has_substantial_images { "yes" } else { "no" },
+                        if c.is_garbled { "yes" } else { "no" },
+                        vector,
+                        if c.needs_ocr { "yes" } else { "no" },
+                    );
+                }
+            }
+
+            // Exit non-zero when any page needs OCR, so the command is usable as
+            // a shell predicate (e.g. `is-complex doc.pdf && parse --disable-ocr`).
+            if complex_pages > 0 {
+                std::process::exit(1);
+            }
         }
     }
 

--- a/crates/liteparse/src/main.rs
+++ b/crates/liteparse/src/main.rs
@@ -533,8 +533,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     is_complex.len()
                 );
                 println!(
-                    "{:>4}  {:>7}  {:>5}  {:>6}  {:>7}  {:>7}  {:>5}",
-                    "page", "text", "cov", "images", "garbled", "vector", "ocr"
+                    "{:>4}  {:>7}  {:>5}  {:>6}  {:>6}  {:>7}  {:>7}  {:>5}",
+                    "page", "text", "cov", "images", "imgcov", "garbled", "vector", "ocr"
                 );
                 for c in &is_complex {
                     let vector = match c.uncovered_vector_area {
@@ -542,7 +542,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         None => "-".to_string(),
                     };
                     println!(
-                        "{:>4}  {:>7}  {:>5.2}  {:>6}  {:>7}  {:>7}  {:>5}",
+                        "{:>4}  {:>7}  {:>5.2}  {:>6}  {:>6.2}  {:>7}  {:>7}  {:>5}",
                         c.page_number,
                         c.text_length,
                         c.text_coverage,
@@ -551,6 +551,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         } else {
                             "no"
                         },
+                        c.image_coverage,
                         if c.is_garbled { "yes" } else { "no" },
                         vector,
                         if c.needs_ocr { "yes" } else { "no" },

--- a/crates/liteparse/src/main.rs
+++ b/crates/liteparse/src/main.rs
@@ -225,9 +225,10 @@ struct IsComplexCommand {
     /// Input file path
     file: String,
 
-    /// Whether to output the result as JSON (true/false) or plain text (true/false)
+    /// Emit dense, whitespace-free JSON instead of pretty-printed (still valid
+    /// for `jq` and friends).
     #[arg(long)]
-    json: bool,
+    compact: bool,
 
     /// Max pages to parse
     #[arg(long, default_value = "1000")]
@@ -517,46 +518,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let complex_pages = is_complex.iter().filter(|c| c.needs_ocr).count();
 
-            if cmd.json && !cmd.quiet {
-                let json = serde_json::to_string(&is_complex)?;
-                println!("{}", json);
-            } else if !cmd.quiet {
+            // Always emit JSON on stdout so the command composes with `jq` and
+            // friends without a flag. Pretty by default for human readability;
+            // `--compact` drops the whitespace. Both parse identically.
+            let json = if cmd.compact {
+                serde_json::to_string(&is_complex)?
+            } else {
+                serde_json::to_string_pretty(&is_complex)?
+            };
+            println!("{}", json);
+
+            // The human-readable verdict goes to stderr so it never pollutes the
+            // JSON on stdout. The exit code below carries the same signal for
+            // scripts that don't want to read either stream.
+            if !cmd.quiet {
                 let verdict = if complex_pages > 0 {
                     "COMPLEX"
                 } else {
                     "SIMPLE"
                 };
-                println!(
+                eprintln!(
                     "{} — {}/{} page(s) need OCR",
                     verdict,
                     complex_pages,
                     is_complex.len()
                 );
-                println!(
-                    "{:>4}  {:>7}  {:>5}  {:>6}  {:>6}  {:>7}  {:>7}  {:>5}",
-                    "page", "text", "cov", "images", "imgcov", "garbled", "vector", "ocr"
-                );
-                for c in &is_complex {
-                    let vector = match c.uncovered_vector_area {
-                        Some(area) => format!("{:.0}", area),
-                        None => "-".to_string(),
-                    };
-                    println!(
-                        "{:>4}  {:>7}  {:>5.2}  {:>6}  {:>6.2}  {:>7}  {:>7}  {:>5}",
-                        c.page_number,
-                        c.text_length,
-                        c.text_coverage,
-                        if c.has_substantial_images {
-                            "yes"
-                        } else {
-                            "no"
-                        },
-                        c.image_coverage,
-                        if c.is_garbled { "yes" } else { "no" },
-                        vector,
-                        if c.needs_ocr { "yes" } else { "no" },
-                    );
-                }
             }
 
             // Exit non-zero when any page needs OCR, so the command is usable as

--- a/crates/liteparse/src/main.rs
+++ b/crates/liteparse/src/main.rs
@@ -517,11 +517,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let complex_pages = is_complex.iter().filter(|c| c.needs_ocr).count();
 
-            if cmd.json {
+            if cmd.json && !cmd.quiet {
                 let json = serde_json::to_string(&is_complex)?;
                 println!("{}", json);
-            } else {
-                let verdict = if complex_pages > 0 { "COMPLEX" } else { "SIMPLE" };
+            } else if !cmd.quiet {
+                let verdict = if complex_pages > 0 {
+                    "COMPLEX"
+                } else {
+                    "SIMPLE"
+                };
                 println!(
                     "{} — {}/{} page(s) need OCR",
                     verdict,
@@ -542,7 +546,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         c.page_number,
                         c.text_length,
                         c.text_coverage,
-                        if c.has_substantial_images { "yes" } else { "no" },
+                        if c.has_substantial_images {
+                            "yes"
+                        } else {
+                            "no"
+                        },
                         if c.is_garbled { "yes" } else { "no" },
                         vector,
                         if c.needs_ocr { "yes" } else { "no" },
@@ -551,7 +559,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             // Exit non-zero when any page needs OCR, so the command is usable as
-            // a shell predicate (e.g. `is-complex doc.pdf && parse --disable-ocr`).
+            // a shell predicate: exit 0 (simple) → `&& parse --no-ocr` is safe.
             if complex_pages > 0 {
                 std::process::exit(1);
             }

--- a/crates/liteparse/src/ocr_merge.rs
+++ b/crates/liteparse/src/ocr_merge.rs
@@ -15,6 +15,14 @@ use serde::Serialize;
 /// pages at this threshold.
 const UNCOVERED_VECTOR_AREA_THRESHOLD: f32 = 400.0;
 
+/// Minimum side length (pt) for a raster image object to count toward image
+/// coverage; smaller objects (rule lines, bullets, icons) are ignored.
+const MIN_IMAGE_SIZE_PT: f32 = 25.0;
+
+/// A single image at or above this fraction of the page is treated as a
+/// full-page background and ignored.
+const MAX_IMAGE_PAGE_COVERAGE: f32 = 0.9;
+
 /// Owned page bitmap prepared for OCR. Indices refer to positions in the `pages` slice.
 pub(crate) struct RenderedPage {
     pub idx: usize,
@@ -29,6 +37,18 @@ pub struct PageComplexityStats {
     pub text_length: usize,
     pub text_coverage: f32,
     pub has_substantial_images: bool,
+    /// Number of raster image objects counted on the page, after the size and
+    /// single-image coverage filters.
+    pub image_block_count: usize,
+    /// Combined area of the counted images over the page area, clamped to 1.0.
+    /// Stacked or overlapping images can inflate the raw sum past the truly
+    /// covered fraction, hence the clamp — read it as "summed image-bbox area,"
+    /// not unique covered area.
+    pub image_coverage: f32,
+    /// Area of the single largest counted image over the page area, clamped to
+    /// 1.0. Useful for telling a single full-bleed scan apart from many small
+    /// inline figures that sum to a similar `image_coverage`.
+    pub largest_image_coverage: f32,
     /// Filled vector-outline area not covered by native text, in pt². `None`
     /// when a cheaper predicate already flagged the page for OCR, so this
     /// expensive page-object walk was skipped (it wasn't the deciding signal).
@@ -55,9 +75,26 @@ pub(crate) fn calculate_page_complexity(
         .filter(|item| !is_unusable_native(item))
         .map(|item| item.text.len())
         .sum();
-    let has_images = !page_obj.image_bounds(25.0, 0.9).is_empty();
+    let image_bounds = page_obj.image_bounds(MIN_IMAGE_SIZE_PT, MAX_IMAGE_PAGE_COVERAGE);
+    let has_images = !image_bounds.is_empty();
 
     let page_area = page.page_width * page.page_height;
+
+    let (image_area_sum, largest_image_area) =
+        image_bounds
+            .iter()
+            .fold((0.0_f32, 0.0_f32), |(sum, max), b| {
+                let area = b.width.max(0.0) * b.height.max(0.0);
+                (sum + area, max.max(area))
+            });
+    let (image_coverage, largest_image_coverage) = if page_area > 0.0 {
+        (
+            (image_area_sum / page_area).min(1.0),
+            (largest_image_area / page_area).min(1.0),
+        )
+    } else {
+        (0.0, 0.0)
+    };
     let text_bbox_area: f32 = page
         .text_items
         .iter()
@@ -97,6 +134,9 @@ pub(crate) fn calculate_page_complexity(
         text_length,
         text_coverage,
         has_substantial_images: has_images,
+        image_block_count: image_bounds.len(),
+        image_coverage,
+        largest_image_coverage,
         uncovered_vector_area,
         is_garbled,
         page_area,

--- a/crates/liteparse/src/ocr_merge.rs
+++ b/crates/liteparse/src/ocr_merge.rs
@@ -31,6 +31,49 @@ pub(crate) struct RenderedPage {
     pub height: u32,
 }
 
+/// Why a page was flagged as needing more than the cheap text-only path.
+/// Multiple reasons can apply to one page (e.g. a sparse page whose little
+/// text is also garbled). Empty exactly when `needs_ocr` is false.
+///
+/// This is the discriminator a caller routes on: a scan goes to OCR, dense
+/// vector text to a vector-aware pass, and so on. New variants will be added
+/// as the routing function learns to recommend heavier pipelines (tables,
+/// charts, LLM passes), so callers should treat unknown variants leniently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ComplexityReason {
+    /// A single raster covers essentially the whole page and there is little or
+    /// no extractable text behind it — a scanned/photographed page.
+    Scanned,
+    /// Almost no extractable native text, and no full-page raster behind it
+    /// (a blank page, or a near-empty cover/divider).
+    NoText,
+    /// Some real text, but it covers very little of the page — typically a
+    /// figure-heavy page with only thin captions.
+    SparseText,
+    /// Substantial embedded raster figures sit alongside the native text.
+    EmbeddedImages,
+    /// The native text decodes to garbage (broken cmap / Type3 char-code
+    /// fallback), so the visible glyphs and the extracted text disagree.
+    Garbled,
+    /// Text is painted as filled vector outlines, outside the text layer, so
+    /// no native text items represent it.
+    VectorText,
+}
+
+impl ComplexityReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ComplexityReason::Scanned => "scanned",
+            ComplexityReason::NoText => "no-text",
+            ComplexityReason::SparseText => "sparse-text",
+            ComplexityReason::EmbeddedImages => "embedded-images",
+            ComplexityReason::Garbled => "garbled",
+            ComplexityReason::VectorText => "vector-text",
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct PageComplexityStats {
     pub page_number: usize,
@@ -49,13 +92,24 @@ pub struct PageComplexityStats {
     /// 1.0. Useful for telling a single full-bleed scan apart from many small
     /// inline figures that sum to a similar `image_coverage`.
     pub largest_image_coverage: f32,
+    /// A single raster covering ≥90% of the page is present. Such full-page
+    /// backgrounds are excluded from `image_coverage`/`largest_image_coverage`
+    /// (they're not inline figures), so this flag is the only signal that
+    /// distinguishes a scan from a genuinely blank page — both otherwise report
+    /// no text and no counted images.
+    pub full_page_image: bool,
     /// Filled vector-outline area not covered by native text, in pt². `None`
     /// when a cheaper predicate already flagged the page for OCR, so this
     /// expensive page-object walk was skipped (it wasn't the deciding signal).
     pub uncovered_vector_area: Option<f32>,
     pub is_garbled: bool,
     pub page_area: f32,
+    /// Whether the page needs more than the cheap text-only path. Equivalent to
+    /// `!reasons.is_empty()`; kept as a flat bool for the common predicate case
+    /// and as the internal per-page OCR gate.
     pub needs_ocr: bool,
+    /// Every reason the page was flagged, in no particular priority order.
+    pub reasons: Vec<ComplexityReason>,
 }
 
 pub(crate) fn calculate_page_complexity(
@@ -75,10 +129,21 @@ pub(crate) fn calculate_page_complexity(
         .filter(|item| !is_unusable_native(item))
         .map(|item| item.text.len())
         .sum();
-    let image_bounds = page_obj.image_bounds(MIN_IMAGE_SIZE_PT, MAX_IMAGE_PAGE_COVERAGE);
+    // Collect every raster ≥ MIN_IMAGE_SIZE_PT, including full-page ones, so a
+    // scan can be told apart from a blank page. The "counted" subset below then
+    // drops full-page backgrounds, matching the old
+    // `image_bounds(.., MAX_IMAGE_PAGE_COVERAGE)` behaviour for inline figures.
+    let pw = page.page_width;
+    let ph = page.page_height;
+    let all_images = page_obj.image_bounds(MIN_IMAGE_SIZE_PT, f32::INFINITY);
+    let is_full_page = |b: &ImageBounds| {
+        b.width > pw * MAX_IMAGE_PAGE_COVERAGE && b.height > ph * MAX_IMAGE_PAGE_COVERAGE
+    };
+    let full_page_image = all_images.iter().any(is_full_page);
+    let image_bounds: Vec<&ImageBounds> = all_images.iter().filter(|b| !is_full_page(b)).collect();
     let has_images = !image_bounds.is_empty();
 
-    let page_area = page.page_width * page.page_height;
+    let page_area = pw * ph;
 
     let (image_area_sum, largest_image_area) =
         image_bounds
@@ -112,7 +177,27 @@ pub(crate) fn calculate_page_complexity(
     // wide intra-cell whitespace) is spatially sparse but needs no OCR.
     let sparse_text = text_length < 2000 && text_coverage < 0.15;
     let is_garbled = page_is_garbled(page);
-    let mut needs_ocr = text_length < 20 || sparse_text || has_images || is_garbled;
+
+    let mut reasons = Vec::new();
+    if text_length < 20 {
+        // Too little text to be the page's content. A full-page raster behind
+        // it means a scan; otherwise it's effectively blank.
+        reasons.push(if full_page_image {
+            ComplexityReason::Scanned
+        } else {
+            ComplexityReason::NoText
+        });
+    } else if sparse_text {
+        // There is real text, but it's too thin to be the whole page.
+        reasons.push(ComplexityReason::SparseText);
+    }
+    if has_images {
+        reasons.push(ComplexityReason::EmbeddedImages);
+    }
+    if is_garbled {
+        reasons.push(ComplexityReason::Garbled);
+    }
+    let mut needs_ocr = !reasons.is_empty();
 
     // Text drawn as filled vector outlines lives outside the text layer
     // entirely: no text items, no image XObjects, so none of the cheap
@@ -123,7 +208,10 @@ pub(crate) fn calculate_page_complexity(
     let uncovered_vector_area = if !needs_ocr {
         let path_bounds = page_obj.filled_path_bounds(3.0, 0.9);
         let uncovered = uncovered_path_area(&path_bounds, &page.text_items);
-        needs_ocr = uncovered >= UNCOVERED_VECTOR_AREA_THRESHOLD;
+        if uncovered >= UNCOVERED_VECTOR_AREA_THRESHOLD {
+            needs_ocr = true;
+            reasons.push(ComplexityReason::VectorText);
+        }
         Some(uncovered)
     } else {
         None
@@ -137,10 +225,12 @@ pub(crate) fn calculate_page_complexity(
         image_block_count: image_bounds.len(),
         image_coverage,
         largest_image_coverage,
+        full_page_image,
         uncovered_vector_area,
         is_garbled,
         page_area,
         needs_ocr,
+        reasons,
     })
 }
 

--- a/crates/liteparse/src/ocr_merge.rs
+++ b/crates/liteparse/src/ocr_merge.rs
@@ -4,6 +4,7 @@ use crate::error::LiteParseError;
 use crate::ocr::{OcrEngine, OcrOptions, OcrResult};
 use crate::types::{Page, TextItem};
 use pdfium::{Document, ImageBounds};
+use serde::Serialize;
 
 /// Minimum dark filled-path area (pt², ~72 DPI page space) not covered by
 /// native text before a page is sent to OCR. 400 pt² is roughly one word at
@@ -22,6 +23,87 @@ pub(crate) struct RenderedPage {
     pub height: u32,
 }
 
+#[derive(Debug, Serialize)]
+pub struct PageComplexityStats {
+    pub page_number: usize,
+    pub text_length: usize,
+    pub text_coverage: f32,
+    pub has_substantial_images: bool,
+    /// Filled vector-outline area not covered by native text, in pt². `None`
+    /// when a cheaper predicate already flagged the page for OCR, so this
+    /// expensive page-object walk was skipped (it wasn't the deciding signal).
+    pub uncovered_vector_area: Option<f32>,
+    pub is_garbled: bool,
+    pub page_area: f32,
+    pub needs_ocr: bool,
+}
+
+pub(crate) fn calculate_page_complexity(
+    page: &Page,
+    page_obj: &pdfium::Page,
+) -> Result<PageComplexityStats, LiteParseError> {
+    // Count only usable native text. Substitution-cipher-style corrupt
+    // encodings (e.g. PDFs with a broken cmap) produce long "text" that looks
+    // populated but is unreadable — without this, such pages bypass OCR
+    // because text_length >= 20 and coverage looks fine. The same applies to
+    // unmappable items (Type3 fonts with no ToUnicode), whose text is a
+    // char-code fallback and whose bounding boxes come from deceptive
+    // declared metrics.
+    let text_length: usize = page
+        .text_items
+        .iter()
+        .filter(|item| !is_unusable_native(item))
+        .map(|item| item.text.len())
+        .sum();
+    let has_images = !page_obj.image_bounds(25.0, 0.9).is_empty();
+
+    let page_area = page.page_width * page.page_height;
+    let text_bbox_area: f32 = page
+        .text_items
+        .iter()
+        .filter(|item| !is_unusable_native(item))
+        .map(|item| item.width * item.height)
+        .sum();
+    let text_coverage = if page_area > 0.0 {
+        text_bbox_area / page_area
+    } else {
+        0.0
+    };
+
+    // Low spatial coverage only signals a scan/sparse page when there also
+    // isn't much native text. A text-dense page (e.g. a ruled table with
+    // wide intra-cell whitespace) is spatially sparse but needs no OCR.
+    let sparse_text = text_length < 2000 && text_coverage < 0.15;
+    let is_garbled = page_is_garbled(page);
+    let mut needs_ocr = text_length < 20 || sparse_text || has_images || is_garbled;
+
+    // Text drawn as filled vector outlines lives outside the text layer
+    // entirely: no text items, no image XObjects, so none of the cheap
+    // predicates fire on such a text-dense page. Detect it by measuring filled
+    // path area that native text doesn't account for. Checked last so this
+    // relatively expensive page-object walk only runs when the cheap predicates
+    // all pass; when they don't, the area is left unmeasured (`None`).
+    let uncovered_vector_area = if !needs_ocr {
+        let path_bounds = page_obj.filled_path_bounds(3.0, 0.9);
+        let uncovered = uncovered_path_area(&path_bounds, &page.text_items);
+        needs_ocr = uncovered >= UNCOVERED_VECTOR_AREA_THRESHOLD;
+        Some(uncovered)
+    } else {
+        None
+    };
+
+    Ok(PageComplexityStats {
+        page_number: page.page_number,
+        text_length,
+        text_coverage,
+        has_substantial_images: has_images,
+        uncovered_vector_area,
+        is_garbled,
+        page_area,
+        needs_ocr,
+    })
+}
+
 /// Render pages that need OCR from an already-open document.
 ///
 /// The pdfium `Document` holds raw pointers that are not `Send`, so callers must
@@ -33,54 +115,10 @@ pub(crate) fn render_pages_for_ocr(
 ) -> Result<Vec<RenderedPage>, LiteParseError> {
     let mut rendered = Vec::new();
     for (idx, page) in pages.iter().enumerate() {
-        // Count only usable native text. Substitution-cipher-style corrupt
-        // encodings (e.g. PDFs with a broken cmap) produce long "text" that looks
-        // populated but is unreadable — without this, such pages bypass OCR
-        // because text_length >= 20 and coverage looks fine. The same applies to
-        // unmappable items (Type3 fonts with no ToUnicode), whose text is a
-        // char-code fallback and whose bounding boxes come from deceptive
-        // declared metrics.
-        let text_length: usize = page
-            .text_items
-            .iter()
-            .filter(|item| !is_unusable_native(item))
-            .map(|item| item.text.len())
-            .sum();
         let page_obj = document.page((page.page_number - 1) as i32)?;
-        let has_images = !page_obj.image_bounds(25.0, 0.9).is_empty();
+        let page_complexity = calculate_page_complexity(page, &page_obj)?;
 
-        let page_area = page.page_width * page.page_height;
-        let text_bbox_area: f32 = page
-            .text_items
-            .iter()
-            .filter(|item| !is_unusable_native(item))
-            .map(|item| item.width * item.height)
-            .sum();
-        let text_coverage = if page_area > 0.0 {
-            text_bbox_area / page_area
-        } else {
-            0.0
-        };
-
-        // Low spatial coverage only signals a scan/sparse page when there also
-        // isn't much native text. A text-dense page (e.g. a ruled table with
-        // wide intra-cell whitespace) is spatially sparse but needs no OCR.
-        let sparse_text = text_length < 2000 && text_coverage < 0.15;
-        let mut needs_ocr = text_length < 20 || sparse_text || has_images || page_is_garbled(page);
-
-        // Text drawn as filled vector outlines lives outside the text layer
-        // entirely: no text items, no image XObjects, so none of the above
-        // triggers fire on a text-dense page. Detect it by measuring filled
-        // path area that native text doesn't account for. Checked last so the
-        // page-object walk only runs when the cheap predicates all pass.
-        if !needs_ocr {
-            let path_bounds = page_obj.filled_path_bounds(3.0, 0.9);
-            let uncovered = uncovered_path_area(&path_bounds, &page.text_items);
-
-            needs_ocr = uncovered >= UNCOVERED_VECTOR_AREA_THRESHOLD;
-        }
-
-        if !needs_ocr {
+        if !page_complexity.needs_ocr {
             continue;
         }
 

--- a/crates/liteparse/src/parser.rs
+++ b/crates/liteparse/src/parser.rs
@@ -80,6 +80,81 @@ impl LiteParse {
         self
     }
 
+    /// Parse the configured `target_pages` string (e.g. `"1-5,10"`) into an
+    /// explicit page list, or `None` when no selection was configured.
+    fn resolve_target_pages(&self) -> Result<Option<Vec<u32>>, LiteParseError> {
+        self.config
+            .target_pages
+            .as_ref()
+            .map(|s| parse_target_pages(s))
+            .transpose()
+            .map_err(|e| format!("invalid --target-pages: {}", e).into())
+    }
+
+    /// Determine the complexity of each page in a document, returning a vector
+    /// of `PageComplexityStats` for each page. This is useful for deciding
+    /// whether to enable OCR on a per-page basis, or for other heuristics.
+    pub async fn is_complex(
+        &self,
+        input: PdfInput,
+    ) -> Result<Vec<ocr_merge::PageComplexityStats>, LiteParseError> {
+        let log = |msg: &str| {
+            if !self.config.quiet {
+                eprintln!("{}", msg);
+            }
+        };
+
+        let t0 = web_time::Instant::now();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let (validated_input, _guard) =
+            conversion::resolve_pdf_input(input, self.config.password.as_deref(), false).await?;
+
+        #[cfg(target_arch = "wasm32")]
+        let validated_input = input;
+
+        // Determine which pages to extract
+        let target_pages = self.resolve_target_pages()?;
+
+        // Load the document and extract text items. Complexity signals derive
+        // from the text layer and page objects only — embedded image rasters
+        // and hyperlinks are irrelevant here, so both are skipped to keep this
+        // pass fast (its whole purpose is a cheap pre-OCR check).
+        let password = self.config.password.as_deref();
+
+        let lib = Library::init();
+        let document = extract::load_document_from_input(&lib, &validated_input, password)?;
+
+        let (pages, _) = extract::extract_pages_and_images(
+            &document,
+            target_pages.as_deref(),
+            self.config.max_pages,
+            false, // render_images: image rasters not needed for complexity
+            false, // extract_links: irrelevant for complexity stats
+        )?;
+        let t_extract = web_time::Instant::now();
+        log(&format!(
+            "[liteparse] extract: {:.1}ms ({} pages)",
+            t_extract.duration_since(t0).as_secs_f64() * 1000.0,
+            pages.len()
+        ));
+
+        let t_complexity = web_time::Instant::now();
+        let page_complexities = pages
+            .iter()
+            .map(|page| {
+                let page_obj = document.page((page.page_number - 1) as i32)?;
+                ocr_merge::calculate_page_complexity(page, &page_obj)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        log(&format!(
+            "[liteparse] complexity: {:.1}ms",
+            t_complexity.duration_since(t_extract).as_secs_f64() * 1000.0
+        ));
+
+        Ok(page_complexities)
+    }
+
     /// Parse a document from a file path, returning structured results.
     ///
     /// Non-PDF files are automatically converted to PDF first (requires
@@ -113,13 +188,7 @@ impl LiteParse {
         let validated_input = input;
 
         // Determine which pages to extract
-        let target_pages = self
-            .config
-            .target_pages
-            .as_ref()
-            .map(|s| parse_target_pages(s))
-            .transpose()
-            .map_err(|e| format!("invalid --target-pages: {}", e))?;
+        let target_pages = self.resolve_target_pages()?;
 
         // Extract text (and pre-render OCR pages in one PDF load when OCR is on).
         // The PDFium lock is acquired for this entire critical section and

--- a/packages/node/src/cli.ts
+++ b/packages/node/src/cli.ts
@@ -147,7 +147,7 @@ program
     "Check if a document is 'complex' enough to require OCR or other advanced parsing",
   )
   .argument("<file>", "Path to the document file")
-  .option("--json", "Output the result as JSON")
+  .option("--compact", "Emit dense, whitespace-free JSON instead of pretty")
   .option("--max-pages <n>", "Max pages to parse", parseInt)
   .option(
     "--target-pages <pages>",
@@ -168,36 +168,23 @@ program
 
       const complexPages = stats.filter((s) => s.needsOcr).length;
 
-      if (opts.json) {
-        process.stdout.write(JSON.stringify(stats));
-        process.stdout.write("\n");
-      } else {
+      // Always emit JSON on stdout so the command composes with `jq` without a
+      // flag. Pretty by default; `--compact` drops the whitespace. Both parse
+      // identically for any reader.
+      process.stdout.write(
+        opts.compact
+          ? JSON.stringify(stats)
+          : JSON.stringify(stats, null, 2),
+      );
+      process.stdout.write("\n");
+
+      // Human verdict goes to stderr so it never pollutes the JSON on stdout;
+      // the exit code below carries the same signal for scripts.
+      if (!opts.quiet) {
         const verdict = complexPages > 0 ? "COMPLEX" : "SIMPLE";
-        console.log(
+        console.error(
           `${verdict} — ${complexPages}/${stats.length} page(s) need OCR`,
         );
-        console.log(
-          ["page", "text", "cov", "images", "garbled", "vector", "ocr"].join(
-            "\t",
-          ),
-        );
-        for (const s of stats) {
-          const vector =
-            s.uncoveredVectorArea !== undefined
-              ? s.uncoveredVectorArea.toFixed(0)
-              : "-";
-          console.log(
-            [
-              s.pageNumber,
-              s.textLength,
-              s.textCoverage.toFixed(2),
-              s.hasSubstantialImages ? "yes" : "no",
-              s.isGarbled ? "yes" : "no",
-              vector,
-              s.needsOcr ? "yes" : "no",
-            ].join("\t"),
-          );
-        }
       }
 
       // Exit non-zero when any page needs OCR, so the command is usable as a

--- a/packages/node/src/cli.ts
+++ b/packages/node/src/cli.ts
@@ -142,6 +142,76 @@ program
   });
 
 program
+  .command("is-complex")
+  .description(
+    "Check if a document is 'complex' enough to require OCR or other advanced parsing",
+  )
+  .argument("<file>", "Path to the document file")
+  .option("--json", "Output the result as JSON")
+  .option("--max-pages <n>", "Max pages to parse", parseInt)
+  .option(
+    "--target-pages <pages>",
+    'Pages to check (e.g., "1-5,10,15-20")',
+  )
+  .option("--password <password>", "Password for encrypted documents")
+  .option("-q, --quiet", "Suppress progress output")
+  .action(async (file: string, opts: Record<string, unknown>) => {
+    try {
+      const config: Partial<LiteParseConfig> = {};
+      if (opts.maxPages) config.maxPages = opts.maxPages as number;
+      if (opts.targetPages) config.targetPages = opts.targetPages as string;
+      if (opts.password) config.password = opts.password as string;
+      if (opts.quiet) config.quiet = true;
+
+      const parser = new LiteParse(config);
+      const stats = await parser.isComplex(file);
+
+      const complexPages = stats.filter((s) => s.needsOcr).length;
+
+      if (opts.json) {
+        process.stdout.write(JSON.stringify(stats));
+        process.stdout.write("\n");
+      } else {
+        const verdict = complexPages > 0 ? "COMPLEX" : "SIMPLE";
+        console.log(
+          `${verdict} — ${complexPages}/${stats.length} page(s) need OCR`,
+        );
+        console.log(
+          ["page", "text", "cov", "images", "garbled", "vector", "ocr"].join(
+            "\t",
+          ),
+        );
+        for (const s of stats) {
+          const vector =
+            s.uncoveredVectorArea !== undefined
+              ? s.uncoveredVectorArea.toFixed(0)
+              : "-";
+          console.log(
+            [
+              s.pageNumber,
+              s.textLength,
+              s.textCoverage.toFixed(2),
+              s.hasSubstantialImages ? "yes" : "no",
+              s.isGarbled ? "yes" : "no",
+              vector,
+              s.needsOcr ? "yes" : "no",
+            ].join("\t"),
+          );
+        }
+      }
+
+      // Exit non-zero when any page needs OCR, so the command is usable as a
+      // shell predicate (e.g. `is-complex doc.pdf && parse --no-ocr`).
+      if (complexPages > 0) process.exit(1);
+    } catch (err) {
+      console.error(
+        `Error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(1);
+    }
+  });
+
+program
   .command("screenshot")
   .description("Generate screenshots of document pages")
   .argument("<file>", "Path to the document file")

--- a/packages/node/src/lib.ts
+++ b/packages/node/src/lib.ts
@@ -133,8 +133,14 @@ export interface PageComplexityStats {
   imageBlockCount: number;
   /** Summed image-bbox area over page area, clamped to 1. */
   imageCoverage: number;
-  /** Largest single image's area over page area, clamped to 1. */
+  /** Largest single *counted* image's area over page area, clamped to 1. */
   largestImageCoverage: number;
+  /**
+   * A single raster covers ≥90% of the page. Full-page backgrounds are excluded
+   * from the image coverage fields, so this is the only signal that tells a scan
+   * apart from a blank page — both otherwise report no text and no images.
+   */
+  fullPageImage: boolean;
   /**
    * Filled vector-outline area not covered by native text, in pt². `undefined`
    * when a cheaper signal already decided the page, so this walk was skipped.
@@ -142,8 +148,14 @@ export interface PageComplexityStats {
   uncoveredVectorArea?: number;
   isGarbled: boolean;
   pageArea: number;
-  /** Verdict: whether this page should be sent through OCR. */
+  /** Verdict: whether this page needs more than the cheap text-only path. */
   needsOcr: boolean;
+  /**
+   * Every reason the page was flagged (e.g. `"scanned"`, `"sparse-text"`,
+   * `"garbled"`). Empty exactly when `needsOcr` is false. This is the value to
+   * route on; new reasons may be added over time.
+   */
+  reasons: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -248,10 +260,12 @@ export class LiteParse {
       imageBlockCount: s.imageBlockCount,
       imageCoverage: s.imageCoverage,
       largestImageCoverage: s.largestImageCoverage,
+      fullPageImage: s.fullPageImage,
       uncoveredVectorArea: s.uncoveredVectorArea ?? undefined,
       isGarbled: s.isGarbled,
       pageArea: s.pageArea,
       needsOcr: s.needsOcr,
+      reasons: s.reasons,
     }));
   }
 

--- a/packages/node/src/lib.ts
+++ b/packages/node/src/lib.ts
@@ -7,6 +7,7 @@ import {
   type NativePageInput,
   type NativeTextItem,
   type NativeExtractedImage,
+  type NativePageComplexityStats,
 } from "./native.js";
 
 // ---------------------------------------------------------------------------
@@ -119,6 +120,32 @@ export interface ScreenshotResult {
   imageBuffer: Buffer;
 }
 
+/**
+ * Per-page complexity signals from {@link LiteParse.isComplex}, used to decide
+ * whether a document needs OCR or other advanced parsing.
+ */
+export interface PageComplexityStats {
+  pageNumber: number;
+  textLength: number;
+  /** Fraction of the page area covered by native text (0–1). */
+  textCoverage: number;
+  hasSubstantialImages: boolean;
+  imageBlockCount: number;
+  /** Summed image-bbox area over page area, clamped to 1. */
+  imageCoverage: number;
+  /** Largest single image's area over page area, clamped to 1. */
+  largestImageCoverage: number;
+  /**
+   * Filled vector-outline area not covered by native text, in pt². `undefined`
+   * when a cheaper signal already decided the page, so this walk was skipped.
+   */
+  uncoveredVectorArea?: number;
+  isGarbled: boolean;
+  pageArea: number;
+  /** Verdict: whether this page should be sent through OCR. */
+  needsOcr: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // LiteParse class
 // ---------------------------------------------------------------------------
@@ -201,6 +228,31 @@ export class LiteParse {
       text: result.text,
       images: (result.images ?? []).map(toImage),
     };
+  }
+
+  /**
+   * Determine per-page complexity without running a full parse. Returns one
+   * entry per page with signals and a `needsOcr` verdict — a cheap pre-OCR
+   * check to decide whether a document needs advanced parsing.
+   */
+  async isComplex(input: LiteParseInput): Promise<PageComplexityStats[]> {
+    const nativeInput =
+      typeof input === "string" ? input : Buffer.from(input);
+    const stats: NativePageComplexityStats[] =
+      await this._native.isComplex(nativeInput);
+    return stats.map((s) => ({
+      pageNumber: s.pageNumber,
+      textLength: s.textLength,
+      textCoverage: s.textCoverage,
+      hasSubstantialImages: s.hasSubstantialImages,
+      imageBlockCount: s.imageBlockCount,
+      imageCoverage: s.imageCoverage,
+      largestImageCoverage: s.largestImageCoverage,
+      uncoveredVectorArea: s.uncoveredVectorArea ?? undefined,
+      isGarbled: s.isGarbled,
+      pageArea: s.pageArea,
+      needsOcr: s.needsOcr,
+    }));
   }
 
   async screenshot(

--- a/packages/node/src/native.ts
+++ b/packages/node/src/native.ts
@@ -110,10 +110,12 @@ export interface NativePageComplexityStats {
   imageBlockCount: number;
   imageCoverage: number;
   largestImageCoverage: number;
+  fullPageImage: boolean;
   uncoveredVectorArea?: number;
   isGarbled: boolean;
   pageArea: number;
   needsOcr: boolean;
+  reasons: string[];
 }
 
 export interface LiteParseNative {

--- a/packages/node/src/native.ts
+++ b/packages/node/src/native.ts
@@ -102,9 +102,24 @@ export interface NativeScreenshotResult {
   imageBuffer: Buffer;
 }
 
+export interface NativePageComplexityStats {
+  pageNumber: number;
+  textLength: number;
+  textCoverage: number;
+  hasSubstantialImages: boolean;
+  imageBlockCount: number;
+  imageCoverage: number;
+  largestImageCoverage: number;
+  uncoveredVectorArea?: number;
+  isGarbled: boolean;
+  pageArea: number;
+  needsOcr: boolean;
+}
+
 export interface LiteParseNative {
   parse(input: string | Buffer): Promise<NativeParseResult>;
   parsePages(pages: NativePageInput[]): NativeParseResult;
+  isComplex(input: string | Buffer): Promise<NativePageComplexityStats[]>;
   screenshot(
     input: string | Buffer,
     pageNumbers?: number[] | null,

--- a/packages/python/liteparse/__init__.py
+++ b/packages/python/liteparse/__init__.py
@@ -2,6 +2,7 @@ from .parser import LiteParse, search_items
 from .types import (
     ExtractedImage,
     LiteParseConfig,
+    PageComplexityStats,
     ParseResult,
     ParsedPage,
     TextItem,
@@ -17,6 +18,7 @@ __all__ = [
     "ParsedPage",
     "TextItem",
     "ScreenshotResult",
+    "PageComplexityStats",
     "ExtractedImage",
     "ParseError",
     "search_items",

--- a/packages/python/liteparse/parser.py
+++ b/packages/python/liteparse/parser.py
@@ -216,10 +216,12 @@ class LiteParse:
                     image_block_count=s.image_block_count,
                     image_coverage=s.image_coverage,
                     largest_image_coverage=s.largest_image_coverage,
+                    full_page_image=s.full_page_image,
                     uncovered_vector_area=s.uncovered_vector_area,
                     is_garbled=s.is_garbled,
                     page_area=s.page_area,
                     needs_ocr=s.needs_ocr,
+                    reasons=list(s.reasons),
                 )
                 for s in native_stats
             ]

--- a/packages/python/liteparse/parser.py
+++ b/packages/python/liteparse/parser.py
@@ -9,6 +9,7 @@ from liteparse._liteparse import search_items as _native_search_items
 from .types import (
     ExtractedImage,
     LiteParseConfig,
+    PageComplexityStats,
     ParsedPage,
     ParseError,
     ParseResult,
@@ -172,6 +173,56 @@ class LiteParse:
                     raise FileNotFoundError(f"File not found: {file_path}")
                 native_result = self._native.parse(str(file_path.absolute()))
             return _convert_native_result(native_result)
+        except FileNotFoundError:
+            raise
+        except Exception as e:
+            raise ParseError(str(e)) from e
+
+    def is_complex(
+        self,
+        file_data: Union[str, Path, bytes],
+    ) -> List[PageComplexityStats]:
+        """
+        Determine per-page complexity without running a full parse.
+
+        Returns one entry per page with signals (text coverage, images, garbled
+        text, vector area) and a ``needs_ocr`` verdict — a cheap pre-OCR check to
+        decide whether a document needs advanced parsing.
+
+        Args:
+            file_data: Path to the document file, or raw PDF bytes.
+
+        Returns:
+            List of PageComplexityStats, one per page.
+
+        Raises:
+            ParseError: If the check fails.
+            FileNotFoundError: If the file doesn't exist.
+        """
+        try:
+            if isinstance(file_data, bytes):
+                native_stats = self._native.is_complex_bytes(file_data)
+            else:
+                file_path = Path(file_data)
+                if not file_path.exists():
+                    raise FileNotFoundError(f"File not found: {file_path}")
+                native_stats = self._native.is_complex(str(file_path.absolute()))
+            return [
+                PageComplexityStats(
+                    page_number=s.page_number,
+                    text_length=s.text_length,
+                    text_coverage=s.text_coverage,
+                    has_substantial_images=s.has_substantial_images,
+                    image_block_count=s.image_block_count,
+                    image_coverage=s.image_coverage,
+                    largest_image_coverage=s.largest_image_coverage,
+                    uncovered_vector_area=s.uncovered_vector_area,
+                    is_garbled=s.is_garbled,
+                    page_area=s.page_area,
+                    needs_ocr=s.needs_ocr,
+                )
+                for s in native_stats
+            ]
         except FileNotFoundError:
             raise
         except Exception as e:

--- a/packages/python/liteparse/types.py
+++ b/packages/python/liteparse/types.py
@@ -81,10 +81,12 @@ class PageComplexityStats:
     image_block_count: int
     image_coverage: float
     largest_image_coverage: float
+    full_page_image: bool
     uncovered_vector_area: Optional[float]
     is_garbled: bool
     page_area: float
     needs_ocr: bool
+    reasons: list[str]
 
 
 @dataclass

--- a/packages/python/liteparse/types.py
+++ b/packages/python/liteparse/types.py
@@ -72,6 +72,22 @@ class ScreenshotResult:
 
 
 @dataclass
+class PageComplexityStats:
+    """Per-page complexity signals used to decide whether a document needs OCR."""
+    page_number: int
+    text_length: int
+    text_coverage: float
+    has_substantial_images: bool
+    image_block_count: int
+    image_coverage: float
+    largest_image_coverage: float
+    uncovered_vector_area: Optional[float]
+    is_garbled: bool
+    page_area: float
+    needs_ocr: bool
+
+
+@dataclass
 class LiteParseConfig:
     """Resolved parser configuration."""
     ocr_language: str


### PR DESCRIPTION
Adds a dedicated function for deciding if a PDF page is complex and needs OCR or more advanced processing
- exit code 1 or 0 for the entire doc on the CLI
- detailed stats per page for user-defined routing
- optional JSON mode for processing downstream
- exposed in library + CLI

```bash
# basic usage
$ lit is-complex paper.pdf       
[liteparse] extract: 221.9ms (8 pages)
[liteparse] complexity: 0.0ms
[
  {
    "page_number": 1,
    "text_length": 3586,
    "text_coverage": 0.3047249,
    "has_substantial_images": false,
    "image_block_count": 0,
    "image_coverage": 0.0,
    "largest_image_coverage": 0.0,
    "full_page_image": false,
    "uncovered_vector_area": 848.9645,
    "is_garbled": false,
    "page_area": 501156.9,
    "needs_ocr": true,
    "reasons": [
      "vector-text"
    ]
  },
  {
    "page_number": 2,
    ...
   },
  ...
]

# jq chaining
$ lit is-complex paper.pdf -q | jq '[.[] | select(.needs_ocr) | .page_number]'
[
  1,
  4,
  7
]

# decide doc-wide if processing is needed
$ lit is-complex paper.pdf -q && lit parse paper.pdf --no-ocr || echo "might need better processing"
might need better processing
```