### PR TITLE
fix(suryaocr): run Surya 2 on GPU in a single llama.cpp container

### DIFF
--- a/ocr/suryaocr/Dockerfile
+++ b/ocr/suryaocr/Dockerfile
@@ -1,25 +1,51 @@
-FROM ghcr.io/astral-sh/uv:python3.12-trixie
+# Single image: GPU-enabled llama.cpp `llama-server` + the Surya OCR API.
+#
+# Based on the official CUDA llama.cpp server image, which already provides a
+# `qwen35`-capable `llama-server` (with libggml-cuda), the CUDA runtime, and
+# Python 3.12. Surya's llamacpp backend finds `llama-server` on PATH and spawns
+# it INSIDE this same container, so one image runs both the API and the model
+# server. Run with `--gpus all`.
+#
+# (Stock Ollama's bundled llama.cpp cannot load Surya 2's custom qwen35 GGUF;
+#  this upstream build can.)
+FROM ghcr.io/ggml-org/llama.cpp:server-cuda
 
-# System libraries needed by torch / Pillow / Surya
-RUN apt-get update && apt-get install -y \
-    libgomp1 \
-    libglib2.0-0 \
-    libsm6 \
-    libxext6 \
-    libxrender-dev \
+# Bring uv in from its official image (no external install script needed).
+COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /usr/local/bin/uv
+
+# Python/runtime libs for Surya, torch, and Pillow.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-venv \
     libgl1 \
+    libglib2.0-0 \
+    libgomp1 \
+    libcurl4 \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
+# llama-server and its shared libraries live in /app.
+ENV PATH="/app:${PATH}"
+ENV LD_LIBRARY_PATH="/app:${LD_LIBRARY_PATH}"
+
+# Surya: llama.cpp backend, all layers on GPU. Surya spawns llama-server and
+# downloads the GGUF weights from Hugging Face on the first OCR request.
+ENV SURYA_INFERENCE_BACKEND=llamacpp
+ENV LLAMA_CPP_NGL=99
+# Surya's layout step is the only request that sends a grammar; its regex
+# `pattern` breaks the upstream llama.cpp grammar parser. Run layout
+# unconstrained so the OCR pipeline returns results on this build.
+ENV SURYA_GUIDED_LAYOUT=false
+# Cache model weights (Surya torch models + the GGUF) under /models.
+ENV HF_HOME=/models
+
+WORKDIR /opt/app
 
 # Copy project metadata, lockfile, and server code
 COPY pyproject.toml uv.lock README.md server.py test_server.py ./
 
-# Install dependencies
+# Install dependencies (uses the committed lockfile)
 RUN uv sync --frozen
 
-# Expose port
+# The base image's entrypoint is llama-server; clear it and run the API.
+ENTRYPOINT []
 EXPOSE 8830
-
-# Run server
 CMD ["uv", "run", "python3", "server.py"]

--- a/ocr/suryaocr/README.md
+++ b/ocr/suryaocr/README.md
@@ -34,6 +34,50 @@ inference backend, which you must provide. Surya does **not** bundle it.
 Without a backend, startup succeeds and `GET /health` works, but `POST /ocr`
 returns a 500 with "llama-server binary not found".
 
+## Docker (GPU, single image)
+
+The provided `Dockerfile` builds **one image that runs both the API and the
+model server on a GPU**. It is based on the official CUDA llama.cpp image
+(`ghcr.io/ggml-org/llama.cpp:server-cuda`), which ships a `qwen35`-capable
+`llama-server` (Surya 2's custom GGUF architecture) with `libggml-cuda` and the
+CUDA runtime. Surya spawns `llama-server` from `PATH` inside the same container,
+so no sidecar or separate inference service is needed.
+
+```bash
+# Build
+docker build -t suryaocr-liteparse:cuda .
+
+# Run (requires the NVIDIA container runtime)
+docker run --rm --gpus all -p 8830:8830 \
+  -v "$HOME/.cache/suryaocr-models:/models" \
+  suryaocr-liteparse:cuda
+```
+
+- `--gpus all` exposes the host GPUs; all model layers are offloaded
+  (`LLAMA_CPP_NGL=99`).
+- The `-v …:/models` mount caches weights (`HF_HOME=/models`). The **first**
+  `POST /ocr` downloads the GGUF weights from Hugging Face and spawns
+  `llama-server` (a few minutes); subsequent requests reuse the cache and the
+  running server.
+
+The image bakes in the backend configuration: `SURYA_INFERENCE_BACKEND=llamacpp`,
+`LLAMA_CPP_NGL=99`, and `SURYA_GUIDED_LAYOUT=false`. The last one is required on
+the upstream `llama-server` build: Surya's layout step is the only request that
+sends a grammar, and its regex `pattern` breaks llama.cpp's
+json-schema→GBNF converter (`failed to parse grammar`), which otherwise yields
+empty results. With guided layout off, layout runs as free generation (Surya
+parses the output itself) and the rest of the pipeline never uses a grammar.
+
+To use a CUDA GPU via vLLM instead of bundled llama.cpp, set
+`SURYA_INFERENCE_BACKEND=vllm` (see the backend section above).
+
+Verify it is up:
+
+```bash
+curl http://localhost:8830/health
+curl -X POST -F "file=@image.png" http://localhost:8830/ocr
+```
+
 ## Usage
 
 The service exposes:
@@ -86,13 +130,20 @@ performance across both Latin and non-Latin scripts.
 
 ## Device / GPU
 
-Surya auto-detects the best available device. Force a device with the
-`TORCH_DEVICE` environment variable:
+There are two device knobs, for two different parts of the pipeline:
 
-```bash
-TORCH_DEVICE=cuda uv run server.py   # GPU
-TORCH_DEVICE=cpu  uv run server.py   # CPU
-```
+- `LLAMA_CPP_NGL` controls how many layers of the **VLM** (the model that reads
+  text) the `llamacpp` backend offloads to the GPU. `99` offloads everything;
+  `0` keeps it on CPU. The Docker image sets `99`.
+- `TORCH_DEVICE` controls the device for Surya's **helper torch models**
+  (e.g. layout). Surya auto-detects, or you can force it:
+
+  ```bash
+  TORCH_DEVICE=cuda uv run server.py   # GPU
+  TORCH_DEVICE=cpu  uv run server.py   # CPU
+  ```
+
+For a turnkey GPU deployment, prefer the Docker image above — it wires both up.
 
 ## Use with LiteParse
 

--- a/ocr/suryaocr/server.py
+++ b/ocr/suryaocr/server.py
@@ -1,10 +1,27 @@
 import io
 import logging
+import os
 import re
 import traceback
 from html import unescape
 from html.parser import HTMLParser
 from typing import Any
+
+# Surya 2 is a VLM-backed model: text recognition runs through an inference
+# backend. Default to the CPU-friendly llama.cpp backend, which spawns a
+# `llama-server` binary (bundled in the Docker image; install locally with
+# `brew install llama.cpp` or from github.com/ggml-org/llama.cpp/releases) and
+# downloads the GGUF weights on first use. Override for GPU with
+# SURYA_INFERENCE_BACKEND=vllm, or attach to an already-running inference
+# server with SURYA_INFERENCE_URL. These must be set before importing surya.
+os.environ.setdefault("SURYA_INFERENCE_BACKEND", "llamacpp")
+os.environ.setdefault("LLAMA_CPP_NGL", "0")  # 0 = CPU; set 99 for full GPU offload
+# Surya only sends a grammar for the layout step (LAYOUT_JSON_SCHEMA), whose
+# regex `pattern` the upstream llama.cpp json-schema→GBNF converter cannot
+# parse ("failed to parse grammar"). Disable guided layout so layout runs as
+# free generation (Surya parses the output itself); block/full-page OCR never
+# use a grammar. Required for the llama.cpp backend to return results.
+os.environ.setdefault("SURYA_GUIDED_LAYOUT", "false")
 
 import uvicorn
 from fastapi import FastAPI, HTTPException


### PR DESCRIPTION
## Summary

Makes the `ocr/suryaocr` server actually serve OCR. The merged Surya server (#323) shipped a **CPU-only image with no inference-backend configuration**, so a live `POST /ocr` had no VLM backend to talk to and returned empty results. This PR wires up Surya 2's llama.cpp backend end-to-end inside a **single GPU container**.

## What changed

**`Dockerfile` — single GPU image**
- Rebased on `ghcr.io/ggml-org/llama.cpp:server-cuda`, which ships a `qwen35`-capable `llama-server` (Surya 2's custom GGUF architecture — stock Ollama's bundled llama.cpp cannot load it), `libggml-cuda`, and the CUDA runtime.
- Surya spawns `llama-server` from `PATH` **inside the same container**, so one image runs both the API and the model server. Run with `--gpus all`.
- Adds `uv`, the Python/torch/Pillow runtime libs, a GGUF cache dir (`HF_HOME=/models`), and clears the base image entrypoint.

**`server.py` — backend selection + grammar fix**
- Selects the `llamacpp` backend before importing `surya`, and documents the `vllm` / `SURYA_INFERENCE_URL` overrides.
- Sets `SURYA_GUIDED_LAYOUT=false`. Surya's layout step is the only request that sends a grammar, and its regex `pattern` (`^\d{1,4} \d{1,4} \d{1,4} \d{1,4}$`) breaks the upstream llama.cpp json-schema→GBNF converter (`failed to parse grammar`) — which was the direct cause of the empty results. With it off, layout runs as free generation (Surya parses the output itself); block and full-page OCR never use a grammar.

## Why this was empty before

`RecognitionPredictor([image])` runs full-page OCR → output loops → falls back to layout + block OCR. The layout request sent the json-schema grammar → `llama-server` returned `400 failed to parse grammar` → no layout boxes → no blocks → `{"results":[]}`. Block OCR (the step that reads text) sends no grammar and works fine once it receives boxes.

## Testing

Verified on a 4× A100 box:
- Build succeeds; single container started with `--gpus all`.
- `GET /health` → `{"status":"healthy"}`.
- `POST /ocr` on a receipt image → **10 text blocks** with bboxes and confidence (e.g. `SHOP`, `Article Count Amount Tax`, `T-Shirt XL.....1 $14,95 20%`, `GROSS $75,80`), `llama-server` running on GPU.
- `9/9` unit tests pass (`pytest test_server.py`).

No change to the LiteParse OCR API contract — `/ocr` still returns `{ results: [{ text, bbox, confidence, polygon? }] }`.
