### PR TITLE
fix(config): default ocr_enabled off when no built-in OCR engine is compiled in

### DIFF
--- a/crates/liteparse/src/config.rs
+++ b/crates/liteparse/src/config.rs
@@ -72,7 +72,17 @@ impl Default for LiteParseConfig {
     fn default() -> Self {
         Self {
             ocr_language: "eng".to_string(),
-            ocr_enabled: true,
+            // OCR is on by default only when a built-in engine is compiled in
+            // (the `tesseract` feature). Builds without a built-in engine
+            // (`tesseract` disabled, or WASM) default to OFF, so a consumer that
+            // just wants native text extraction works out of the box instead of
+            // hitting "OCR enabled but no engine available". OCR is still fully
+            // available in those builds by opting in explicitly: set
+            // `ocr_enabled = true` together with an `ocr_server_url` (or, on
+            // WASM, an `ocrEngine` callback). That explicit request still fails
+            // fast if no engine is reachable, so a real misconfiguration is
+            // never silently swallowed.
+            ocr_enabled: cfg!(feature = "tesseract"),
             ocr_server_url: None,
             ocr_server_headers: Vec::new(),
             tessdata_path: None,
@@ -196,7 +206,8 @@ mod tests {
     fn test_default_config() {
         let c = LiteParseConfig::default();
         assert_eq!(c.ocr_language, "eng");
-        assert!(c.ocr_enabled);
+        // OCR defaults on only when a built-in engine is compiled in.
+        assert_eq!(c.ocr_enabled, cfg!(feature = "tesseract"));
         assert_eq!(c.max_pages, 1000);
         assert_eq!(c.dpi, 150.0);
         assert_eq!(c.output_format, OutputFormat::Json);


### PR DESCRIPTION
## What

`LiteParseConfig::default()` sets `ocr_enabled = true` unconditionally. In a build with no built-in OCR engine — the `tesseract` feature disabled, or a WASM build — `parse_input` then fails with `OCR enabled but no ... engine` on every document, including born-digital PDFs that need no OCR.

This defaults `ocr_enabled` to whether a built-in engine is compiled in (`cfg!(feature = "tesseract")`).

## Why

Embedding liteparse as a library without the Tesseract/Leptonica system dependencies is a natural choice, but the default config currently makes every parse fail in that configuration until the caller also sets `ocr_enabled = false`. Tying the default to engine availability makes it work out of the box.

This changes only the **default**, not the error behavior. A build that explicitly opts into OCR (`ocr_enabled = true` together with an `ocr_server_url`, or a WASM `ocrEngine` callback) still **fails fast** when no engine is reachable, so a genuine misconfiguration is never silently swallowed.

- `tesseract` feature on (the default build): unchanged, OCR on by default.
- no built-in engine: OCR off by default; native text extraction works out of the box; explicit opt-in still fails fast.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo test -p liteparse --no-default-features --lib` green (`test_default_config` updated to assert the feature-aware default)
- `cargo clippy --no-default-features` no new warnings

## Notes

Open to alternatives if you'd prefer to keep the unconditional default (for example, leaving it and documenting the engine-less setup instead). This felt like the least-surprising out-of-box behavior while preserving fail-fast for explicit OCR requests. Happy to adjust.
