### PR TITLE
fix: derive __version__ from package metadata instead of a stale literal

### DIFF
--- a/packages/python/liteparse/__init__.py
+++ b/packages/python/liteparse/__init__.py
@@ -1,3 +1,5 @@
+from importlib.metadata import PackageNotFoundError, version
+
 from .parser import LiteParse, search_items
 from .types import (
     ExtractedImage,
@@ -11,7 +13,10 @@ from .types import (
     ParseError,
 )
 
-__version__ = "2.0.0"
+try:
+    __version__ = version("liteparse")
+except PackageNotFoundError:  # source tree without installed dist metadata
+    __version__ = "0.0.0+unknown"
 __all__ = [
     "LiteParse",
     "LiteParseConfig",


### PR DESCRIPTION
## Problem

`liteparse.__version__` is a hardcoded literal in `packages/python/liteparse/__init__.py` that has been stuck at `"2.0.0"` while the package has continued to release. On the current `2.5.1` wheel:

```python
>>> import liteparse, importlib.metadata
>>> liteparse.__version__
'2.0.0'
>>> importlib.metadata.version("liteparse")
'2.5.1'
```

The attribute disagrees with the real installed version (the one in `packages/python/pyproject.toml`), so any downstream code that pins or logs `__version__` reads the wrong value.

## Fix

Derive `__version__` from the installed distribution metadata instead of duplicating the version as a literal, so it stays in lockstep with `pyproject.toml` automatically and never drifts again:

```python
from importlib.metadata import PackageNotFoundError, version

try:
    __version__ = version("liteparse")
except PackageNotFoundError:  # source tree without installed dist metadata
    __version__ = "0.0.0+unknown"
```

`importlib.metadata` is stdlib on the supported Pythons (`requires-python >=3.10`), so no new dependency. The `PackageNotFoundError` guard keeps `import liteparse` working from a raw source checkout that hasn't been installed.

## Scope / verification

Pure-Python, single-file change — no Rust, no bindings, no parsing behavior touched (so it can't affect the regression suite). Verified against the installed `2.5.1` wheel: `__version__` now reports `2.5.1` and matches `importlib.metadata.version("liteparse")`.
