### PR TITLE
fix: proper stub fallback in wasm build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,6 +1312,7 @@ dependencies = [
  "console_error_panic_hook",
  "js-sys",
  "liteparse",
+ "liteparse-pdfium-sys",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",

--- a/crates/liteparse-wasm/Cargo.toml
+++ b/crates/liteparse-wasm/Cargo.toml
@@ -20,6 +20,14 @@ serde-wasm-bindgen = "0.6"
 tsify-next = { version = "0.5", default-features = false, features = ["js"] }
 console_error_panic_hook = { version = "0.1", optional = true }
 
+# Direct dependency purely so this crate's build script receives
+# DEP_PDFIUM_LIB_PATH (pdfium-sys sets `links = "pdfium"`). build.rs uses it to
+# detect whether pdfium ships a standalone libsetjmp.a and, if so, drop the
+# fallback setjmp/longjmp stubs in wasi_stubs.rs. Only the wasm target links
+# pdfium statically, so scope it there.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+pdfium-sys = { package = "liteparse-pdfium-sys", version = "1.3.0", path = "../pdfium-sys" }
+
 [features]
 default = ["panic_hook"]
 panic_hook = ["dep:console_error_panic_hook"]

--- a/crates/liteparse-wasm/build.rs
+++ b/crates/liteparse-wasm/build.rs
@@ -1,7 +1,15 @@
 use std::env;
+use std::path::Path;
 
 fn main() {
+    // Declared so `#[cfg(have_libsetjmp)]` in wasi_stubs.rs doesn't trip the
+    // unexpected-cfgs lint on toolchains that check it.
+    println!("cargo:rustc-check-cfg=cfg(have_libsetjmp)");
+
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    if target_arch != "wasm32" {
+        return;
+    }
 
     // pdfium's wasm build links libsetjmp.a for __c_longjmp, but that archive's
     // single object also defines the __wasm_setjmp/__wasm_longjmp helpers that
@@ -9,7 +17,21 @@ fn main() {
     // helpers, so allow the linker to keep the first and resolve the otherwise
     // missing __c_longjmp from the same archive. Must live here (the final
     // cdylib) because rustc-link-arg is not propagated from dependency crates.
-    if target_arch == "wasm32" {
-        println!("cargo:rustc-link-arg=--allow-multiple-definition");
+    println!("cargo:rustc-link-arg=--allow-multiple-definition");
+
+    // pdfium-sys (links = "pdfium") exports the resolved pdfium lib dir as
+    // DEP_PDFIUM_LIB_PATH. Newer pdfium wasm releases ship a standalone
+    // libsetjmp.a providing the *real* __wasm_longjmp, which throws the
+    // __c_longjmp WASM exception tag so FreeType's setjmp error recovery can
+    // unwind. When that archive is linked we set `have_libsetjmp` so the
+    // fallback setjmp/longjmp stubs in wasi_stubs.rs are dropped — otherwise the
+    // trapping __wasm_longjmp stub shadows the real one (link order +
+    // --allow-multiple-definition keep the first definition) and any FreeType
+    // longjmp aborts the whole module. Older pdfium builds fold setjmp into
+    // libc.a with no libsetjmp.a; there the stubs remain the only providers.
+    if let Ok(lib_path) = env::var("DEP_PDFIUM_LIB_PATH") {
+        if Path::new(&lib_path).join("libsetjmp.a").exists() {
+            println!("cargo:rustc-cfg=have_libsetjmp");
+        }
     }
 }

--- a/crates/liteparse-wasm/src/wasi_stubs.rs
+++ b/crates/liteparse-wasm/src/wasi_stubs.rs
@@ -43,8 +43,18 @@ pub extern "C" fn pthread_mutex_destroy(_mutex: *mut u8) -> i32 {
 //   - __wasm_setjmp_test(table, env) -> label — 2 params
 //
 // The table is a flat array of (env, label) pairs on the stack, zero-terminated.
+//
+// These are FALLBACK stubs, compiled only when the linked pdfium build ships no
+// standalone libsetjmp.a (older releases that fold setjmp into libc.a). When
+// libsetjmp.a IS present, build.rs sets `have_libsetjmp` and these are dropped
+// so the real runtime resolves the symbols instead — critically its
+// __wasm_longjmp actually throws the __c_longjmp tag, whereas the stub below can
+// only trap. Leaving the stub in alongside libsetjmp.a lets it shadow the real
+// implementation (link order under --allow-multiple-definition), which turns
+// FreeType's setjmp error recovery on malformed fonts into a module abort.
 // ---------------------------------------------------------------------------
 
+#[cfg(not(have_libsetjmp))]
 #[unsafe(no_mangle)]
 pub extern "C" fn __wasm_setjmp(env: u32, label: u32, table: *mut u32) {
     unsafe {
@@ -61,6 +71,7 @@ pub extern "C" fn __wasm_setjmp(env: u32, label: u32, table: *mut u32) {
     }
 }
 
+#[cfg(not(have_libsetjmp))]
 #[unsafe(no_mangle)]
 pub extern "C" fn __wasm_setjmp_test(table: *const u32, env: u32) -> u32 {
     unsafe {
@@ -78,10 +89,12 @@ pub extern "C" fn __wasm_setjmp_test(table: *const u32, env: u32) -> u32 {
     }
 }
 
+#[cfg(not(have_libsetjmp))]
 #[unsafe(no_mangle)]
 pub extern "C" fn __wasm_longjmp(_env: *mut u8, _val: i32) {
     // longjmp throws the __c_longjmp WASM exception tag, which we can't do
-    // from Rust. Trap instead — in practice, FreeType's setjmp error recovery
-    // rarely triggers during normal PDF parsing.
+    // from Rust. Trap instead. This branch only compiles when no libsetjmp.a is
+    // linked (see the module note above); with libsetjmp.a present the real
+    // runtime provides a __wasm_longjmp that unwinds correctly.
     core::arch::wasm32::unreachable();
 }


### PR DESCRIPTION
Fixes https://github.com/run-llama/liteparse/issues/351

Issue was chromium started shipping duplicates of our stubs, and our stubs were shadowing the real implementation.
