### PR TITLE
feat: add inline is-complex signals to parse json result, opt-in only

### DIFF
--- a/crates/liteparse-napi/src/types.rs
+++ b/crates/liteparse-napi/src/types.rs
@@ -66,6 +66,10 @@ pub struct JsLiteParseConfig {
     /// Drop diagonal text (rotation >2° off the nearest right angle). Default
     /// false. Use to exclude rotated watermarks/stamps from the output.
     pub skip_diagonal_text: Option<bool>,
+    /// Compute per-page complexity signals during parse and attach them to each
+    /// page as `ParsedPage.complexity` (the same signals `isComplex` returns).
+    /// Default false; enabling it runs an extra vector-text detection pass.
+    pub include_complexity: Option<bool>,
 }
 
 /// A page sub-region as the fraction cropped from each side (top-left origin,
@@ -155,6 +159,9 @@ impl JsLiteParseConfig {
         if let Some(v) = self.skip_diagonal_text {
             cfg.skip_diagonal_text = v;
         }
+        if let Some(v) = self.include_complexity {
+            cfg.include_complexity = v;
+        }
         cfg
     }
 
@@ -202,6 +209,7 @@ impl JsLiteParseConfig {
                 left: c.left as f64,
             }),
             skip_diagonal_text: Some(cfg.skip_diagonal_text),
+            include_complexity: Some(cfg.include_complexity),
         }
     }
 }
@@ -403,6 +411,9 @@ pub struct JsParsedPage {
     pub text: String,
     pub markdown: String,
     pub text_items: Vec<JsTextItem>,
+    /// Per-page complexity signals. Present only when parsing was configured
+    /// with `includeComplexity`; `undefined`/`None` otherwise.
+    pub complexity: Option<JsPageComplexityStats>,
 }
 
 impl JsParsedPage {
@@ -414,6 +425,10 @@ impl JsParsedPage {
             text: page.text.clone(),
             markdown: page.markdown.clone(),
             text_items: page.text_items.iter().map(JsTextItem::from_rust).collect(),
+            complexity: page
+                .complexity
+                .as_ref()
+                .map(JsPageComplexityStats::from_rust),
         }
     }
 }

--- a/crates/liteparse-napi/src/types.rs
+++ b/crates/liteparse-napi/src/types.rs
@@ -411,8 +411,6 @@ pub struct JsParsedPage {
     pub text: String,
     pub markdown: String,
     pub text_items: Vec<JsTextItem>,
-    /// Per-page complexity signals. Present only when parsing was configured
-    /// with `includeComplexity`; `undefined`/`None` otherwise.
     pub complexity: Option<JsPageComplexityStats>,
 }
 

--- a/crates/liteparse-python/src/cli.rs
+++ b/crates/liteparse-python/src/cli.rs
@@ -72,6 +72,10 @@ struct ParseCommand {
     /// `[text](url)` in markdown output; pass this to emit plain anchor text.
     #[arg(long)]
     no_links: bool,
+    /// Include per-page complexity signals as a `complexity` object on each
+    /// page of JSON output. Off by default.
+    #[arg(long)]
+    complexity: bool,
 }
 
 #[derive(Args, Debug)]
@@ -121,6 +125,10 @@ struct BatchParseCommand {
     quiet: bool,
     #[arg(long)]
     num_workers: Option<usize>,
+    /// Include per-page complexity signals as a `complexity` object on each
+    /// page of JSON output. Off by default.
+    #[arg(long)]
+    complexity: bool,
 }
 
 /// Parse a `Name: Value` header string into a `(name, value)` pair.
@@ -183,6 +191,7 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                 ocr_server_headers: cmd.ocr_server_headers,
                 image_mode,
                 extract_links: !cmd.no_links,
+                include_complexity: cmd.complexity,
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {
@@ -278,6 +287,7 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
                 ocr_server_headers: cmd.ocr_server_headers,
+                include_complexity: cmd.complexity,
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -134,6 +134,10 @@ struct PyParsedPage {
     markdown: String,
     #[pyo3(get)]
     text_items: Vec<PyTextItem>,
+    /// Per-page complexity signals. Populated only when parsing was configured
+    /// with `include_complexity=True`; `None` otherwise.
+    #[pyo3(get)]
+    complexity: Option<PyPageComplexityStats>,
 }
 
 #[pymethods]
@@ -162,6 +166,10 @@ impl PyParsedPage {
                 .into_iter()
                 .map(PyTextItem::from_rust)
                 .collect(),
+            complexity: page
+                .complexity
+                .as_ref()
+                .map(PyPageComplexityStats::from_rust),
         }
     }
 }
@@ -458,6 +466,7 @@ impl LiteParse {
         emit_word_boxes = None,
         crop_box = None,
         skip_diagonal_text = None,
+        include_complexity = None,
     ))]
     fn new(
         ocr_language: Option<String>,
@@ -480,6 +489,7 @@ impl LiteParse {
         emit_word_boxes: Option<bool>,
         crop_box: Option<(f32, f32, f32, f32)>,
         skip_diagonal_text: Option<bool>,
+        include_complexity: Option<bool>,
     ) -> PyResult<Self> {
         let mut cfg = LiteParseConfig::default();
         if let Some(v) = ocr_language {
@@ -554,6 +564,9 @@ impl LiteParse {
         }
         if let Some(v) = skip_diagonal_text {
             cfg.skip_diagonal_text = v;
+        }
+        if let Some(v) = include_complexity {
+            cfg.include_complexity = v;
         }
 
         let inner = liteparse::parser::LiteParse::new(cfg.clone());

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -134,8 +134,6 @@ struct PyParsedPage {
     markdown: String,
     #[pyo3(get)]
     text_items: Vec<PyTextItem>,
-    /// Per-page complexity signals. Populated only when parsing was configured
-    /// with `include_complexity=True`; `None` otherwise.
     #[pyo3(get)]
     complexity: Option<PyPageComplexityStats>,
 }

--- a/crates/liteparse-wasm/src/lib.rs
+++ b/crates/liteparse-wasm/src/lib.rs
@@ -68,6 +68,10 @@ pub struct LiteParseConfig {
     /// Drop diagonal text (rotation >2° off the nearest right angle). Default
     /// false. Use to exclude rotated watermarks/stamps from the output.
     skip_diagonal_text: Option<bool>,
+    /// Compute per-page complexity signals during parse and attach them to each
+    /// page as `ParsedPage.complexity` (the same signals `isComplex` returns).
+    /// Default false; enabling it runs an extra vector-text detection pass.
+    include_complexity: Option<bool>,
 }
 
 /// A page sub-region as the fraction cropped from each side (top-left origin,
@@ -161,6 +165,9 @@ impl LiteParseConfig {
         if let Some(v) = self.skip_diagonal_text {
             cfg.skip_diagonal_text = v;
         }
+        if let Some(v) = self.include_complexity {
+            cfg.include_complexity = v;
+        }
         cfg.num_workers = 1;
         Ok(cfg)
     }
@@ -203,6 +210,7 @@ impl LiteParseConfig {
                 left: c.left,
             }),
             skip_diagonal_text: Some(cfg.skip_diagonal_text),
+            include_complexity: Some(cfg.include_complexity),
         }
     }
 }
@@ -255,6 +263,10 @@ pub struct ParsedPage {
     pub text: String,
     pub markdown: String,
     pub text_items: Vec<TextItem>,
+    /// Per-page complexity signals. Present only when parsing was configured
+    /// with `includeComplexity`; omitted otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub complexity: Option<PageComplexityStats>,
 }
 
 #[derive(Serialize, Tsify)]
@@ -492,6 +504,7 @@ impl LiteParse {
                         },
                     })
                     .collect(),
+                complexity: p.complexity.as_ref().map(PageComplexityStats::from_rust),
             })
             .collect();
 

--- a/crates/liteparse-wasm/src/lib.rs
+++ b/crates/liteparse-wasm/src/lib.rs
@@ -263,8 +263,6 @@ pub struct ParsedPage {
     pub text: String,
     pub markdown: String,
     pub text_items: Vec<TextItem>,
-    /// Per-page complexity signals. Present only when parsing was configured
-    /// with `includeComplexity`; omitted otherwise.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub complexity: Option<PageComplexityStats>,
 }

--- a/crates/liteparse/src/config.rs
+++ b/crates/liteparse/src/config.rs
@@ -71,6 +71,13 @@ pub struct LiteParseConfig {
     /// Drop diagonal (skewed) text — items whose rotation is more than 2°
     /// off the nearest right angle (0/90/180/270). Default `false`.
     pub skip_diagonal_text: bool,
+    /// Compute per-page complexity signals during `parse` and attach them to
+    /// each `ParsedPage` (surfaced as a `complexity` object per page in JSON).
+    /// These are the same signals the standalone `is_complex` API returns.
+    /// Default `false`: the vector-text detection walk this runs is only worth
+    /// paying for when a caller actually consumes the signals, so parse stays
+    /// on its cheap path unless this is explicitly opted into.
+    pub include_complexity: bool,
 }
 
 /// A page sub-region expressed as the fraction cropped from each side.
@@ -145,6 +152,7 @@ impl Default for LiteParseConfig {
             emit_word_boxes: false,
             crop_box: None,
             skip_diagonal_text: false,
+            include_complexity: false,
         }
     }
 }

--- a/crates/liteparse/src/config.rs
+++ b/crates/liteparse/src/config.rs
@@ -74,9 +74,7 @@ pub struct LiteParseConfig {
     /// Compute per-page complexity signals during `parse` and attach them to
     /// each `ParsedPage` (surfaced as a `complexity` object per page in JSON).
     /// These are the same signals the standalone `is_complex` API returns.
-    /// Default `false`: the vector-text detection walk this runs is only worth
-    /// paying for when a caller actually consumes the signals, so parse stays
-    /// on its cheap path unless this is explicitly opted into.
+    /// Default `false`.
     pub include_complexity: bool,
 }
 

--- a/crates/liteparse/src/main.rs
+++ b/crates/liteparse/src/main.rs
@@ -119,6 +119,12 @@ struct ParseCommand {
     /// parity, where ground truth uses no link syntax).
     #[arg(long)]
     no_links: bool,
+
+    /// Include per-page complexity signals (the same `is-complex` reports) as a
+    /// `complexity` object on each page of JSON output. Off by default; enabling
+    /// it runs the extra vector-text detection pass.
+    #[arg(long)]
+    complexity: bool,
 }
 
 #[derive(Args, Debug)]
@@ -207,6 +213,11 @@ struct BatchParseCommand {
     /// Number of concurrent OCR workers (default: CPU cores - 1)
     #[arg(long)]
     num_workers: Option<usize>,
+
+    /// Include per-page complexity signals as a `complexity` object on each
+    /// page of JSON output. Off by default.
+    #[arg(long)]
+    complexity: bool,
 }
 
 #[derive(Args, Debug)]
@@ -308,6 +319,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ocr_server_headers: cmd.ocr_server_headers,
                 image_mode,
                 extract_links: !cmd.no_links,
+                include_complexity: cmd.complexity,
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {
@@ -408,6 +420,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
                 ocr_server_headers: cmd.ocr_server_headers,
+                include_complexity: cmd.complexity,
                 ..Default::default()
             };
             if let Some(n) = cmd.num_workers {

--- a/crates/liteparse/src/markdown_layout/test_helpers.rs
+++ b/crates/liteparse/src/markdown_layout/test_helpers.rs
@@ -42,6 +42,7 @@ pub(crate) fn page(lines: Vec<ProjectedLine>) -> ParsedPage {
         figures: vec![],
         struct_nodes: vec![],
         image_refs: vec![],
+        complexity: None,
     }
 }
 
@@ -192,6 +193,7 @@ pub(crate) fn header_footer_page(n: usize, header: &str, footer: &str, body: &st
         figures: vec![],
         struct_nodes: vec![],
         image_refs: vec![],
+        complexity: None,
     }
 }
 

--- a/crates/liteparse/src/ocr_merge.rs
+++ b/crates/liteparse/src/ocr_merge.rs
@@ -75,7 +75,7 @@ impl ComplexityReason {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct PageComplexityStats {
     pub page_number: usize,
     pub text_length: usize,

--- a/crates/liteparse/src/output/json.rs
+++ b/crates/liteparse/src/output/json.rs
@@ -1,3 +1,4 @@
+use crate::ocr_merge::PageComplexityStats;
 use crate::types::ParsedPage;
 use serde::Serialize;
 
@@ -23,6 +24,10 @@ pub(crate) struct JsonPage {
     pub height: f32,
     pub text: String,
     pub text_items: Vec<JsonTextItem>,
+    /// Per-page complexity signals. Present only when parsing was configured
+    /// with `include_complexity` (otherwise omitted from the JSON entirely).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub complexity: Option<PageComplexityStats>,
 }
 
 #[derive(Debug, Serialize)]
@@ -54,6 +59,7 @@ pub(crate) fn build_json(pages: &[ParsedPage]) -> ParseResultJson {
                         confidence: item.confidence.or(Some(1.0)),
                     })
                     .collect(),
+                complexity: page.complexity.clone(),
             })
             .collect(),
     }
@@ -98,6 +104,7 @@ mod tests {
             figures: vec![],
             struct_nodes: vec![],
             image_refs: vec![],
+            complexity: None,
         }
     }
 

--- a/crates/liteparse/src/output/json.rs
+++ b/crates/liteparse/src/output/json.rs
@@ -24,8 +24,6 @@ pub(crate) struct JsonPage {
     pub height: f32,
     pub text: String,
     pub text_items: Vec<JsonTextItem>,
-    /// Per-page complexity signals. Present only when parsing was configured
-    /// with `include_complexity` (otherwise omitted from the JSON entirely).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub complexity: Option<PageComplexityStats>,
 }

--- a/crates/liteparse/src/output/markdown.rs
+++ b/crates/liteparse/src/output/markdown.rs
@@ -158,6 +158,7 @@ mod tests {
             figures: vec![],
             struct_nodes: vec![],
             image_refs: vec![],
+            complexity: None,
         }
     }
 
@@ -206,6 +207,7 @@ mod tests {
             figures: vec![],
             struct_nodes: vec![],
             image_refs: vec![],
+            complexity: None,
         };
         let out = format_markdown(&[p], &[], ImageMode::Placeholder);
         assert!(out.contains("```text"));

--- a/crates/liteparse/src/output/text.rs
+++ b/crates/liteparse/src/output/text.rs
@@ -27,6 +27,7 @@ mod tests {
             figures: vec![],
             struct_nodes: vec![],
             image_refs: vec![],
+            complexity: None,
         }
     }
 

--- a/crates/liteparse/src/parser.rs
+++ b/crates/liteparse/src/parser.rs
@@ -372,9 +372,8 @@ impl LiteParse {
 
         // Grid projection
         let mut parsed_pages = projection::project_pages_to_grid(pages);
-        // Attach per-page complexity signals (empty unless `include_complexity`).
-        // Projection is 1:1 with the input pages and preserves order, so a
-        // positional zip aligns each page with its own stats.
+
+        // Attach per-page complexity signals
         for (page, stats) in parsed_pages.iter_mut().zip(complexity) {
             page.complexity = Some(stats);
         }

--- a/crates/liteparse/src/parser.rs
+++ b/crates/liteparse/src/parser.rs
@@ -285,7 +285,7 @@ impl LiteParse {
         };
         let ocr_grayscale = ocr_engine.as_ref().is_some_and(|e| e.prefers_grayscale());
 
-        let (pages, ocr_rendered, outline, images) = {
+        let (pages, ocr_rendered, outline, images, complexity) = {
             let lib = Library::init();
             let document = extract::load_document_from_input(&lib, &validated_input, password)?;
             let outline = extract::extract_outline(&document);
@@ -324,8 +324,22 @@ impl LiteParse {
             } else {
                 Vec::new()
             };
+            // Per-page complexity signals, opt-in via `include_complexity`. Needs
+            // the live PDFium document (image / filled-path geometry), so it runs
+            // here inside the lock; empty otherwise so the cheap path pays nothing.
+            let complexity = if self.config.include_complexity {
+                pages
+                    .iter()
+                    .map(|page| {
+                        let page_obj = document.page((page.page_number - 1) as i32)?;
+                        ocr_merge::calculate_page_complexity(page, &page_obj)
+                    })
+                    .collect::<Result<Vec<_>, _>>()?
+            } else {
+                Vec::new()
+            };
             // `lib` is dropped here, releasing the PDFium lock.
-            (pages, rendered, outline, images)
+            (pages, rendered, outline, images, complexity)
         };
         let mut pages = pages;
         let t1 = web_time::Instant::now();
@@ -360,6 +374,12 @@ impl LiteParse {
 
         // Grid projection
         let mut parsed_pages = projection::project_pages_to_grid(pages);
+        // Attach per-page complexity signals (empty unless `include_complexity`).
+        // Projection is 1:1 with the input pages and preserves order, so a
+        // positional zip aligns each page with its own stats.
+        for (page, stats) in parsed_pages.iter_mut().zip(complexity) {
+            page.complexity = Some(stats);
+        }
         let t2 = web_time::Instant::now();
         log(&format!(
             "[liteparse] project: {:.1}ms",

--- a/crates/liteparse/src/parser.rs
+++ b/crates/liteparse/src/parser.rs
@@ -324,9 +324,7 @@ impl LiteParse {
             } else {
                 Vec::new()
             };
-            // Per-page complexity signals, opt-in via `include_complexity`. Needs
-            // the live PDFium document (image / filled-path geometry), so it runs
-            // here inside the lock; empty otherwise so the cheap path pays nothing.
+
             let complexity = if self.config.include_complexity {
                 pages
                     .iter()

--- a/crates/liteparse/src/projection.rs
+++ b/crates/liteparse/src/projection.rs
@@ -2909,6 +2909,7 @@ pub fn project_pages_to_grid(pages: Vec<Page>) -> Vec<ParsedPage> {
                 figures,
                 struct_nodes: page.struct_nodes,
                 image_refs: page.image_refs,
+                complexity: None,
             }
         })
         .collect()

--- a/crates/liteparse/src/types.rs
+++ b/crates/liteparse/src/types.rs
@@ -180,6 +180,11 @@ pub struct ParsedPage {
     /// page has no embedded images. Not part of JSON/text output.
     #[serde(skip)]
     pub image_refs: Vec<ImageRef>,
+    /// Per-page complexity signals (the same the `is_complex` API returns).
+    /// Populated only when `LiteParseConfig::include_complexity` is set;
+    /// `None` otherwise. Surfaced as a per-page `complexity` object in JSON.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub complexity: Option<crate::ocr_merge::PageComplexityStats>,
 }
 
 /// One embedded raster image on a page. `id` is a stable, page-scoped slug

--- a/packages/node/src/cli.ts
+++ b/packages/node/src/cli.ts
@@ -61,6 +61,10 @@ program
   .option("--config <file>", "JSON config file path")
   .option("-q, --quiet", "Suppress progress output")
   .option("--num-workers <n>", "Number of concurrent OCR workers", parseInt)
+  .option(
+    "--complexity",
+    "Include per-page complexity signals in JSON output",
+  )
   .action(async (file: string, opts: Record<string, unknown>) => {
     try {
       const config: Partial<LiteParseConfig> = {};
@@ -91,6 +95,7 @@ program
       if (opts.password) config.password = opts.password as string;
       if (opts.quiet) config.quiet = true;
       if (opts.numWorkers) config.numWorkers = opts.numWorkers as number;
+      if (opts.complexity) config.includeComplexity = true;
 
       // Default CLI output to text (library defaults to json)
       if (!config.outputFormat) config.outputFormat = "text";

--- a/packages/node/src/lib.ts
+++ b/packages/node/src/lib.ts
@@ -71,6 +71,13 @@ export interface LiteParseConfig {
    * watermarks/stamps from the output.
    */
   skipDiagonalText: boolean;
+  /**
+   * Compute per-page complexity signals during {@link LiteParse.parse} and
+   * attach them to each page as {@link ParsedPage.complexity} (the same signals
+   * {@link LiteParse.isComplex} returns). Default false; enabling it runs an
+   * extra vector-text detection pass.
+   */
+  includeComplexity: boolean;
 }
 
 /**
@@ -161,6 +168,12 @@ export interface ParsedPage {
   text: string;
   markdown: string;
   textItems: TextItem[];
+  /**
+   * Per-page complexity signals (the same {@link LiteParse.isComplex} returns).
+   * Present only when parsing with `includeComplexity: true`; `undefined`
+   * otherwise.
+   */
+  complexity?: PageComplexityStats;
 }
 
 export interface ExtractedImage {
@@ -253,6 +266,7 @@ export class LiteParse {
       emitWordBoxes: userConfig.emitWordBoxes,
       cropBox: userConfig.cropBox,
       skipDiagonalText: userConfig.skipDiagonalText,
+      includeComplexity: userConfig.includeComplexity,
     };
 
     this._native = new native.LiteParse(nativeConfig);
@@ -280,6 +294,7 @@ export class LiteParse {
       emitWordBoxes: resolved.emitWordBoxes ?? false,
       cropBox: resolved.cropBox ?? undefined,
       skipDiagonalText: resolved.skipDiagonalText ?? false,
+      includeComplexity: resolved.includeComplexity ?? false,
     };
   }
 
@@ -327,21 +342,7 @@ export class LiteParse {
       typeof input === "string" ? input : Buffer.from(input);
     const stats: NativePageComplexityStats[] =
       await this._native.isComplex(nativeInput);
-    return stats.map((s) => ({
-      pageNumber: s.pageNumber,
-      textLength: s.textLength,
-      textCoverage: s.textCoverage,
-      hasSubstantialImages: s.hasSubstantialImages,
-      imageBlockCount: s.imageBlockCount,
-      imageCoverage: s.imageCoverage,
-      largestImageCoverage: s.largestImageCoverage,
-      fullPageImage: s.fullPageImage,
-      uncoveredVectorArea: s.uncoveredVectorArea ?? undefined,
-      isGarbled: s.isGarbled,
-      pageArea: s.pageArea,
-      needsOcr: s.needsOcr,
-      reasons: s.reasons,
-    }));
+    return stats.map(toComplexity);
   }
 
   async screenshot(
@@ -367,6 +368,24 @@ export class LiteParse {
   }
 }
 
+function toComplexity(s: NativePageComplexityStats): PageComplexityStats {
+  return {
+    pageNumber: s.pageNumber,
+    textLength: s.textLength,
+    textCoverage: s.textCoverage,
+    hasSubstantialImages: s.hasSubstantialImages,
+    imageBlockCount: s.imageBlockCount,
+    imageCoverage: s.imageCoverage,
+    largestImageCoverage: s.largestImageCoverage,
+    fullPageImage: s.fullPageImage,
+    uncoveredVectorArea: s.uncoveredVectorArea ?? undefined,
+    isGarbled: s.isGarbled,
+    pageArea: s.pageArea,
+    needsOcr: s.needsOcr,
+    reasons: s.reasons,
+  };
+}
+
 function toPage(p: NativeParsedPage): ParsedPage {
   return {
     pageNum: p.pageNum,
@@ -375,6 +394,7 @@ function toPage(p: NativeParsedPage): ParsedPage {
     text: p.text,
     markdown: p.markdown,
     textItems: p.textItems.map(toTextItem),
+    complexity: p.complexity ? toComplexity(p.complexity) : undefined,
   };
 }
 

--- a/packages/node/src/native.ts
+++ b/packages/node/src/native.ts
@@ -40,6 +40,7 @@ export interface LiteParseNativeConfig {
   emitWordBoxes?: boolean;
   cropBox?: NativeCropBox;
   skipDiagonalText?: boolean;
+  includeComplexity?: boolean;
 }
 
 export interface NativeCropBox {
@@ -102,6 +103,7 @@ export interface NativeParsedPage {
   text: string;
   markdown: string;
   textItems: NativeTextItem[];
+  complexity?: NativePageComplexityStats;
 }
 
 export interface NativeExtractedImage {

--- a/packages/python/liteparse/parser.py
+++ b/packages/python/liteparse/parser.py
@@ -19,6 +19,25 @@ from .types import (
 )
 
 
+def _convert_complexity(s: Any) -> PageComplexityStats:
+    """Convert a native PyPageComplexityStats to our Python dataclass."""
+    return PageComplexityStats(
+        page_number=s.page_number,
+        text_length=s.text_length,
+        text_coverage=s.text_coverage,
+        has_substantial_images=s.has_substantial_images,
+        image_block_count=s.image_block_count,
+        image_coverage=s.image_coverage,
+        largest_image_coverage=s.largest_image_coverage,
+        full_page_image=s.full_page_image,
+        uncovered_vector_area=s.uncovered_vector_area,
+        is_garbled=s.is_garbled,
+        page_area=s.page_area,
+        needs_ocr=s.needs_ocr,
+        reasons=list(s.reasons),
+    )
+
+
 def _convert_native_result(native_result: Any) -> ParseResult:
     """Convert a native PyParseResult to our Python ParseResult."""
     pages: List[ParsedPage] = []
@@ -47,6 +66,7 @@ def _convert_native_result(native_result: Any) -> ParseResult:
             )
             for item in native_page.text_items
         ]
+        native_complexity = getattr(native_page, "complexity", None)
         pages.append(
             ParsedPage(
                 page_num=native_page.page_num,
@@ -55,6 +75,11 @@ def _convert_native_result(native_result: Any) -> ParseResult:
                 text=native_page.text,
                 markdown=native_page.markdown,
                 text_items=text_items,
+                complexity=(
+                    _convert_complexity(native_complexity)
+                    if native_complexity is not None
+                    else None
+                ),
             )
         )
     images = [
@@ -109,6 +134,7 @@ class LiteParse:
         emit_word_boxes: Optional[bool] = None,
         crop_box: Optional[Tuple[float, float, float, float]] = None,
         skip_diagonal_text: Optional[bool] = None,
+        include_complexity: Optional[bool] = None,
     ):
         """
         Initialize LiteParse parser.
@@ -154,6 +180,11 @@ class LiteParse:
             skip_diagonal_text: Drop diagonal text — items whose rotation is
                 more than 2° off the nearest right angle (0/90/180/270).
                 Default False. Use to exclude rotated watermarks/stamps.
+            include_complexity: Compute per-page complexity signals during
+                :meth:`parse` and attach them to each page as
+                ``ParsedPage.complexity`` (the same :meth:`is_complex` returns).
+                Default False; enabling it runs an extra vector-text detection
+                pass.
         """
         kwargs = {}
         if ocr_enabled is not None:
@@ -196,6 +227,8 @@ class LiteParse:
             kwargs["crop_box"] = crop_box
         if skip_diagonal_text is not None:
             kwargs["skip_diagonal_text"] = skip_diagonal_text
+        if include_complexity is not None:
+            kwargs["include_complexity"] = include_complexity
 
         self._native = _NativeLiteParse(**kwargs)
 
@@ -259,24 +292,7 @@ class LiteParse:
                 if not file_path.exists():
                     raise FileNotFoundError(f"File not found: {file_path}")
                 native_stats = self._native.is_complex(str(file_path.absolute()))
-            return [
-                PageComplexityStats(
-                    page_number=s.page_number,
-                    text_length=s.text_length,
-                    text_coverage=s.text_coverage,
-                    has_substantial_images=s.has_substantial_images,
-                    image_block_count=s.image_block_count,
-                    image_coverage=s.image_coverage,
-                    largest_image_coverage=s.largest_image_coverage,
-                    full_page_image=s.full_page_image,
-                    uncovered_vector_area=s.uncovered_vector_area,
-                    is_garbled=s.is_garbled,
-                    page_area=s.page_area,
-                    needs_ocr=s.needs_ocr,
-                    reasons=list(s.reasons),
-                )
-                for s in native_stats
-            ]
+            return [_convert_complexity(s) for s in native_stats]
         except FileNotFoundError:
             raise
         except Exception as e:

--- a/packages/python/liteparse/types.py
+++ b/packages/python/liteparse/types.py
@@ -43,6 +43,10 @@ class ParsedPage:
     text: str
     markdown: str = ""
     text_items: List[TextItem] = field(default_factory=list)
+    #: Per-page complexity signals (the same :meth:`LiteParse.is_complex`
+    #: returns). Populated only when parsing with ``include_complexity=True``;
+    #: ``None`` otherwise.
+    complexity: Optional[PageComplexityStats] = None
 
 
 @dataclass


### PR DESCRIPTION
Fixes https://github.com/run-llama/liteparse/issues/345