### PR TITLE
Expose failed OCR page numbers in parse results

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ lit parse document.pdf --target-pages "1-5,10,15-20"
 # Parse without OCR
 lit parse document.pdf --no-ocr
 
+# Continue if OCR fails and report failed pages in JSON
+lit parse document.pdf --format json --ocr-failure-non-fatal
+
 # Parse a remote PDF
 curl -sL https://example.com/report.pdf | lit parse -
 ```
@@ -265,6 +268,7 @@ Options:
       --preserve-small-text    Keep very small text
       --password <password>    Password for encrypted documents
       --num-workers <n>        Concurrent OCR workers [default: CPU cores - 1]
+      --ocr-failure-non-fatal  Continue if OCR fails; JSON includes failed OCR pages
   -q, --quiet                  Suppress progress output
   -h, --help                   Print help
 ```
@@ -286,6 +290,7 @@ Options:
       --extension <ext>        Only process files with this extension (e.g., ".pdf")
       --password <password>    Password for encrypted documents
       --num-workers <n>        Concurrent OCR workers
+      --ocr-failure-non-fatal  Continue if OCR fails; JSON includes failed OCR pages
   -q, --quiet                  Suppress progress output
   -h, --help                   Print help
 ```
@@ -345,6 +350,12 @@ Or pass the path directly:
 ```bash
 lit parse document.pdf --tessdata-path /path/to/tessdata
 ```
+
+By default, a systemic OCR failure on text-sparse pages aborts parsing so OCR setup
+problems are visible. If you prefer partial output, pass
+`--ocr-failure-non-fatal`; JSON output includes `failed_ocr_pages`, a list of
+1-based page numbers whose OCR pass failed, and `ocr_failures`, objects with the
+page number and OCR engine error string.
 
 ### Optional: HTTP OCR Servers
 

--- a/crates/liteparse-napi/src/types.rs
+++ b/crates/liteparse-napi/src/types.rs
@@ -440,7 +440,16 @@ impl JsParsedPage {
 pub struct JsParseResult {
     pub pages: Vec<JsParsedPage>,
     pub text: String,
+    pub failed_ocr_pages: Vec<u32>,
+    pub ocr_failures: Vec<JsOcrFailure>,
     pub images: Vec<JsExtractedImage>,
+}
+
+#[napi(object)]
+#[derive(Clone)]
+pub struct JsOcrFailure {
+    pub page_number: u32,
+    pub error: String,
 }
 
 #[napi(object)]
@@ -512,6 +521,19 @@ impl JsParseResult {
         Self {
             pages: result.pages.iter().map(JsParsedPage::from_rust).collect(),
             text: result.text.clone(),
+            failed_ocr_pages: result
+                .failed_ocr_pages
+                .iter()
+                .map(|&page| page as u32)
+                .collect(),
+            ocr_failures: result
+                .ocr_failures
+                .iter()
+                .map(|failure| JsOcrFailure {
+                    page_number: failure.page_number as u32,
+                    error: failure.error.clone(),
+                })
+                .collect(),
             images: result
                 .images
                 .iter()

--- a/crates/liteparse-python/src/cli.rs
+++ b/crates/liteparse-python/src/cli.rs
@@ -58,6 +58,9 @@ struct ParseCommand {
     quiet: bool,
     #[arg(long)]
     num_workers: Option<usize>,
+    /// Continue parsing when OCR fails and report failed pages in JSON output.
+    #[arg(long)]
+    ocr_failure_non_fatal: bool,
     /// How to surface raster images in markdown output: `off`, `placeholder`
     /// (default), or `embed` (extracts PNG bytes, written next to the output
     /// when `--image-output-dir` is set).
@@ -125,6 +128,9 @@ struct BatchParseCommand {
     quiet: bool,
     #[arg(long)]
     num_workers: Option<usize>,
+    /// Continue parsing when OCR fails and report failed pages in JSON output.
+    #[arg(long)]
+    ocr_failure_non_fatal: bool,
     /// Include per-page complexity signals as a `complexity` object on each
     /// page of JSON output. Off by default.
     #[arg(long)]
@@ -189,6 +195,7 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
                 ocr_server_headers: cmd.ocr_server_headers,
+                ocr_failure_fatal: !cmd.ocr_failure_non_fatal,
                 image_mode,
                 extract_links: !cmd.no_links,
                 include_complexity: cmd.complexity,
@@ -200,7 +207,11 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
             let lp = LiteParse::new(config);
             let result = rt.block_on(lp.parse(&cmd.file))?;
             let formatted = match lp.config().output_format {
-                OutputFormat::Json => json::format_json(&result.pages)?,
+                OutputFormat::Json => json::format_json(
+                    &result.pages,
+                    &result.failed_ocr_pages,
+                    &result.ocr_failures,
+                )?,
                 OutputFormat::Text => text::format_text(&result.pages),
                 OutputFormat::Markdown => result.text.clone(),
             };
@@ -287,6 +298,7 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
                 ocr_server_headers: cmd.ocr_server_headers,
+                ocr_failure_fatal: !cmd.ocr_failure_non_fatal,
                 include_complexity: cmd.complexity,
                 ..Default::default()
             };
@@ -328,9 +340,12 @@ pub fn run_cli(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                     Ok(result) => {
                         let fmt_result: Result<String, Box<dyn std::error::Error>> =
                             match lp.config().output_format {
-                                OutputFormat::Json => {
-                                    json::format_json(&result.pages).map_err(|e| e.into())
-                                }
+                                OutputFormat::Json => json::format_json(
+                                    &result.pages,
+                                    &result.failed_ocr_pages,
+                                    &result.ocr_failures,
+                                )
+                                .map_err(|e| e.into()),
                                 OutputFormat::Text => Ok(text::format_text(&result.pages)),
                                 OutputFormat::Markdown => Ok(result.text.clone()),
                             };

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -180,7 +180,30 @@ struct PyParseResult {
     #[pyo3(get)]
     text: String,
     #[pyo3(get)]
+    failed_ocr_pages: Vec<usize>,
+    #[pyo3(get)]
+    ocr_failures: Vec<PyOcrFailure>,
+    #[pyo3(get)]
     images: Vec<PyExtractedImage>,
+}
+
+#[pyclass(frozen, from_py_object)]
+#[derive(Clone)]
+struct PyOcrFailure {
+    #[pyo3(get)]
+    page_number: usize,
+    #[pyo3(get)]
+    error: String,
+}
+
+#[pymethods]
+impl PyOcrFailure {
+    fn __repr__(&self) -> String {
+        format!(
+            "OcrFailure(page_number={}, error={:?})",
+            self.page_number, self.error
+        )
+    }
 }
 
 #[pymethods]
@@ -196,9 +219,10 @@ impl PyParseResult {
 
     fn __repr__(&self) -> String {
         format!(
-            "ParseResult(pages={}, text_len={}, images={})",
+            "ParseResult(pages={}, text_len={}, failed_ocr_pages={}, images={})",
             self.pages.len(),
             self.text.len(),
+            self.failed_ocr_pages.len(),
             self.images.len()
         )
     }
@@ -213,6 +237,15 @@ impl PyParseResult {
                 .map(PyParsedPage::from_rust)
                 .collect(),
             text: result.text,
+            failed_ocr_pages: result.failed_ocr_pages,
+            ocr_failures: result
+                .ocr_failures
+                .into_iter()
+                .map(|failure| PyOcrFailure {
+                    page_number: failure.page_number,
+                    error: failure.error,
+                })
+                .collect(),
             images: result
                 .images
                 .into_iter()
@@ -693,6 +726,7 @@ fn _liteparse(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<LiteParse>()?;
     m.add_class::<PyLiteParseConfig>()?;
     m.add_class::<PyParseResult>()?;
+    m.add_class::<PyOcrFailure>()?;
     m.add_class::<PyExtractedImage>()?;
     m.add_class::<PyParsedPage>()?;
     m.add_class::<PyTextItem>()?;

--- a/crates/liteparse-wasm/src/lib.rs
+++ b/crates/liteparse-wasm/src/lib.rs
@@ -273,7 +273,17 @@ pub struct ParsedPage {
 pub struct ParseResult {
     pub pages: Vec<ParsedPage>,
     pub text: String,
+    pub failed_ocr_pages: Vec<usize>,
+    pub ocr_failures: Vec<OcrFailure>,
     pub images: Vec<ExtractedImage>,
+}
+
+#[derive(Serialize, Tsify)]
+#[tsify(into_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct OcrFailure {
+    pub page_number: usize,
+    pub error: String,
 }
 
 #[derive(Serialize, Tsify)]
@@ -520,6 +530,15 @@ impl LiteParse {
         Ok(ParseResult {
             pages,
             text: result.text.clone(),
+            failed_ocr_pages: result.failed_ocr_pages.clone(),
+            ocr_failures: result
+                .ocr_failures
+                .iter()
+                .map(|failure| OcrFailure {
+                    page_number: failure.page_number,
+                    error: failure.error.clone(),
+                })
+                .collect(),
             images,
         })
     }

--- a/crates/liteparse/src/main.rs
+++ b/crates/liteparse/src/main.rs
@@ -98,6 +98,10 @@ struct ParseCommand {
     #[arg(long)]
     num_workers: Option<usize>,
 
+    /// Continue parsing when OCR fails and report failed pages in JSON output
+    #[arg(long)]
+    ocr_failure_non_fatal: bool,
+
     /// How to surface raster images in markdown output:
     /// `off` strips them, `placeholder` (default) emits `![](image_pN_K.png)`
     /// references in reading order, `embed` extracts each image's PNG bytes
@@ -214,6 +218,10 @@ struct BatchParseCommand {
     #[arg(long)]
     num_workers: Option<usize>,
 
+    /// Continue parsing when OCR fails and report failed pages in JSON output
+    #[arg(long)]
+    ocr_failure_non_fatal: bool,
+
     /// Include per-page complexity signals as a `complexity` object on each
     /// page of JSON output. Off by default.
     #[arg(long)]
@@ -317,6 +325,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
                 ocr_server_headers: cmd.ocr_server_headers,
+                ocr_failure_fatal: !cmd.ocr_failure_non_fatal,
                 image_mode,
                 extract_links: !cmd.no_links,
                 include_complexity: cmd.complexity,
@@ -329,7 +338,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let lp = LiteParse::new(config);
             let result = lp.parse(&cmd.file).await?;
             let formatted = match lp.config().output_format {
-                OutputFormat::Json => json::format_json(&result.pages)?,
+                OutputFormat::Json => json::format_json(
+                    &result.pages,
+                    &result.failed_ocr_pages,
+                    &result.ocr_failures,
+                )?,
                 OutputFormat::Text => text::format_text(&result.pages),
                 OutputFormat::Markdown => result.text.clone(),
             };
@@ -420,6 +433,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 quiet: cmd.quiet,
                 ocr_server_url: cmd.ocr_server_url,
                 ocr_server_headers: cmd.ocr_server_headers,
+                ocr_failure_fatal: !cmd.ocr_failure_non_fatal,
                 include_complexity: cmd.complexity,
                 ..Default::default()
             };
@@ -464,9 +478,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     Ok(result) => {
                         let fmt_result: Result<String, Box<dyn std::error::Error>> =
                             match lp.config().output_format {
-                                OutputFormat::Json => {
-                                    json::format_json(&result.pages).map_err(|e| e.into())
-                                }
+                                OutputFormat::Json => json::format_json(
+                                    &result.pages,
+                                    &result.failed_ocr_pages,
+                                    &result.ocr_failures,
+                                )
+                                .map_err(|e| e.into()),
                                 OutputFormat::Text => Ok(text::format_text(&result.pages)),
                                 OutputFormat::Markdown => Ok(result.text.clone()),
                             };

--- a/crates/liteparse/src/ocr_merge.rs
+++ b/crates/liteparse/src/ocr_merge.rs
@@ -113,6 +113,12 @@ pub struct PageComplexityStats {
     pub reasons: Vec<ComplexityReason>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct OcrFailure {
+    pub page_number: usize,
+    pub error: String,
+}
+
 pub(crate) fn calculate_page_complexity(
     page: &Page,
     page_obj: &pdfium::Page,
@@ -283,7 +289,7 @@ pub(crate) async fn ocr_and_merge_rendered(
     ocr_language: &str,
     num_workers: usize,
     ocr_failure_fatal: bool,
-) -> Result<(), LiteParseError> {
+) -> Result<Vec<OcrFailure>, LiteParseError> {
     // Phase 1: spawn one async task per page. A semaphore limits how many run
     // `recognize` concurrently to `num_workers`.
     //
@@ -353,6 +359,7 @@ pub(crate) async fn ocr_and_merge_rendered(
     // a broken OCR setup would abort perfectly good native-text documents.
     let total_tasks = handles.len();
     let mut failed_tasks = 0usize;
+    let mut ocr_failures = Vec::new();
     let mut failed_sparse_text_page = false;
     let mut first_error: Option<String> = None;
 
@@ -361,11 +368,15 @@ pub(crate) async fn ocr_and_merge_rendered(
             Ok(Ok(results)) => results,
             Ok(Err(e)) => {
                 failed_tasks += 1;
+                let msg = e.to_string();
+                ocr_failures.push(OcrFailure {
+                    page_number,
+                    error: msg.clone(),
+                });
                 failed_sparse_text_page |= page_has_sparse_native_text(&pages[idx]);
                 // Only log the first failure to avoid flooding stderr with an
                 // identical message for every page.
                 if first_error.is_none() {
-                    let msg = e.to_string();
                     eprintln!("[ocr] failed for page {}: {}", page_number, msg);
                     first_error = Some(msg);
                 }
@@ -373,9 +384,13 @@ pub(crate) async fn ocr_and_merge_rendered(
             }
             Err(e) => {
                 failed_tasks += 1;
+                let msg = e.to_string();
+                ocr_failures.push(OcrFailure {
+                    page_number,
+                    error: msg.clone(),
+                });
                 failed_sparse_text_page |= page_has_sparse_native_text(&pages[idx]);
                 if first_error.is_none() {
-                    let msg = e.to_string();
                     eprintln!("[ocr] task panicked for page {}: {}", page_number, msg);
                     first_error = Some(msg);
                 }
@@ -496,8 +511,13 @@ pub(crate) async fn ocr_and_merge_rendered(
         let detail = first_error.unwrap_or_else(|| "unknown error".to_string());
         if ocr_failure_fatal {
             return Err(LiteParseError::Ocr(format!(
-                "OCR failed for all {} page(s): {}",
-                total_tasks, detail
+                "OCR failed for all {} page(s) {:?}: {}",
+                total_tasks,
+                ocr_failures
+                    .iter()
+                    .map(|f| f.page_number)
+                    .collect::<Vec<_>>(),
+                detail
             )));
         }
         // Non-fatal mode: the caller prefers partial results over a hard abort,
@@ -512,12 +532,17 @@ pub(crate) async fn ocr_and_merge_rendered(
     // Surface a concise summary for partial failures without flooding stderr.
     if failed_tasks > 0 {
         eprintln!(
-            "[ocr] {}/{} page(s) failed OCR; continuing with partial results",
-            failed_tasks, total_tasks
+            "[ocr] {}/{} page(s) failed OCR {:?}; continuing with partial results",
+            failed_tasks,
+            total_tasks,
+            ocr_failures
+                .iter()
+                .map(|f| f.page_number)
+                .collect::<Vec<_>>()
         );
     }
 
-    Ok(())
+    Ok(ocr_failures)
 }
 
 /// True when the page's native (already-extracted) text is sparse enough that
@@ -978,6 +1003,10 @@ mod tests {
         }
     }
 
+    fn failure_pages(failures: &[OcrFailure]) -> Vec<usize> {
+        failures.iter().map(|f| f.page_number).collect()
+    }
+
     // When every OCR task fails (e.g. missing language data), the function must
     // return an error instead of silently reporting success with no OCR text.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -996,6 +1025,10 @@ mod tests {
             "unexpected error message: {msg}"
         );
         assert!(
+            msg.contains("[1, 2]"),
+            "error should include failed page numbers: {msg}"
+        );
+        assert!(
             msg.contains("traineddata"),
             "error should carry the underlying cause: {msg}"
         );
@@ -1012,6 +1045,7 @@ mod tests {
             ocr_and_merge_rendered(&mut pages, Vec::new(), 72.0, engine, "eng", 2, true).await;
 
         assert!(result.is_ok(), "empty OCR set should succeed: {result:?}");
+        assert!(result.unwrap().is_empty());
     }
 
     // Regression guard: when OCR fails but every failing page already had native
@@ -1030,6 +1064,9 @@ mod tests {
             result.is_ok(),
             "OCR failure on already-native-text pages must not abort the parse: {result:?}"
         );
+        let failures = result.unwrap();
+        assert_eq!(failure_pages(&failures), vec![1, 2]);
+        assert!(failures[0].error.contains("traineddata"));
         // Native text is preserved untouched.
         assert_eq!(pages[0].text_items.len(), 1);
         assert_eq!(pages[1].text_items.len(), 1);
@@ -1052,6 +1089,10 @@ mod tests {
             err.to_string().contains("OCR failed for all 2 page(s)"),
             "unexpected error message: {err}"
         );
+        assert!(
+            err.to_string().contains("[1, 2]"),
+            "error should include failed page numbers: {err}"
+        );
     }
 
     // Regression guard for the review finding: low-coverage pages are rendered
@@ -1070,6 +1111,10 @@ mod tests {
         assert!(
             err.to_string().contains("OCR failed for all 1 page(s)"),
             "unexpected error message: {err}"
+        );
+        assert!(
+            err.to_string().contains("[1]"),
+            "error should include failed page numbers: {err}"
         );
     }
 
@@ -1090,6 +1135,9 @@ mod tests {
             result.is_ok(),
             "non-fatal mode must not abort on systemic OCR failure: {result:?}"
         );
+        let failures = result.unwrap();
+        assert_eq!(failure_pages(&failures), vec![1, 2]);
+        assert!(failures[1].error.contains("traineddata"));
         // The native-text page keeps its text; the blank page simply has no OCR.
         assert_eq!(pages[0].text_items.len(), 1);
     }

--- a/crates/liteparse/src/output/json.rs
+++ b/crates/liteparse/src/output/json.rs
@@ -1,4 +1,4 @@
-use crate::ocr_merge::PageComplexityStats;
+use crate::ocr_merge::{OcrFailure, PageComplexityStats};
 use crate::types::ParsedPage;
 use serde::Serialize;
 
@@ -30,12 +30,20 @@ pub(crate) struct JsonPage {
 
 #[derive(Debug, Serialize)]
 pub(crate) struct ParseResultJson {
+    pub failed_ocr_pages: Vec<usize>,
+    pub ocr_failures: Vec<OcrFailure>,
     pub pages: Vec<JsonPage>,
 }
 
 /// Build structured JSON output from parsed pages.
-pub(crate) fn build_json(pages: &[ParsedPage]) -> ParseResultJson {
+pub(crate) fn build_json(
+    pages: &[ParsedPage],
+    failed_ocr_pages: &[usize],
+    ocr_failures: &[OcrFailure],
+) -> ParseResultJson {
     ParseResultJson {
+        failed_ocr_pages: failed_ocr_pages.to_vec(),
+        ocr_failures: ocr_failures.to_vec(),
         pages: pages
             .iter()
             .map(|page| JsonPage {
@@ -64,8 +72,12 @@ pub(crate) fn build_json(pages: &[ParsedPage]) -> ParseResultJson {
 }
 
 /// Format parsed pages as pretty-printed JSON string.
-pub fn format_json(pages: &[ParsedPage]) -> Result<String, serde_json::Error> {
-    let result = build_json(pages);
+pub fn format_json(
+    pages: &[ParsedPage],
+    failed_ocr_pages: &[usize],
+    ocr_failures: &[OcrFailure],
+) -> Result<String, serde_json::Error> {
+    let result = build_json(pages, failed_ocr_pages, ocr_failures);
     serde_json::to_string_pretty(&result)
 }
 
@@ -108,7 +120,9 @@ mod tests {
 
     #[test]
     fn test_build_json_native_text_defaults_confidence_to_one() {
-        let j = build_json(&[page(vec![item("hi", None)])]);
+        let j = build_json(&[page(vec![item("hi", None)])], &[], &[]);
+        assert!(j.failed_ocr_pages.is_empty());
+        assert!(j.ocr_failures.is_empty());
         assert_eq!(j.pages.len(), 1);
         assert_eq!(j.pages[0].page, 1);
         assert_eq!(j.pages[0].text_items[0].confidence, Some(1.0));
@@ -117,21 +131,37 @@ mod tests {
 
     #[test]
     fn test_build_json_preserves_ocr_confidence() {
-        let j = build_json(&[page(vec![item("hi", Some(0.42))])]);
+        let failures = vec![OcrFailure {
+            page_number: 2,
+            error: "missing traineddata".into(),
+        }];
+        let j = build_json(&[page(vec![item("hi", Some(0.42))])], &[2], &failures);
+        assert_eq!(j.failed_ocr_pages, vec![2]);
+        assert_eq!(j.ocr_failures[0].error, "missing traineddata");
         assert_eq!(j.pages[0].text_items[0].confidence, Some(0.42));
     }
 
     #[test]
     fn test_format_json_pretty() {
-        let s = format_json(&[page(vec![item("hi", None)])]).unwrap();
+        let failures = vec![OcrFailure {
+            page_number: 3,
+            error: "OCR timeout".into(),
+        }];
+        let s = format_json(&[page(vec![item("hi", None)])], &[3], &failures).unwrap();
         assert!(s.contains("\n"));
+        assert!(s.contains("\"failed_ocr_pages\""));
+        assert!(s.contains("\"ocr_failures\""));
+        assert!(s.contains("OCR timeout"));
+        assert!(s.contains("3"));
         assert!(s.contains("\"text\": \"hi\""));
         assert!(s.contains("\"page\": 1"));
     }
 
     #[test]
     fn test_build_json_empty() {
-        let j = build_json(&[]);
+        let j = build_json(&[], &[], &[]);
+        assert!(j.failed_ocr_pages.is_empty());
+        assert!(j.ocr_failures.is_empty());
         assert!(j.pages.is_empty());
     }
 }

--- a/crates/liteparse/src/parser.rs
+++ b/crates/liteparse/src/parser.rs
@@ -9,6 +9,7 @@ use crate::ocr::http_simple::HttpOcrEngine;
 #[cfg(feature = "tesseract")]
 use crate::ocr::tesseract::TesseractOcrEngine;
 use crate::ocr_merge;
+use crate::ocr_merge::OcrFailure;
 use crate::output::markdown;
 use crate::projection;
 #[cfg(not(target_arch = "wasm32"))]
@@ -22,6 +23,10 @@ pub struct ParseResult {
     pub pages: Vec<ParsedPage>,
     /// Full document text, concatenated from all pages.
     pub text: String,
+    /// 1-based page numbers whose OCR task failed while parsing continued.
+    pub failed_ocr_pages: Vec<usize>,
+    /// OCR failures with page numbers and engine error messages.
+    pub ocr_failures: Vec<OcrFailure>,
     /// Document outline (bookmarks) when present. Used by the markdown
     /// emitter as a high-priority heading source on untagged PDFs.
     pub outline: Vec<OutlineTarget>,
@@ -343,8 +348,9 @@ impl LiteParse {
         let t1 = web_time::Instant::now();
 
         // OCR pass (engine resolved before the render block above).
+        let mut ocr_failures = Vec::new();
         if let Some(engine) = ocr_engine {
-            ocr_merge::ocr_and_merge_rendered(
+            ocr_failures = ocr_merge::ocr_and_merge_rendered(
                 &mut pages,
                 ocr_rendered,
                 self.config.dpi,
@@ -355,6 +361,7 @@ impl LiteParse {
             )
             .await?;
         }
+        let failed_ocr_pages = ocr_failures.iter().map(|f| f.page_number).collect();
         let t_ocr = web_time::Instant::now();
         log(&format!(
             "[liteparse] ocr: {:.1}ms",
@@ -410,6 +417,8 @@ impl LiteParse {
         Ok(ParseResult {
             pages: parsed_pages,
             text: full_text,
+            failed_ocr_pages,
+            ocr_failures,
             outline,
             images,
         })
@@ -445,6 +454,8 @@ impl LiteParse {
         ParseResult {
             pages: parsed_pages,
             text: full_text,
+            failed_ocr_pages: Vec::new(),
+            ocr_failures: Vec::new(),
             outline,
             images: Vec::new(),
         }

--- a/packages/node/native.d.ts
+++ b/packages/node/native.d.ts
@@ -163,7 +163,13 @@ export interface JsParsedPage {
 export interface JsParseResult {
   pages: Array<JsParsedPage>
   text: string
+  failedOcrPages: Array<number>
+  ocrFailures: Array<JsOcrFailure>
   images: Array<JsExtractedImage>
+}
+export interface JsOcrFailure {
+  pageNumber: number
+  error: string
 }
 export interface JsExtractedImage {
   id: string

--- a/packages/node/src/cli.ts
+++ b/packages/node/src/cli.ts
@@ -62,6 +62,10 @@ program
   .option("-q, --quiet", "Suppress progress output")
   .option("--num-workers <n>", "Number of concurrent OCR workers", parseInt)
   .option(
+    "--ocr-failure-non-fatal",
+    "Continue parsing when OCR fails and report failed pages in JSON output",
+  )
+  .option(
     "--complexity",
     "Include per-page complexity signals in JSON output",
   )
@@ -95,6 +99,7 @@ program
       if (opts.password) config.password = opts.password as string;
       if (opts.quiet) config.quiet = true;
       if (opts.numWorkers) config.numWorkers = opts.numWorkers as number;
+      if (opts.ocrFailureNonFatal) config.ocrFailureFatal = false;
       if (opts.complexity) config.includeComplexity = true;
 
       // Default CLI output to text (library defaults to json)
@@ -107,6 +112,8 @@ program
         config.outputFormat === "json"
           ? JSON.stringify(
               {
+                failedOcrPages: result.failedOcrPages,
+                ocrFailures: result.ocrFailures,
                 pages: result.pages.map((p) => ({
                   page: p.pageNum,
                   width: p.width,
@@ -287,6 +294,10 @@ program
   .option("--password <password>", "Password for encrypted documents")
   .option("-q, --quiet", "Suppress progress output")
   .option("--num-workers <n>", "Number of concurrent OCR workers", parseInt)
+  .option(
+    "--ocr-failure-non-fatal",
+    "Continue parsing when OCR fails and report failed pages in JSON output",
+  )
   .action(
     async (
       inputDir: string,
@@ -308,6 +319,7 @@ program
         if (opts.password) config.password = opts.password as string;
         if (opts.quiet) config.quiet = true;
         if (opts.numWorkers) config.numWorkers = opts.numWorkers as number;
+        if (opts.ocrFailureNonFatal) config.ocrFailureFatal = false;
 
         const parser = new LiteParse(config);
         const outExt = format === "json" ? ".json" : format === "markdown" ? ".md" : ".txt";
@@ -358,6 +370,8 @@ program
               format === "json"
                 ? JSON.stringify(
                     {
+                      failedOcrPages: result.failedOcrPages,
+                      ocrFailures: result.ocrFailures,
                       pages: result.pages.map((p) => ({
                         page: p.pageNum,
                         width: p.width,

--- a/packages/node/src/lib.ts
+++ b/packages/node/src/lib.ts
@@ -187,8 +187,17 @@ export interface ExtractedImage {
 export interface ParseResult {
   pages: ParsedPage[];
   text: string;
+  /** 1-based page numbers whose OCR task failed while parsing continued. */
+  failedOcrPages: number[];
+  /** OCR failures with page numbers and engine error messages. */
+  ocrFailures: OcrFailure[];
   /** Populated only when configured with `imageMode: "embed"`. */
   images: ExtractedImage[];
+}
+
+export interface OcrFailure {
+  pageNumber: number;
+  error: string;
 }
 
 export interface ScreenshotResult {
@@ -306,6 +315,8 @@ export class LiteParse {
     return {
       pages: result.pages.map(toPage),
       text: result.text,
+      failedOcrPages: result.failedOcrPages ?? [],
+      ocrFailures: result.ocrFailures ?? [],
       images: (result.images ?? []).map(toImage),
     };
   }
@@ -328,6 +339,8 @@ export class LiteParse {
     return {
       pages: result.pages.map(toPage),
       text: result.text,
+      failedOcrPages: result.failedOcrPages ?? [],
+      ocrFailures: result.ocrFailures ?? [],
       images: (result.images ?? []).map(toImage),
     };
   }

--- a/packages/node/src/native.ts
+++ b/packages/node/src/native.ts
@@ -116,7 +116,14 @@ export interface NativeExtractedImage {
 export interface NativeParseResult {
   pages: NativeParsedPage[];
   text: string;
+  failedOcrPages: number[];
+  ocrFailures: NativeOcrFailure[];
   images: NativeExtractedImage[];
+}
+
+export interface NativeOcrFailure {
+  pageNumber: number;
+  error: string;
 }
 
 export interface NativeScreenshotResult {

--- a/packages/python/liteparse/__init__.py
+++ b/packages/python/liteparse/__init__.py
@@ -4,6 +4,7 @@ from .parser import LiteParse, search_items
 from .types import (
     ExtractedImage,
     LiteParseConfig,
+    OcrFailure,
     PageComplexityStats,
     ParseResult,
     ParsedPage,
@@ -26,6 +27,7 @@ __all__ = [
     "WordBox",
     "ScreenshotResult",
     "PageComplexityStats",
+    "OcrFailure",
     "ExtractedImage",
     "ParseError",
     "search_items",

--- a/packages/python/liteparse/parser.py
+++ b/packages/python/liteparse/parser.py
@@ -9,6 +9,7 @@ from liteparse._liteparse import search_items as _native_search_items
 from .types import (
     ExtractedImage,
     LiteParseConfig,
+    OcrFailure,
     PageComplexityStats,
     ParsedPage,
     ParseError,
@@ -94,6 +95,11 @@ def _convert_native_result(native_result: Any) -> ParseResult:
     return ParseResult(
         pages=pages,
         text=native_result.text,
+        failed_ocr_pages=list(getattr(native_result, "failed_ocr_pages", [])),
+        ocr_failures=[
+            OcrFailure(page_number=f.page_number, error=f.error)
+            for f in getattr(native_result, "ocr_failures", [])
+        ],
         images=images,
     )
 

--- a/packages/python/liteparse/types.py
+++ b/packages/python/liteparse/types.py
@@ -69,6 +69,10 @@ class ParseResult:
     pages: List[ParsedPage]
     text: str
     images: List[ExtractedImage] = field(default_factory=list)
+    #: 1-based page numbers whose OCR task failed while parsing continued.
+    failed_ocr_pages: List[int] = field(default_factory=list)
+    #: OCR failures with page numbers and engine error messages.
+    ocr_failures: List[OcrFailure] = field(default_factory=list)
 
     @property
     def num_pages(self) -> int:
@@ -107,6 +111,13 @@ class PageComplexityStats:
     page_area: float
     needs_ocr: bool
     reasons: list[str]
+
+
+@dataclass
+class OcrFailure:
+    """A failed OCR page and the error reported by the OCR engine."""
+    page_number: int
+    error: str
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Track OCR failures by 1-based page number
- Return failed OCR pages in Rust, Python, Node, WASM, and JSON output
- Include failed page numbers in fatal OCR errors

## Testing
- python -m compileall packages/python/liteparse
- cargo fmt --all
- cargo test ...