### PR TITLE
fix: python search_items more flexible input

### DIFF
--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -88,21 +88,6 @@ impl PyTextItem {
 }
 
 impl PyTextItem {
-    fn to_rust(&self) -> liteparse::types::TextItem {
-        liteparse::types::TextItem {
-            text: self.text.clone(),
-            x: self.x as f32,
-            y: self.y as f32,
-            width: self.width as f32,
-            height: self.height as f32,
-            rotation: self.rotation as f32,
-            font_name: self.font_name.clone(),
-            font_size: self.font_size.map(|v| v as f32),
-            confidence: self.confidence.map(|v| v as f32),
-            ..Default::default()
-        }
-    }
-
     fn from_rust(item: liteparse::types::TextItem) -> Self {
         Self {
             text: item.text,
@@ -667,10 +652,52 @@ impl LiteParse {
 // Module
 // ---------------------------------------------------------------------------
 
+/// Duck-typed input for [`search_items`]. Extracts by attribute name, so it
+/// accepts both the native `PyTextItem` and the pure-Python `TextItem`
+/// dataclass that `LiteParse.parse()` hands back (see `parser.py`,
+/// `_convert_native_result`). 
+#[derive(FromPyObject)]
+struct SearchInputItem {
+    text: String,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+    #[pyo3(default)]
+    font_name: Option<String>,
+    #[pyo3(default)]
+    font_size: Option<f64>,
+    #[pyo3(default)]
+    confidence: Option<f64>,
+    #[pyo3(default)]
+    rotation: f64,
+}
+
+impl SearchInputItem {
+    fn to_rust(&self) -> liteparse::types::TextItem {
+        liteparse::types::TextItem {
+            text: self.text.clone(),
+            x: self.x as f32,
+            y: self.y as f32,
+            width: self.width as f32,
+            height: self.height as f32,
+            rotation: self.rotation as f32,
+            font_name: self.font_name.clone(),
+            font_size: self.font_size.map(|v| v as f32),
+            confidence: self.confidence.map(|v| v as f32),
+            ..Default::default()
+        }
+    }
+}
+
 /// Search text items for phrase matches, returning merged items with combined bounding boxes.
 #[pyfunction]
 #[pyo3(signature = (items, phrase, *, case_sensitive = false))]
-fn search_items(items: Vec<PyTextItem>, phrase: String, case_sensitive: bool) -> Vec<PyTextItem> {
+fn search_items(
+    items: Vec<SearchInputItem>,
+    phrase: String,
+    case_sensitive: bool,
+) -> Vec<PyTextItem> {
     let rust_items: Vec<_> = items.iter().map(|i| i.to_rust()).collect();
     let options = liteparse::search::SearchOptions {
         phrase,

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -655,7 +655,7 @@ impl LiteParse {
 /// Duck-typed input for [`search_items`]. Extracts by attribute name, so it
 /// accepts both the native `PyTextItem` and the pure-Python `TextItem`
 /// dataclass that `LiteParse.parse()` hands back (see `parser.py`,
-/// `_convert_native_result`). 
+/// `_convert_native_result`).
 #[derive(FromPyObject)]
 struct SearchInputItem {
     text: String,


### PR DESCRIPTION
Fixes https://github.com/run-llama/liteparse/issues/362