### PR TITLE
docs: update various docs to note that imagemagick is no longer needed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ liteparse/
 │   │       ├── projection.rs   # Spatial grid projection (layout reconstruction)
 │   │       ├── extract.rs      # Raw text extraction from PDFium
 │   │       ├── render.rs       # Page rendering / screenshots
-│   │       ├── conversion.rs   # Non-PDF format conversion (LibreOffice, ImageMagick)
+│   │       ├── conversion.rs   # Non-PDF format conversion (LibreOffice, image/resvg/usvg rust crates)
 │   │       ├── ocr_merge.rs    # Merging OCR results with native text
 │   │       ├── error.rs        # Error types
 │   │       ├── ocr/            # OCR engine implementations
@@ -68,7 +68,7 @@ liteparse/
 ## Data Flow
 
 1. **Input**: File path or raw bytes received (any supported format)
-2. **Conversion** (if needed): Non-PDF formats converted to PDF via LibreOffice/ImageMagick
+2. **Conversion** (if needed): Non-PDF formats converted to PDF via LibreOffice and image/resvg/usvg rust crates
 3. **PDF Loading**: PDFium extracts text items, images, metadata
 4. **OCR** (if enabled): Pages rendered and OCR'd for text-sparse areas
 5. **Grid Projection**: Spatial reconstruction of text layout using anchor system
@@ -106,7 +106,7 @@ OCR only runs on embedded images where text extraction failed, not the entire do
 Uses a default-first approach where users only override what they need. See `crates/liteparse/src/config.rs` for defaults.
 
 ### 6. Format Conversion via External Tools
-Rather than implementing format parsers, LiteParse converts non-PDF formats using system tools (LibreOffice, ImageMagick) into PDF. This provides broad format support with minimal code.
+Rather than implementing format parsers, LiteParse converts office file formats using system tools (LibreOffice) into PDF. This provides broad format support with minimal code.
 
 ## Common Tasks
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ flowchart LR
 
       subgraph Core["Rust Core"]
           direction TB
-          CONV["Format Conversion\nLibreOffice / ImageMagick"]
+          CONV["Format Conversion\nLibreOffice / Rust image + resvg + usvg crates"]
           EXTRACT["Text Extraction\nPDFium C library"]
           OCR["Selective OCR\nTesseract / HTTP / Custom"]
           MERGE["OCR Merge\nNative text + OCR results"]
@@ -386,21 +386,13 @@ choco install libreoffice-fresh
 
 > _On Windows, you may need to add LibreOffice's program directory (usually `C:\Program Files\LibreOffice\program`) to your PATH._
 
-#### Images (via ImageMagick)
+#### Images (native support)
 - **Formats**: `.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.tiff`, `.webp`, `.svg`
 
-Install ImageMagick for image-to-PDF conversion:
-
-```bash
-# macOS
-brew install imagemagick
-
-# Ubuntu/Debian
-apt-get install imagemagick
-
-# Windows
-choco install imagemagick.app
-```
+> ![NOTE]
+>
+> As of [v2.8.0](https://github.com/run-llama/liteparse/releases/tag/crates-v2.8.0), `imagemagick` is no longer required to convert images to PDF. Conversion is natively
+> handled by the rust code.
 
 ## Environment Variables
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,7 +53,7 @@ flowchart LR
 
       subgraph Core["Rust Core"]
           direction TB
-          CONV["Format Conversion\nLibreOffice / ImageMagick"]
+          CONV["Format Conversion\nLibreOffice / image/resvg/usvg rust crates"]
           EXTRACT["Text Extraction\nPDFium C library"]
           OCR["Selective OCR\nTesseract / HTTP / Custom"]
           MERGE["OCR Merge\nNative text + OCR results"]
@@ -302,21 +302,8 @@ choco install libreoffice-fresh
 
 > _Windows 上可能需要把 LibreOffice 的 program 目录（通常是 `C:\Program Files\LibreOffice\program`）加入 PATH。_
 
-#### 图像（通过 ImageMagick）
+#### 图像
 - **支持格式**：`.jpg`、`.jpeg`、`.png`、`.gif`、`.bmp`、`.tiff`、`.webp`、`.svg`
-
-安装 ImageMagick 以启用图像转 PDF：
-
-```bash
-# macOS
-brew install imagemagick
-
-# Ubuntu/Debian
-apt-get install imagemagick
-
-# Windows
-choco install imagemagick.app
-```
 
 ## 环境变量
 

--- a/crates/liteparse/README.md
+++ b/crates/liteparse/README.md
@@ -222,7 +222,7 @@ not inherit the OAR model or runtime dependency footprint.
 - PDF (`.pdf`)
 - Microsoft Office (`.docx`, `.xlsx`, `.pptx`, etc.) — requires LibreOffice
 - OpenDocument (`.odt`, `.ods`, `.odp`) — requires LibreOffice
-- Images (`.png`, `.jpg`, `.tiff`, etc.) — requires ImageMagick
+- Images (`.png`, `.jpg`, `.tiff`, etc.)
 
 ## CLI
 

--- a/docs/src/content/docs/liteparse/guides/multi-format.mdx
+++ b/docs/src/content/docs/liteparse/guides/multi-format.mdx
@@ -17,7 +17,12 @@ LiteParse automatically converts non-PDF formats to PDF before parsing. This let
 | PowerPoint | `.ppt`, `.pptx`, `.pptm`, `.odp`, `.key` |
 | Spreadsheets | `.xls`, `.xlsx`, `.xlsm`, `.ods`, `.csv`, `.tsv`, `.numbers` |
 
-### Images (via ImageMagick)
+### Images (native support)
+
+<Aside>
+    As of [v2.8.0](https://github.com/run-llama/liteparse/releases/tag/crates-v2.8.0), LiteParse no longer requires `imagemagick` for image to PDF conversion,
+    which is now natively handled by the rust code.
+</Aside>
 
 `.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.tiff`, `.webp`, `.svg`
 
@@ -41,19 +46,6 @@ choco install libreoffice-fresh
 ```
 
 > On Windows, you may need to add the LibreOffice CLI directory (typically `C:\Program Files\LibreOffice\program`) to your PATH and restart.
-
-### ImageMagick (for images)
-
-```bash
-# macOS
-brew install imagemagick
-
-# Ubuntu/Debian
-apt-get install imagemagick
-
-# Windows
-choco install imagemagick.app
-```
 
 ## Usage
 

--- a/full.Dockerfile
+++ b/full.Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tesseract-ocr-eng \
     ca-certificates \
     libreoffice \
-    imagemagick \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/target/release/lit /usr/local/bin/lit

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -123,7 +123,7 @@ for (const page of pages.filter((p) => p.needsOcr)) {
 - PDF (`.pdf`)
 - Microsoft Office (`.docx`, `.xlsx`, `.pptx`, etc.) — requires LibreOffice
 - OpenDocument (`.odt`, `.ods`, `.odp`) — requires LibreOffice
-- Images (`.png`, `.jpg`, `.tiff`, etc.) — requires ImageMagick
+- Images (`.png`, `.jpg`, `.tiff`, etc.)
 - And more!
 
 ## CLI

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -119,7 +119,7 @@ for page in pages:
 - PDF (`.pdf`)
 - Microsoft Office (`.docx`, `.xlsx`, `.pptx`, etc.) — requires LibreOffice
 - OpenDocument (`.odt`, `.ods`, `.odp`) — requires LibreOffice
-- Images (`.png`, `.jpg`, `.tiff`, etc.) — requires ImageMagick
+- Images (`.png`, `.jpg`, `.tiff`, etc.)
 - And more!
 
 ## CLI


### PR DESCRIPTION
Update docs, READMEs and AGENTS.md to note that ImageMagick is no longer needed for image conversion
