### PR TITLE
fix: improve consistency in reported confidence values across bindings

### DIFF
--- a/crates/liteparse-napi/src/types.rs
+++ b/crates/liteparse-napi/src/types.rs
@@ -348,6 +348,7 @@ pub struct JsTextItem {
     pub char_codes: Option<Vec<u32>>,
     /// True when the trailing source space was synthesized by PDFium.
     pub trailing_space_generated: Option<bool>,
+    /// OCR confidence score (0.0-1.0). Undefined for native PDF text.
     pub confidence: Option<f64>,
     /// Rotation in degrees (viewport space). Defaults to 0 when omitted.
     pub rotation: Option<f64>,
@@ -404,7 +405,7 @@ impl JsTextItem {
             stroke_color: item.stroke_color.clone(),
             char_codes: Some(item.char_codes.clone()),
             trailing_space_generated: Some(item.trailing_space_generated),
-            confidence: item.confidence.map(|v| v as f64).or(Some(1.0)),
+            confidence: item.confidence.map(|v| v as f64),
             words: item.words.iter().map(JsWordBox::from_rust).collect(),
         }
     }

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -92,6 +92,7 @@ struct PyTextItem {
     /// True when the trailing source space was synthesized by PDFium.
     #[pyo3(get)]
     trailing_space_generated: bool,
+    /// OCR confidence score (0.0-1.0). None for native PDF text.
     #[pyo3(get)]
     confidence: Option<f64>,
     /// Rotation in degrees (viewport space). Defaults to 0.
@@ -372,7 +373,7 @@ impl PyTextItem {
             stroke_color: item.stroke_color,
             char_codes: item.char_codes,
             trailing_space_generated: item.trailing_space_generated,
-            confidence: item.confidence.map(|v| v as f64).or(Some(1.0)),
+            confidence: item.confidence.map(|v| v as f64),
             rotation: item.rotation as f64,
             words: item.words.into_iter().map(PyWordBox::from_rust).collect(),
         }

--- a/packages/node/src/cli-json.ts
+++ b/packages/node/src/cli-json.ts
@@ -35,7 +35,10 @@ function textItemToCliJson(item: TextItem, extractTextMetadata: boolean) {
     ...(item.trailingSpaceGenerated
       ? { trailing_space_generated: true }
       : {}),
-    ...(item.confidence !== undefined ? { confidence: item.confidence } : {}),
+    // The CLI JSON format reports native text as fully confident, matching the
+    // Rust CLI. The `confidence` field on TextItem itself stays undefined for
+    // native text so it can discriminate OCR-derived items.
+    confidence: item.confidence ?? 1.0,
   };
 }
 

--- a/packages/node/src/lib.ts
+++ b/packages/node/src/lib.ts
@@ -154,6 +154,7 @@ export interface TextItem {
   charCodes?: number[];
   /** True when the trailing source space was synthesized by PDFium. */
   trailingSpaceGenerated?: boolean;
+  /** OCR confidence score (0.0-1.0). Undefined for native PDF text. */
   confidence?: number;
   /** Rotation in degrees (viewport space). Defaults to 0 when omitted. */
   rotation?: number;

--- a/packages/python/liteparse/types.py
+++ b/packages/python/liteparse/types.py
@@ -42,6 +42,7 @@ class TextItem:
     char_codes: List[int] = field(default_factory=list)
     #: True when the trailing source space was synthesized by PDFium.
     trailing_space_generated: bool = False
+    #: OCR confidence score (0.0-1.0). ``None`` for native PDF text.
     confidence: Optional[float] = None
     rotation: float = 0.0
     #: Per-word sub-boxes. Empty unless the parser was configured with


### PR DESCRIPTION
Fixes https://github.com/run-llama/liteparse/issues/377