### PR TITLE
fix(python): expose render_form_fields in get_config()

### DIFF
--- a/packages/python/liteparse/parser.py
+++ b/packages/python/liteparse/parser.py
@@ -682,6 +682,7 @@ class LiteParse:
             extract_xfa_packets=cfg.extract_xfa_packets,
             extract_content_bounds=cfg.extract_content_bounds,
             detect_screenshot_rects=cfg.detect_screenshot_rects,
+            render_form_fields=cfg.render_form_fields,
         )
 
     def __repr__(self) -> str:

--- a/packages/python/liteparse/types.py
+++ b/packages/python/liteparse/types.py
@@ -383,6 +383,7 @@ class LiteParseConfig:
     extract_xfa_packets: bool = False
     detect_screenshot_rects: bool = False
     extract_content_bounds: bool = False
+    render_form_fields: bool = False
 
 
 class ParseError(Exception):

--- a/packages/python/tests/test_config_e2e.py
+++ b/packages/python/tests/test_config_e2e.py
@@ -1,15 +1,66 @@
 """E2E tests for LiteParse.get_config() — validates the resolved config mirrors the native config."""
 
+import inspect
+from dataclasses import fields
+
 from liteparse import LiteParse
+from liteparse._liteparse import PyLiteParseConfig
+from liteparse.types import LiteParseConfig
+
+NATIVE_CONFIG_FIELDS = {
+    name for name in dir(PyLiteParseConfig) if not name.startswith("_")
+}
+
+NON_DEFAULT_OPTIONS = {
+    "ocr_enabled": True,
+    "ocr_server_url": "http://ocr.example/v1",
+    "ocr_server_headers": {"Authorization": "Bearer token"},
+    "ocr_language": "fra",
+    "tessdata_path": "tessdata",
+    "max_pages": 7,
+    "target_pages": "2-4",
+    "dpi": 222.0,
+    "output_format": "markdown",
+    "preserve_very_small_text": True,
+    "password": "s3cret",
+    "quiet": True,
+    "num_workers": 3,
+    "image_mode": "embed",
+    "extract_images": True,
+    "image_output_dir": "out/images",
+    "extract_links": False,
+    "keep_headers_footers": True,
+    "extract_annotations": True,
+    "extract_form_fields": True,
+    "extract_structure_tree": True,
+    "extract_xfa_packets": True,
+    "extract_content_bounds": True,
+    "detect_screenshot_rects": True,
+    "render_form_fields": True,
+    "ocr_failure_fatal": False,
+    "ocr_hedge_delays_ms": [0, 500],
+    "emit_word_boxes": True,
+    "extract_text_metadata": True,
+    "crop_box": (0.0, 0.25, 0.5, 0.125),
+    "skip_diagonal_text": True,
+    "include_complexity": True,
+    "extract_vector_graphics": True,
+}
 
 
-class TestGetConfig:
-    """Constructor options are reflected in the resolved config."""
+class TestConfigSurfaceParity:
+    """The Python config surfaces stay in step with the native config."""
 
-    def test_render_form_fields_defaults_to_false(self):
-        config = LiteParse(quiet=True).get_config()
-        assert config.render_form_fields is False
+    def test_every_python_config_surface_declares_the_native_fields(self):
+        assert {f.name for f in fields(LiteParseConfig)} == NATIVE_CONFIG_FIELDS
 
-    def test_render_form_fields_reflects_constructor_option(self):
-        config = LiteParse(render_form_fields=True, quiet=True).get_config()
-        assert config.render_form_fields is True
+        constructor_options = set(inspect.signature(LiteParse.__init__).parameters)
+        assert constructor_options - {"self"} == NATIVE_CONFIG_FIELDS
+
+        assert set(NON_DEFAULT_OPTIONS) == NATIVE_CONFIG_FIELDS
+
+    def test_get_config_reports_every_constructor_option(self):
+        config = LiteParse(**NON_DEFAULT_OPTIONS).get_config()
+
+        reported = {f.name: getattr(config, f.name) for f in fields(LiteParseConfig)}
+        assert reported == NON_DEFAULT_OPTIONS

--- a/packages/python/tests/test_config_e2e.py
+++ b/packages/python/tests/test_config_e2e.py
@@ -1,0 +1,15 @@
+"""E2E tests for LiteParse.get_config() — validates the resolved config mirrors the native config."""
+
+from liteparse import LiteParse
+
+
+class TestGetConfig:
+    """Constructor options are reflected in the resolved config."""
+
+    def test_render_form_fields_defaults_to_false(self):
+        config = LiteParse(quiet=True).get_config()
+        assert config.render_form_fields is False
+
+    def test_render_form_fields_reflects_constructor_option(self):
+        config = LiteParse(render_form_fields=True, quiet=True).get_config()
+        assert config.render_form_fields is True


### PR DESCRIPTION
## Summary

`LiteParse.__init__()` accepts `render_form_fields` and forwards it to the
native parser, but the `LiteParseConfig` dataclass has no such field and
`get_config()` never copies it back. The option applies correctly — only the
reflected config denies it exists.

Same class as #363 (fixed in #368). Python-side only: the PyO3 getter already
exists on `PyLiteParseConfig`, so no `crates/` change is needed.

## Problem

```python
from liteparse import LiteParse

p = LiteParse(render_form_fields=True)

p._native.config.render_form_fields             # True  — the option did apply
hasattr(p.get_config(), "render_form_fields")   # False
p.get_config().render_form_fields
# AttributeError: 'LiteParseConfig' object has no attribute 'render_form_fields'
```

| | expected | actual on main |
|---|---|---|
| `hasattr(get_config(), "render_form_fields")` | `True` | `False` |
| `LiteParse(render_form_fields=True).get_config().render_form_fields` | `True` | `AttributeError` |
| `LiteParse().get_config().render_form_fields` | `False` | `AttributeError` |

No error or warning — the setting is silently invisible when inspecting the
config, exactly as described in #363.

## Cause

`render_form_fields` was added to the Python constructor and forwarded through
`kwargs` (parser.py), and `PyLiteParseConfig` exposes the getter
(`crates/liteparse-python/src/lib.rs`), but the wrapper's mirror of the option
set was not updated. On `main`, `PyLiteParseConfig` exposes 33 fields while
`LiteParseConfig` declares 32 and `get_config()` passes 32 — the symmetric
difference is exactly `{render_form_fields}`.

## Fix

Two lines: add `render_form_fields: bool = False` to `LiteParseConfig` and pass
`render_form_fields=cfg.render_form_fields` in `get_config()`. No behaviour
change to parsing, and no change to CLI or JSON output.

## Tests

Adds `packages/python/tests/test_config_e2e.py` covering the default (`False`)
and the constructor round-trip (`True`).

Verified both fail without the fix. With `types.py` and `parser.py` reverted to
`main` and only the test applied:

```
E   AttributeError: 'LiteParseConfig' object has no attribute 'render_form_fields'
tests/test_config_e2e.py:11: AttributeError
E   AttributeError: 'LiteParseConfig' object has no attribute 'render_form_fields'
tests/test_config_e2e.py:15: AttributeError
2 failed in 0.01s
```

Restored:

```
2 passed in 0.01s
```

Commands run:

- `python -m pytest tests/test_config_e2e.py` from `packages/python/` — 2 passed
- `SKIP_INTEGRATION_TESTS=yes cargo test --workspace --no-default-features --exclude liteparse-python --exclude liteparse-napi` — 306 passed, 0 failed (unchanged; no Rust touched)
- The `ci-python.yml` smoke shape (`from liteparse import LiteParse, ParseResult, ParsedPage, TextItem, ScreenshotResult`; construct; `repr`) — passes, and `get_config()` now ends `..., extract_content_bounds=False, render_form_fields=False)`

Two notes so nothing is overstated:

- I built the extension module locally with
  `cargo rustc -p liteparse-python --no-default-features -- -C link-arg=-undefined -C link-arg=dynamic_lookup`
  and dropped it in as `liteparse/_liteparse.so`, rather than building a wheel
  with maturin. A `pip install` of a real wheel was not exercised.
- The test has to be named explicitly. A bare `pytest tests/` aborts before
  reaching it: the three existing modules fail at collection on `main` already
  (`ImportError` on `BatchResult`, `BoundingBox`, `ImageFormat`, which
  `liteparse/__init__.py` no longer exports), giving
  `Interrupted: 3 errors during collection`. Their fixtures also point at
  `test-docs/` and `expected-dataset/`, which aren't in the repo.
  `ci-python.yml` never invokes pytest, so none of this is visible in CI. I've
  left it alone as a separate concern; the new module is self-contained and
  needs no fixture document.
