### PR TITLE
fix(markdown): don't backslash-escape inside inline code spans

### DIFF
--- a/crates/liteparse/src/markdown_layout/inline.rs
+++ b/crates/liteparse/src/markdown_layout/inline.rs
@@ -55,6 +55,15 @@ fn style_body(text: &str, style: SpanStyle) -> String {
     }
 }
 
+/// Render `text` as a single styled markdown span: style-aware escaping
+/// (`style_body`) plus marker wrapping (`apply_style`). Always use this pair
+/// through here — calling `escape_inline` + `apply_style` directly would
+/// backslash-escape the body of a code span, which CommonMark renders
+/// literally.
+fn render_span(text: &str, style: SpanStyle) -> String {
+    apply_style(&style_body(text, style), style)
+}
+
 /// Wrap `inner` in a markdown inline link to `url`. Uses the angle-bracket
 /// destination form when the URL contains characters that would otherwise
 /// terminate or break the `(url)` form (whitespace or parentheses).
@@ -71,12 +80,24 @@ fn apply_link(inner: &str, url: &str) -> String {
 /// a span is mono we drop the `**/*` wrap. Bold + italic → `***…***`.
 fn apply_style(inner: &str, style: SpanStyle) -> String {
     let styled = if style.mono {
-        // Use backticks; if inner already contains backticks, switch to a
-        // longer fence (pair of backticks plus a space buffer) per CommonMark.
-        if inner.contains('`') {
-            format!("`` {} ``", inner)
-        } else {
+        // The fence must be longer than the longest backtick run inside the
+        // content (a matching-length interior run would close the span early),
+        // with a space buffer so an edge backtick can't merge into the fence.
+        // CommonMark strips one space from each end, so the content round-trips.
+        let longest_run = {
+            let mut longest = 0usize;
+            let mut run = 0usize;
+            for c in inner.chars() {
+                run = if c == '`' { run + 1 } else { 0 };
+                longest = longest.max(run);
+            }
+            longest
+        };
+        if longest_run == 0 {
             format!("`{}`", inner)
+        } else {
+            let fence = "`".repeat(longest_run + 1);
+            format!("{fence} {inner} {fence}")
         }
     } else {
         match (style.bold, style.italic) {
@@ -133,11 +154,7 @@ pub(super) fn render_line_inline(line: &ProjectedLine) -> String {
         if joined.is_empty() {
             return joined;
         }
-        let escaped = style_body(&joined, styles[0]);
-        if styles[0].is_plain() {
-            return escaped;
-        }
-        return apply_style(&escaped, styles[0]);
+        return render_span(&joined, styles[0]);
     }
 
     // Group consecutive spans by style. Within a group, span texts join with
@@ -159,12 +176,7 @@ pub(super) fn render_line_inline(line: &ProjectedLine) -> String {
             group_text.push_str(span.text.trim());
         }
         let group_text = collapse_whitespace(&group_text);
-        let escaped = style_body(&group_text, style);
-        let mut rendered = if style.is_plain() {
-            escaped
-        } else {
-            apply_style(&escaped, style)
-        };
+        let mut rendered = render_span(&group_text, style);
         if let Some(url) = link {
             rendered = apply_link(&rendered, url);
         }
@@ -190,13 +202,7 @@ pub(super) fn render_line_inline(line: &ProjectedLine) -> String {
 /// around it). On any failure we fall back to plain escaped `rest`.
 pub(super) fn render_list_item_text(line: &ProjectedLine, marker: &str, rest: &str) -> String {
     if let Some(style) = line_uniform_style(line) {
-        let plain = collapse_whitespace(rest);
-        let escaped = style_body(&plain, style);
-        return if style.is_plain() {
-            escaped
-        } else {
-            apply_style(&escaped, style)
-        };
+        return render_span(&collapse_whitespace(rest), style);
     }
     let full = render_line_inline(line);
     if let Some(stripped) = strip_leading_marker_from_inline(&full, marker) {
@@ -463,5 +469,21 @@ mod tests {
         let l = styled_line(&[("a_b*c", 50.0, Some("Courier"))], 100.0, 10.0);
         let out = render_line_inline(&l);
         assert_eq!(out, "`a_b*c`");
+    }
+
+    #[test]
+    fn mono_span_with_single_backtick_uses_double_fence() {
+        let l = styled_line(&[("a`b", 50.0, Some("Courier"))], 100.0, 10.0);
+        let out = render_line_inline(&l);
+        assert_eq!(out, "`` a`b ``");
+    }
+
+    #[test]
+    fn mono_span_with_double_backtick_run_uses_longer_fence() {
+        // A 2-backtick run inside the content would close a 2-backtick fence
+        // early; the fence must be one longer than the longest interior run.
+        let l = styled_line(&[("a``b", 50.0, Some("Courier"))], 100.0, 10.0);
+        let out = render_line_inline(&l);
+        assert_eq!(out, "``` a``b ```");
     }
 }

--- a/crates/liteparse/src/markdown_layout/inline.rs
+++ b/crates/liteparse/src/markdown_layout/inline.rs
@@ -44,6 +44,17 @@ pub(super) fn escape_inline(s: &str) -> String {
     out
 }
 
+/// Escape `text` for use as the body of a span with `style`. Backslash escapes
+/// are inert inside code spans per CommonMark, so mono text is passed through
+/// verbatim.
+fn style_body(text: &str, style: SpanStyle) -> String {
+    if style.mono {
+        text.to_string()
+    } else {
+        escape_inline(text)
+    }
+}
+
 /// Wrap `inner` in a markdown inline link to `url`. Uses the angle-bracket
 /// destination form when the URL contains characters that would otherwise
 /// terminate or break the `(url)` form (whitespace or parentheses).
@@ -122,7 +133,7 @@ pub(super) fn render_line_inline(line: &ProjectedLine) -> String {
         if joined.is_empty() {
             return joined;
         }
-        let escaped = escape_inline(&joined);
+        let escaped = style_body(&joined, styles[0]);
         if styles[0].is_plain() {
             return escaped;
         }
@@ -148,7 +159,7 @@ pub(super) fn render_line_inline(line: &ProjectedLine) -> String {
             group_text.push_str(span.text.trim());
         }
         let group_text = collapse_whitespace(&group_text);
-        let escaped = escape_inline(&group_text);
+        let escaped = style_body(&group_text, style);
         let mut rendered = if style.is_plain() {
             escaped
         } else {
@@ -180,7 +191,7 @@ pub(super) fn render_line_inline(line: &ProjectedLine) -> String {
 pub(super) fn render_list_item_text(line: &ProjectedLine, marker: &str, rest: &str) -> String {
     if let Some(style) = line_uniform_style(line) {
         let plain = collapse_whitespace(rest);
-        let escaped = escape_inline(&plain);
+        let escaped = style_body(&plain, style);
         return if style.is_plain() {
             escaped
         } else {
@@ -414,5 +425,43 @@ mod tests {
         // Plain spans stay unwrapped.
         assert!(out.contains("call"));
         assert!(out.contains("on it"));
+    }
+
+    #[test]
+    fn render_line_inline_mono_span_is_not_escaped() {
+        let l = styled_line(
+            &[
+                ("call", 50.0, Some("Arial")),
+                ("get_user_id", 100.0, Some("Courier")),
+                ("now", 200.0, Some("Arial")),
+            ],
+            100.0,
+            10.0,
+        );
+        let out = render_line_inline(&l);
+        assert!(out.contains("`get_user_id`"), "got: {out}");
+        assert!(!out.contains('\\'), "got: {out}");
+    }
+
+    #[test]
+    fn render_line_inline_mono_span_keeps_backslashes() {
+        let l = styled_line(
+            &[
+                ("open", 50.0, Some("Arial")),
+                (r"C:\Program\bin", 100.0, Some("Courier")),
+                ("next", 200.0, Some("Arial")),
+            ],
+            100.0,
+            10.0,
+        );
+        let out = render_line_inline(&l);
+        assert!(out.contains(r"`C:\Program\bin`"), "got: {out}");
+    }
+
+    #[test]
+    fn render_line_inline_uniform_mono_line_is_not_escaped() {
+        let l = styled_line(&[("a_b*c", 50.0, Some("Courier"))], 100.0, 10.0);
+        let out = render_line_inline(&l);
+        assert_eq!(out, "`a_b*c`");
     }
 }


### PR DESCRIPTION
## Summary

Inline code spans in markdown output carry backslash escapes that CommonMark
does not honour inside a code span, so the escapes render literally to the
reader. Affects any document that sets an identifier or path in a monospace
font inside a proportional-font sentence.

## Problem

Prose with a monospace run, driven through `LiteParse::parse_from_pages` with
`output_format = Markdown`:

| input spans | current output | expected |
|---|---|---|
| `"Please call the function named"` (Helvetica) + `"get_user_id"` (Courier) + `"before you continue with the setup."` (Helvetica) | ``Please call the function named `get\_user\_id` before you continue with the setup.`` | ``... `get_user_id` ...`` |
| `"Install the runtime under the folder"` (Helvetica) + `C:\Program\bin` (Courier) + `"and then restart the service daemon."` (Helvetica) | ``Install the runtime under the folder `C:\\Program\\bin` and then restart the service daemon.`` | ``... `C:\Program\bin` ...`` |

Rendered, the reader sees `<code>get\_user\_id</code>` and
`<code>C:\\Program\\bin</code>` — the backslashes are literal content.

It is also reachable in two further shapes, which are worth knowing because they
are hunk shapes you may see in the regression diff:

```
mixed-style list item:  - run the `get\_user\_id` helper   →  - run the `get_user_id` helper
mono span inside a link: see [`a\_b`](url) now             →  see [`a_b`](url) now
```

## Cause

`render_line_inline` escapes `*`, `_` and `\` via `escape_inline()` *before*
calling `apply_style()`, and `apply_style()`'s mono branch wraps the
already-escaped text in backticks:

```rust
let escaped = escape_inline(&group_text);
let mut rendered = if style.is_plain() { escaped } else { apply_style(&escaped, style) };
```

CommonMark §6.1: "Backslash escapes do not work in code blocks, code spans,
autolinks, or raw HTML." The escaping is right for emphasis spans and prose;
it is simply not applicable once the text lands between backticks.

## Fix

Adds `style_body()`, which skips escaping when the span is mono, and routes the
three escape-then-style sites through it: the uniform-line fast path and the
per-group path in `render_line_inline`, and the uniform path in
`render_list_item_text`. The mixed-style fallback at the end of
`render_list_item_text` keeps plain `escape_inline()` — that branch discards
every marker including backticks, so no mono span can reach a backtick wrap
through it.

`escape_inline()` itself is unchanged, so prose and emphasis spans escape
exactly as before.

## Effect on the regression corpus

This changes markdown bytes, so I expect the `output-changed` label. The delta
is bounded, and the bound is structural rather than empirical:

`SpanStyle::is_plain()` is `!bold && !italic && !mono && !strike`, so
`mono ⇒ !is_plain ⇒ apply_style()` always runs ⇒ backticks are always added.
`style_body` differs from `escape_inline` only when `mono`. Therefore **every
byte this change removes is provably a `\` inside a code span.**

Concretely:

- Only text inside a **mono** span changes, and only when it contains `*`, `_`
  or `\`. Every other span is byte-identical.
- The only change is the **removal** of a `\` that was never meaningful in that
  position. Nothing is added, no span boundaries move, no wrapping changes.
- So every diff hunk should read as `` `foo\_bar` `` → `` `foo_bar` `` or
  `` `C:\\x` `` → `` `C:\x` ``. Any hunk that is not a backslash deletion
  inside backticks would be a bug in this change.

Things I specifically checked cannot flip: the code-fence choice in
`apply_style` (`escape_inline` never touches backticks), list-marker stripping
(no marker producible by `parse_list_marker`/`split_ordered_marker` can contain
`*`, `_` or `\`), de-hyphenation (a mono rendering ends in a backtick before and
after), and table cells (`markdown_layout/tables.rs` uses `escape_table_cell`
and never emits backticks).

Markdown output for the four PDFs in the repo (`apple-10k-2024`,
`long_tiny_text`, `annotation_text`, `sample`) is byte-identical before and
after — consistent with the delta being rare, though it also means the in-repo
documents don't exhibit it.

## Tests

Three cases added to the existing `mod tests` in `inline.rs`, next to
`render_line_inline_mono_span`: a mixed-style line with an underscored
identifier, one with a backslash path, and a uniformly-mono line (the fast
path). Verified all three fail without the fix — with `style_body()` reverted
to `escape_inline()` at the three call sites and the tests kept:

```
panicked at inline.rs:442: got: call `get\_user\_id` now
panicked at inline.rs:458: got: open `C:\\Program\\bin` next
panicked at inline.rs:465: assertion `left == right` failed
  left: "`a\\_b\\*c`"
 right: "`a_b*c`"

test result: FAILED. 10 passed; 3 failed
```

Restored: `test result: ok. 13 passed; 0 failed`.

Commands run:

- `SKIP_INTEGRATION_TESTS=yes cargo test --workspace --no-default-features --exclude liteparse-python --exclude liteparse-napi` — 309 passed, 0 failed (306 on `main` plus the 3 added here)
- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --no-default-features --exclude liteparse-python --exclude liteparse-napi` — exit 0, no new warnings

The existing `render_line_inline_mono_span` test uses `"foo()"` and
`render_line_inline_escapes_emphasis_chars` uses `"5*4=20"` in a *plain* span,
so the mono-and-escapable interaction was unpinned; it is now.

An alternative fix would be to strip the escapes inside `apply_style()`'s mono
branch instead of avoiding them upstream. I went with the upstream version
because unescaping is lossy — it cannot distinguish an escape this code
inserted from a backslash that was in the source text. Happy to switch if you
prefer the change confined to `apply_style()`.
