### PR TITLE
fix: keep side-by-side ruled tables separate

### DIFF
--- a/crates/liteparse/src/markdown_layout/tables.rs
+++ b/crates/liteparse/src/markdown_layout/tables.rs
@@ -3089,23 +3089,44 @@ fn extract_h_v_segments(graphics: &[GraphicPrimitive]) -> (Vec<HSeg>, Vec<VSeg>)
     (hs, vs)
 }
 
-/// Cluster H segments sharing a y-coordinate (within `TABLE_GRID_CLUSTER_PT`)
-/// into a single wider grid line whose x-extent is the union of the inputs.
+fn ranges_overlap_or_nearly_touch(a_min: f32, a_max: f32, b_min: f32, b_max: f32) -> bool {
+    a_min <= b_max + TABLE_CROSS_TOLERANCE_PT && b_min <= a_max + TABLE_CROSS_TOLERANCE_PT
+}
+
+/// Cluster connected H segments sharing a y-coordinate (within
+/// `TABLE_GRID_CLUSTER_PT`) into a single wider grid line whose x-extent is
+/// the union of the inputs. Collinear segments separated by whitespace stay
+/// distinct so unrelated side-by-side tables do not become one component.
 fn cluster_h_segments(mut segs: Vec<HSeg>) -> Vec<HSeg> {
     if segs.is_empty() {
         return segs;
     }
     segs.sort_by(|a, b| a.y.total_cmp(&b.y));
     let mut out: Vec<HSeg> = Vec::with_capacity(segs.len());
-    for seg in segs {
-        if let Some(last) = out.last_mut()
-            && (last.y - seg.y).abs() <= TABLE_GRID_CLUSTER_PT
-        {
-            last.x_min = last.x_min.min(seg.x_min);
-            last.x_max = last.x_max.max(seg.x_max);
-            continue;
+    let mut band_start = 0;
+    while band_start < segs.len() {
+        let band_y = segs[band_start].y;
+        let mut band_end = band_start + 1;
+        while band_end < segs.len() && (segs[band_end].y - band_y).abs() <= TABLE_GRID_CLUSTER_PT {
+            band_end += 1;
         }
-        out.push(seg);
+
+        let band = &mut segs[band_start..band_end];
+        band.sort_by(|a, b| a.x_min.total_cmp(&b.x_min));
+        let mut current = band[0];
+        current.y = band_y;
+        for seg in &band[1..] {
+            if ranges_overlap_or_nearly_touch(current.x_min, current.x_max, seg.x_min, seg.x_max) {
+                current.x_min = current.x_min.min(seg.x_min);
+                current.x_max = current.x_max.max(seg.x_max);
+            } else {
+                out.push(current);
+                current = *seg;
+                current.y = band_y;
+            }
+        }
+        out.push(current);
+        band_start = band_end;
     }
     out
 }
@@ -5599,6 +5620,34 @@ mod tests {
         ];
         let runs = detect_ruled_tables(&lines, &extract_rule_segments(&graphics), 612.0, 792.0);
         assert_eq!(runs.len(), 1);
+    }
+
+    #[test]
+    fn ruled_grids_with_shared_rows_remain_separate_components() {
+        // Two side-by-side 2x2 grids intentionally reuse the same y
+        // coordinates. Their horizontal borders must not be extended through
+        // the whitespace between the grids.
+        let mut graphics = Vec::new();
+        for left in [50.0_f32, 350.0] {
+            for y in [100.0_f32, 140.0, 180.0] {
+                graphics.push(stroke(left, y, left + 200.0, y, 0.5));
+            }
+            for x in [left, left + 100.0, left + 200.0] {
+                graphics.push(stroke(x, 100.0, x, 180.0, 0.5));
+            }
+        }
+
+        let (hs, vs) = extract_h_v_segments(&graphics);
+        let hs = cluster_h_segments(hs);
+        let vs = cluster_v_segments(vs);
+        let components = find_grid_components(&hs, &vs);
+
+        assert_eq!(components.len(), 2, "expected two separate grid components");
+        assert!(
+            components
+                .iter()
+                .all(|(h_indices, v_indices)| h_indices.len() == 3 && v_indices.len() == 3)
+        );
     }
 
     #[test]

--- a/crates/liteparse/src/projection.rs
+++ b/crates/liteparse/src/projection.rs
@@ -2889,6 +2889,7 @@ pub fn project_pages_to_grid(pages: Vec<Page>) -> Vec<ParsedPage> {
                 page.page_width,
                 page.page_height,
                 &obstacles,
+                &table_rects,
             );
             ParsedPage {
                 page_number: page.page_number,
@@ -4597,6 +4598,7 @@ pub(crate) fn build_projected_lines(
     page_width: f32,
     page_height: f32,
     figures: &[Rect],
+    table_rects: &[Rect],
 ) -> (Vec<ProjectedLine>, Region) {
     if items.is_empty() {
         return (Vec::new(), Region::default());
@@ -4619,7 +4621,7 @@ pub(crate) fn build_projected_lines(
         .cloned()
         .collect();
 
-    let mut out: Vec<ProjectedLine> = Vec::new();
+    let mut out: Vec<TableOwnedLine> = Vec::new();
     for (path, indices) in leaves {
         // Sort within the leaf by y, tie-break by x. `build_one_line` re-sorts
         // by x for left→right concatenation; the y-banding loop here only
@@ -4672,31 +4674,37 @@ pub(crate) fn build_projected_lines(
             let height_mismatch = raw_h > Y_BAND_HEIGHT_CAP && raw_h > current_h * 2.0;
             let tol_factor = if height_mismatch { 0.3 } else { 0.5 };
             let same = (y - current_y).abs() < current_h.min(h) * tol_factor;
-            if same {
+            let item_region = table_region_for_item(table_rects, &items[idx]);
+            let current_region = table_region_for_group(table_rects, items, &current);
+            let crosses_independent_tables = item_region.is_some_and(|next| {
+                current.iter().any(|&current_index| {
+                    table_region_for_item(table_rects, &items[current_index])
+                        .is_some_and(|current| current != next)
+                })
+            });
+            if same && !crosses_independent_tables {
                 current.push(idx);
                 current_y = current_y.min(y);
                 current_h = current_h.max(h);
             } else {
-                out.push(build_one_line(
-                    items,
-                    &current,
-                    path.clone(),
-                    &heading_excl_figures,
-                ));
+                out.push(TableOwnedLine {
+                    line: build_one_line(items, &current, path.clone(), &heading_excl_figures),
+                    region: current_region,
+                });
                 current = vec![idx];
                 current_y = y;
                 current_h = h;
             }
         }
         if !current.is_empty() {
-            out.push(build_one_line(
-                items,
-                &current,
-                path.clone(),
-                &heading_excl_figures,
-            ));
+            out.push(TableOwnedLine {
+                line: build_one_line(items, &current, path.clone(), &heading_excl_figures),
+                region: table_region_for_group(table_rects, items, &current),
+            });
         }
     }
+
+    reorder_independent_table_lines(&mut out, table_rects);
 
     // Normalize `indent_x` to be leaf-relative: subtract each leaf's minimum
     // line bbox.x from every line in that leaf. This way list-nesting and
@@ -4707,7 +4715,8 @@ pub(crate) fn build_projected_lines(
     {
         use std::collections::HashMap;
         let mut leaf_min: HashMap<Vec<u16>, f32> = HashMap::new();
-        for line in &out {
+        for owned in &out {
+            let line = &owned.line;
             let e = leaf_min
                 .entry(line.region_path.clone())
                 .or_insert(f32::INFINITY);
@@ -4715,7 +4724,8 @@ pub(crate) fn build_projected_lines(
                 *e = line.indent_x;
             }
         }
-        for line in &mut out {
+        for owned in &mut out {
+            let line = &mut owned.line;
             if let Some(min) = leaf_min.get(&line.region_path)
                 && min.is_finite()
             {
@@ -4727,7 +4737,166 @@ pub(crate) fn build_projected_lines(
         }
     }
 
-    (out, region)
+    (out.into_iter().map(|owned| owned.line).collect(), region)
+}
+
+#[derive(Clone)]
+struct TableOwnedLine {
+    line: ProjectedLine,
+    region: Option<usize>,
+}
+
+/// Return the ruled-table region that owns an item. Besides text inside the
+/// grid, include a short label immediately above it; table captions and
+/// section headings commonly sit just outside the top border. A label that
+/// overlaps multiple tables remains page-spanning and is not assigned to
+/// either one.
+fn table_region_for_item(rects: &[Rect], item: &ProjectedTextItem) -> Option<usize> {
+    let item_left = item.orig_x;
+    let item_right = item.orig_x + item.orig_width;
+    let item_top = item.orig_y;
+    let item_bottom = item.orig_y + item.orig_height;
+    let nearby_above = |rect: &Rect| {
+        let gap = rect.y - item_bottom;
+        gap >= -TABLE_LABEL_OVERLAP_PT && gap <= item.orig_height.max(TABLE_LABEL_GAP_PT)
+    };
+
+    let mut matches = rects.iter().enumerate().filter_map(|(index, rect)| {
+        let overlap_x = (item_right.min(rect.x + rect.width) - item_left.max(rect.x)).max(0.0);
+        let horizontally_owned = item.orig_width > 0.0 && overlap_x / item.orig_width >= 0.5;
+        let inside_y = item_top <= rect.y + rect.height && item_bottom >= rect.y;
+        (horizontally_owned && (inside_y || nearby_above(rect))).then_some(index)
+    });
+
+    let first = matches.next()?;
+    matches.next().is_none().then_some(first)
+}
+
+const TABLE_LABEL_GAP_PT: f32 = 12.0;
+const TABLE_LABEL_OVERLAP_PT: f32 = 2.0;
+
+fn table_region_for_group(
+    rects: &[Rect],
+    items: &[ProjectedTextItem],
+    indices: &[usize],
+) -> Option<usize> {
+    let mut regions = indices
+        .iter()
+        .map(|&index| table_region_for_item(rects, &items[index]));
+    let first = regions.next()??;
+    regions.all(|region| region == Some(first)).then_some(first)
+}
+
+/// Same-y rows from side-by-side grids naturally alternate left/right. Group
+/// lines by their owning grid so the table detector sees one complete table
+/// at a time. Non-table lines keep their original slots and relative order.
+fn reorder_independent_table_lines(lines: &mut [TableOwnedLine], rects: &[Rect]) {
+    if rects.len() < 2 {
+        return;
+    }
+
+    let Some(region_ranks) = table_region_ranks(rects) else {
+        return;
+    };
+    let positions: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(index, owned)| owned.region.map(|_| index))
+        .collect();
+    let mut grouped: Vec<TableOwnedLine> = positions
+        .iter()
+        .map(|&index| lines[index].clone())
+        .collect();
+
+    grouped.sort_by(|left, right| {
+        region_ranks[left.region.unwrap()]
+            .cmp(&region_ranks[right.region.unwrap()])
+            .then(left.line.bbox.y.total_cmp(&right.line.bbox.y))
+            .then(left.line.bbox.x.total_cmp(&right.line.bbox.x))
+    });
+
+    for (position, owned) in positions.into_iter().zip(grouped) {
+        lines[position] = owned;
+    }
+}
+
+/// Produce a stable page-reading rank for every table rectangle. Rectangles
+/// sharing a common vertical interval form one side-by-side band and sort by
+/// x; separate bands sort top-to-bottom. `None` means there is no side-by-side
+/// relationship, so projection order does not need rewriting.
+fn table_region_ranks(rects: &[Rect]) -> Option<Vec<usize>> {
+    struct Band {
+        top: f32,
+        common_top: f32,
+        common_bottom: f32,
+        regions: Vec<usize>,
+    }
+
+    let mut by_y: Vec<usize> = (0..rects.len()).collect();
+    by_y.sort_by(|&left, &right| {
+        rects[left]
+            .y
+            .total_cmp(&rects[right].y)
+            .then(rects[left].x.total_cmp(&rects[right].x))
+    });
+    let mut bands: Vec<Band> = Vec::new();
+    for region in by_y {
+        let rect = &rects[region];
+        let bottom = rect.y + rect.height;
+        if let Some(band) = bands
+            .iter_mut()
+            .find(|band| rect.y < band.common_bottom && bottom > band.common_top)
+        {
+            band.common_top = band.common_top.max(rect.y);
+            band.common_bottom = band.common_bottom.min(bottom);
+            band.regions.push(region);
+        } else {
+            bands.push(Band {
+                top: rect.y,
+                common_top: rect.y,
+                common_bottom: bottom,
+                regions: vec![region],
+            });
+        }
+    }
+
+    let has_side_by_side = bands.iter().any(|band| {
+        band.regions.iter().enumerate().any(|(position, &left)| {
+            band.regions[position + 1..].iter().any(|&right| {
+                rects[left].x + rects[left].width <= rects[right].x
+                    || rects[right].x + rects[right].width <= rects[left].x
+            })
+        })
+    });
+    if !has_side_by_side {
+        return None;
+    }
+
+    bands.sort_by(|left, right| left.top.total_cmp(&right.top));
+    let mut ordered = Vec::with_capacity(rects.len());
+    for band in &mut bands {
+        band.regions.sort_by(|&left, &right| {
+            rects[left]
+                .x
+                .total_cmp(&rects[right].x)
+                .then(rects[left].y.total_cmp(&rects[right].y))
+        });
+        ordered.extend(band.regions.iter().copied());
+    }
+
+    let mut ranks = vec![0; rects.len()];
+    for (rank, region) in ordered.into_iter().enumerate() {
+        ranks[region] = rank;
+    }
+    Some(ranks)
+}
+
+#[cfg(test)]
+fn regions_in_rank_order(rects: &[Rect]) -> Vec<usize> {
+    let ranks = table_region_ranks(rects).expect("side-by-side regions");
+    let mut regions: Vec<usize> = (0..rects.len()).collect();
+    regions.sort_by_key(|&region| ranks[region]);
+    regions
 }
 
 fn build_one_line(
@@ -5073,6 +5242,40 @@ mod tests {
         }
     }
 
+    fn table_rect(x: f32, y: f32, width: f32, height: f32) -> Rect {
+        Rect {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    #[test]
+    fn table_region_ranks_order_two_side_by_side_bands_top_to_bottom() {
+        let rects = [
+            table_rect(400.0, 300.0, 180.0, 80.0),
+            table_rect(40.0, 100.0, 180.0, 80.0),
+            table_rect(40.0, 300.0, 180.0, 80.0),
+            table_rect(400.0, 100.0, 180.0, 80.0),
+        ];
+
+        assert_eq!(regions_in_rank_order(&rects), vec![1, 3, 2, 0]);
+    }
+
+    #[test]
+    fn table_region_ranks_do_not_bridge_non_overlapping_outer_tables() {
+        // A overlaps B and B overlaps C, but A and C only touch. Treating
+        // overlap as a transitive relation would order A/C by x before B.
+        let rects = [
+            table_rect(40.0, 0.0, 180.0, 100.0),
+            table_rect(400.0, 50.0, 180.0, 100.0),
+            table_rect(40.0, 100.0, 180.0, 100.0),
+        ];
+
+        assert_eq!(regions_in_rank_order(&rects), vec![0, 1, 2]);
+    }
+
     #[test]
     fn xy_cut_finds_column_gutter_on_two_column_layout() {
         // Two columns, 50pt-wide gutter centered at x=300. Each column has
@@ -5126,7 +5329,7 @@ mod tests {
             items.push(item_at("L", 50.0, y, 200.0, 10.0));
             items.push(item_at("R", 350.0, y, 200.0, 10.0));
         }
-        let (lines, _region) = build_projected_lines(&items, 612.0, 792.0, &[]);
+        let (lines, _region) = build_projected_lines(&items, 612.0, 792.0, &[], &[]);
         // Left col's 5 lines come first (path [0, ...]), then right col's 5
         // (path [1, ...]).
         assert_eq!(lines.len(), 10);
@@ -5159,7 +5362,7 @@ mod tests {
             items.push(item_at("left side text", 50.0, y, 200.0, 10.0));
             items.push(item_at("right side text", 350.0, y, 200.0, 10.0));
         }
-        let (lines, _region) = build_projected_lines(&items, 612.0, 792.0, &[]);
+        let (lines, _region) = build_projected_lines(&items, 612.0, 792.0, &[], &[]);
         // First line (in pre-order) must be the title.
         let first = lines.first().expect("at least one line");
         assert!(

--- a/crates/liteparse/src/projection.rs
+++ b/crates/liteparse/src/projection.rs
@@ -4651,11 +4651,6 @@ pub(crate) fn build_projected_lines(
         let mut current: Vec<usize> = Vec::new();
         let mut current_y: f32 = 0.0;
         let mut current_h: f32 = 0.0;
-        // Ruled-table ownership of `current`, tracked incrementally. A band is
-        // split as soon as an owned item meets a differently-owned one, so at
-        // most one `Some` region is ever present. `current_unowned` records
-        // whether a page-spanning item joined; that makes the whole line
-        // page-spanning rather than table-owned.
         let mut current_region: Option<usize> = None;
         let mut current_unowned = false;
         // PDFium occasionally reports anomalously large item heights (e.g.
@@ -4832,13 +4827,7 @@ fn reorder_independent_table_lines(lines: &mut [TableOwnedLine], rects: &[Rect])
     }
 }
 
-/// Sort one leaf's table-owned lines into whole-table order. Only the span
-/// between the leaf's first and last table line moves, and only when every
-/// line in that span is table-owned: a page-spanning line interleaved between
-/// table rows belongs to no grid and so has no rank to sort by. Sorting around
-/// it would strand it mid-table, splitting the table it lands in — worse than
-/// the interleaved rows this reordering exists to fix. Such a page is left in
-/// projection order instead.
+/// Sort one leaf's table-owned lines into whole-table order.
 fn reorder_leaf_table_lines(lines: &mut [TableOwnedLine], region_ranks: &[usize]) {
     let Some(first) = lines.iter().position(|owned| owned.region.is_some()) else {
         return;

--- a/crates/liteparse/src/projection.rs
+++ b/crates/liteparse/src/projection.rs
@@ -4621,6 +4621,19 @@ pub(crate) fn build_projected_lines(
         .cloned()
         .collect();
 
+    // Ruled-table ownership per item, resolved once up front. The y-banding
+    // loop below consults it for every item, and rescanning `table_rects`
+    // there would make line construction quadratic in the size of a y-band.
+    let item_regions: Vec<Option<usize>> = if table_rects.is_empty() {
+        Vec::new()
+    } else {
+        items
+            .iter()
+            .map(|item| table_region_for_item(table_rects, item))
+            .collect()
+    };
+    let region_of = |index: usize| item_regions.get(index).copied().flatten();
+
     let mut out: Vec<TableOwnedLine> = Vec::new();
     for (path, indices) in leaves {
         // Sort within the leaf by y, tie-break by x. `build_one_line` re-sorts
@@ -4638,6 +4651,13 @@ pub(crate) fn build_projected_lines(
         let mut current: Vec<usize> = Vec::new();
         let mut current_y: f32 = 0.0;
         let mut current_h: f32 = 0.0;
+        // Ruled-table ownership of `current`, tracked incrementally. A band is
+        // split as soon as an owned item meets a differently-owned one, so at
+        // most one `Some` region is ever present. `current_unowned` records
+        // whether a page-spanning item joined; that makes the whole line
+        // page-spanning rather than table-owned.
+        let mut current_region: Option<usize> = None;
+        let mut current_unowned = false;
         // PDFium occasionally reports anomalously large item heights (e.g.
         // 56pt for a single-word run whose real glyph height is ~13pt) when
         // the font's bounding box / line-height is baked into the text-matrix
@@ -4654,6 +4674,8 @@ pub(crate) fn build_projected_lines(
                 current.push(idx);
                 current_y = y;
                 current_h = h;
+                current_region = region_of(idx);
+                current_unowned = current_region.is_none();
                 continue;
             }
             // Use the SMALLER of the two heights for the y-band tolerance —
@@ -4674,32 +4696,41 @@ pub(crate) fn build_projected_lines(
             let height_mismatch = raw_h > Y_BAND_HEIGHT_CAP && raw_h > current_h * 2.0;
             let tol_factor = if height_mismatch { 0.3 } else { 0.5 };
             let same = (y - current_y).abs() < current_h.min(h) * tol_factor;
-            let item_region = table_region_for_item(table_rects, &items[idx]);
-            let current_region = table_region_for_group(table_rects, items, &current);
-            let crosses_independent_tables = item_region.is_some_and(|next| {
-                current.iter().any(|&current_index| {
-                    table_region_for_item(table_rects, &items[current_index])
-                        .is_some_and(|current| current != next)
-                })
-            });
+            let item_region = region_of(idx);
+            let crosses_independent_tables = item_region
+                .is_some_and(|next| current_region.is_some_and(|current| current != next));
             if same && !crosses_independent_tables {
                 current.push(idx);
                 current_y = current_y.min(y);
                 current_h = current_h.max(h);
+                match item_region {
+                    Some(region) => current_region = Some(region),
+                    None => current_unowned = true,
+                }
             } else {
                 out.push(TableOwnedLine {
                     line: build_one_line(items, &current, path.clone(), &heading_excl_figures),
-                    region: current_region,
+                    region: if current_unowned {
+                        None
+                    } else {
+                        current_region
+                    },
                 });
                 current = vec![idx];
                 current_y = y;
                 current_h = h;
+                current_region = item_region;
+                current_unowned = item_region.is_none();
             }
         }
         if !current.is_empty() {
             out.push(TableOwnedLine {
                 line: build_one_line(items, &current, path.clone(), &heading_excl_figures),
-                region: table_region_for_group(table_rects, items, &current),
+                region: if current_unowned {
+                    None
+                } else {
+                    current_region
+                },
             });
         }
     }
@@ -4740,7 +4771,6 @@ pub(crate) fn build_projected_lines(
     (out.into_iter().map(|owned| owned.line).collect(), region)
 }
 
-#[derive(Clone)]
 struct TableOwnedLine {
     line: ProjectedLine,
     region: Option<usize>,
@@ -4775,21 +4805,9 @@ fn table_region_for_item(rects: &[Rect], item: &ProjectedTextItem) -> Option<usi
 const TABLE_LABEL_GAP_PT: f32 = 12.0;
 const TABLE_LABEL_OVERLAP_PT: f32 = 2.0;
 
-fn table_region_for_group(
-    rects: &[Rect],
-    items: &[ProjectedTextItem],
-    indices: &[usize],
-) -> Option<usize> {
-    let mut regions = indices
-        .iter()
-        .map(|&index| table_region_for_item(rects, &items[index]));
-    let first = regions.next()??;
-    regions.all(|region| region == Some(first)).then_some(first)
-}
-
 /// Same-y rows from side-by-side grids naturally alternate left/right. Group
 /// lines by their owning grid so the table detector sees one complete table
-/// at a time. Non-table lines keep their original slots and relative order.
+/// at a time.
 fn reorder_independent_table_lines(lines: &mut [TableOwnedLine], rects: &[Rect]) {
     if rects.len() < 2 {
         return;
@@ -4798,26 +4816,52 @@ fn reorder_independent_table_lines(lines: &mut [TableOwnedLine], rects: &[Rect])
     let Some(region_ranks) = table_region_ranks(rects) else {
         return;
     };
-    let positions: Vec<usize> = lines
-        .iter()
-        .enumerate()
-        .filter_map(|(index, owned)| owned.region.map(|_| index))
-        .collect();
-    let mut grouped: Vec<TableOwnedLine> = positions
-        .iter()
-        .map(|&index| lines[index].clone())
-        .collect();
 
-    grouped.sort_by(|left, right| {
-        region_ranks[left.region.unwrap()]
-            .cmp(&region_ranks[right.region.unwrap()])
+    // Reorder one xy-cut leaf at a time. `markdown_layout` recovers regions by
+    // scanning for maximal runs of equal `region_path` (`classify.rs`), so
+    // carrying a line across a leaf boundary would shatter that leaf into
+    // phantom regions and misalign the per-region table runs keyed off it.
+    let mut start = 0;
+    while start < lines.len() {
+        let mut end = start + 1;
+        while end < lines.len() && lines[end].line.region_path == lines[start].line.region_path {
+            end += 1;
+        }
+        reorder_leaf_table_lines(&mut lines[start..end], &region_ranks);
+        start = end;
+    }
+}
+
+/// Sort one leaf's table-owned lines into whole-table order. Only the span
+/// between the leaf's first and last table line moves, and only when every
+/// line in that span is table-owned: a page-spanning line interleaved between
+/// table rows belongs to no grid and so has no rank to sort by. Sorting around
+/// it would strand it mid-table, splitting the table it lands in — worse than
+/// the interleaved rows this reordering exists to fix. Such a page is left in
+/// projection order instead.
+fn reorder_leaf_table_lines(lines: &mut [TableOwnedLine], region_ranks: &[usize]) {
+    let Some(first) = lines.iter().position(|owned| owned.region.is_some()) else {
+        return;
+    };
+    let last = lines
+        .iter()
+        .rposition(|owned| owned.region.is_some())
+        .unwrap_or(first);
+
+    let span = &mut lines[first..=last];
+    if span.iter().any(|owned| owned.region.is_none()) {
+        return;
+    }
+
+    span.sort_by(|left, right| {
+        let (Some(left_region), Some(right_region)) = (left.region, right.region) else {
+            return std::cmp::Ordering::Equal;
+        };
+        region_ranks[left_region]
+            .cmp(&region_ranks[right_region])
             .then(left.line.bbox.y.total_cmp(&right.line.bbox.y))
             .then(left.line.bbox.x.total_cmp(&right.line.bbox.x))
     });
-
-    for (position, owned) in positions.into_iter().zip(grouped) {
-        lines[position] = owned;
-    }
 }
 
 /// Produce a stable page-reading rank for every table rectangle. Rectangles

--- a/crates/liteparse/tests/side_by_side_ruled_tables.rs
+++ b/crates/liteparse/tests/side_by_side_ruled_tables.rs
@@ -331,3 +331,63 @@ fn spanning_heading_above_side_by_side_tables_remains_spanning() {
 
     assert_eq!(markdown, expected);
 }
+
+#[test]
+fn spanning_line_between_rows_does_not_split_side_by_side_tables() {
+    // A page-spanning note sitting vertically between the data rows of two
+    // side-by-side grids belongs to neither one, so it has no grid rank to
+    // sort by. Reordering the tables around it must not strand it mid-table:
+    // every row of both grids has to survive as table content.
+    let mut text_items = vec![text_item(
+        "Shared service matrix",
+        250.0,
+        80.0,
+        290.0,
+        18.0,
+        true,
+    )];
+    for row in 0..6 {
+        let y = 124.0 + row as f32 * 24.0;
+        for ((text, x), width) in [format!("L{row}a"), format!("L{row}b"), format!("L{row}c")]
+            .into_iter()
+            .zip([56.0, 136.0, 216.0])
+            .zip([60.0, 65.0, 65.0])
+        {
+            text_items.push(text_item(&text, x, y, width, 10.0, row == 0));
+        }
+        for ((text, x), width) in [format!("R{row}a"), format!("R{row}b"), format!("R{row}c")]
+            .into_iter()
+            .zip([426.0, 506.0, 586.0])
+            .zip([60.0, 65.0, 65.0])
+        {
+            text_items.push(text_item(&text, x, y + 0.8, width, 10.0, row == 0));
+        }
+    }
+    text_items.push(text_item(
+        "Note: spanning remark placed after the second data row of both tables.",
+        56.0,
+        184.0,
+        604.0,
+        10.0,
+        false,
+    ));
+
+    let ys = [116.0, 140.0, 164.0, 188.0, 212.0, 236.0, 260.0];
+    let mut graphics = ruled_grid(&[50.0, 130.0, 210.0, 290.0], &ys);
+    graphics.extend(ruled_grid(
+        &[420.0, 500.0, 580.0, 660.0],
+        &ys.map(|y| y + 0.8),
+    ));
+
+    let markdown = markdown_for(text_items, graphics);
+    for row in 0..6 {
+        for label in [format!("L{row}a"), format!("R{row}a")] {
+            assert!(
+                markdown
+                    .lines()
+                    .any(|line| line.starts_with('|') && line.contains(&label)),
+                "{label} is not table content:\n{markdown}"
+            );
+        }
+    }
+}

--- a/crates/liteparse/tests/side_by_side_ruled_tables.rs
+++ b/crates/liteparse/tests/side_by_side_ruled_tables.rs
@@ -1,0 +1,333 @@
+use liteparse::config::ImageMode;
+use liteparse::output::markdown::format_markdown;
+use liteparse::projection::project_pages_to_grid;
+use liteparse::types::{GraphicPrimitive, Page, TextItem};
+
+fn text_item(text: &str, x: f32, y: f32, width: f32, size: f32, bold: bool) -> TextItem {
+    TextItem {
+        text: text.to_string(),
+        x,
+        y,
+        width,
+        height: size * 1.116,
+        font_name: Some(if bold {
+            "LiberationSans-Bold".to_string()
+        } else {
+            "LiberationSans".to_string()
+        }),
+        font_size: Some(size),
+        font_height: Some(size),
+        ..TextItem::default()
+    }
+}
+
+fn stroke(x1: f32, y1: f32, x2: f32, y2: f32) -> GraphicPrimitive {
+    GraphicPrimitive::Stroke {
+        x1,
+        y1,
+        x2,
+        y2,
+        color: Some("ff000000".to_string()),
+        width: 0.5,
+    }
+}
+
+fn ruled_grid(xs: &[f32], ys: &[f32]) -> Vec<GraphicPrimitive> {
+    let mut graphics = Vec::new();
+    for &y in ys {
+        graphics.push(stroke(xs[0], y, *xs.last().unwrap(), y));
+    }
+    for &x in xs {
+        graphics.push(stroke(x, ys[0], x, *ys.last().unwrap()));
+    }
+    graphics
+}
+
+fn markdown_for(text_items: Vec<TextItem>, graphics: Vec<GraphicPrimitive>) -> String {
+    let pages = project_pages_to_grid(vec![Page {
+        page_number: 1,
+        page_width: 792.0,
+        page_height: 612.0,
+        content_bounds: None,
+        text_items,
+        graphics,
+        vector_graphics: None,
+        struct_nodes: Vec::new(),
+        image_refs: Vec::new(),
+        annotations: None,
+        form_fields: None,
+        structure_tree: None,
+    }]);
+    format_markdown(&pages, &[], ImageMode::Off)
+}
+
+#[test]
+fn side_by_side_ruled_tables_keep_their_own_headings_in_markdown() {
+    let mut text_items = vec![
+        text_item("Public Release Reference", 274.4, 50.4, 243.26, 20.0, true),
+        text_item(
+            "A public, synthetic document for evaluating side-by-side table extraction",
+            237.45,
+            78.7,
+            317.13,
+            10.0,
+            false,
+        ),
+        text_item(
+            "This document contains generic release-planning examples only.",
+            50.5,
+            105.35,
+            350.0,
+            10.0,
+            false,
+        ),
+        text_item("Release channels", 50.5, 129.99, 100.57, 12.0, true),
+        text_item("Support windows", 406.9, 130.99, 99.88, 12.0, true),
+    ];
+
+    for (y, values) in [
+        (154.655, ["Channel", "Status", "Owner"]),
+        (174.705, ["Stable", "Ready", "Team A"]),
+        (194.755, ["Beta", "Testing", "Team B"]),
+        (214.805, ["Nightly", "Active", "Team C"]),
+    ] {
+        for ((text, x), width) in values
+            .into_iter()
+            .zip([50.5, 118.5, 180.5])
+            .zip([35.46, 29.5, 32.0])
+        {
+            text_items.push(text_item(text, x, y, width, 9.0, y == 154.655));
+        }
+    }
+
+    for (y, values) in [
+        (155.655, ["Region", "Window", "Contact"]),
+        (175.705, ["East", "Morning", "Desk 1"]),
+        (195.755, ["West", "Afternoon", "Desk 2"]),
+        (215.805, ["Central", "Evening", "Desk 3"]),
+    ] {
+        for ((text, x), width) in values
+            .into_iter()
+            .zip([406.9, 474.9, 536.9])
+            .zip([35.0, 39.0, 34.0])
+        {
+            text_items.push(text_item(text, x, y, width, 9.0, y == 155.655));
+        }
+    }
+
+    let mut graphics = ruled_grid(
+        &[44.0, 112.0, 174.0, 236.0],
+        &[148.0, 168.0, 188.0, 208.0, 228.0],
+    );
+    graphics.extend(ruled_grid(
+        &[400.0, 468.0, 530.0, 594.0],
+        &[149.0, 169.0, 189.0, 209.0, 229.0],
+    ));
+
+    let markdown = markdown_for(text_items, graphics);
+    let expected = "# Public Release Reference\n\n\
+A public, synthetic document for evaluating side-by-side table extraction\n\n\
+This document contains generic release-planning examples only.\n\n\
+## Release channels\n\n\
+| Channel | Status | Owner |\n\
+|---|---|---|\n\
+| Stable | Ready | Team A |\n\
+| Beta | Testing | Team B |\n\
+| Nightly | Active | Team C |\n\n\
+## Support windows\n\n\
+| Region | Window | Contact |\n\
+|---|---|---|\n\
+| East | Morning | Desk 1 |\n\
+| West | Afternoon | Desk 2 |\n\
+| Central | Evening | Desk 3 |";
+
+    assert_eq!(markdown, expected);
+}
+
+#[test]
+fn one_wide_ruled_table_remains_one_table() {
+    let mut text_items = vec![text_item(
+        "Quarterly schedule",
+        50.0,
+        80.0,
+        130.0,
+        14.0,
+        true,
+    )];
+    for (y, values) in [
+        (124.0, ["Quarter", "Status", "Owner"]),
+        (148.0, ["Q1", "Ready", "Team A"]),
+        (172.0, ["Q2", "Testing", "Team B"]),
+    ] {
+        for ((text, x), width) in values
+            .into_iter()
+            .zip([56.0, 260.0, 464.0])
+            .zip([60.0, 70.0, 70.0])
+        {
+            text_items.push(text_item(text, x, y, width, 10.0, y == 124.0));
+        }
+    }
+    let graphics = ruled_grid(&[50.0, 250.0, 454.0, 660.0], &[116.0, 140.0, 164.0, 188.0]);
+
+    let markdown = markdown_for(text_items, graphics);
+    let expected = "# Quarterly schedule\n\n\
+---\n\n\
+| Quarter | Status | Owner |\n\
+|---|---|---|\n\
+| Q1 | Ready | Team A |\n\
+| Q2 | Testing | Team B |";
+
+    assert_eq!(markdown, expected);
+}
+
+#[test]
+fn vertically_stacked_ruled_tables_keep_top_to_bottom_order() {
+    let mut text_items = vec![
+        text_item("Operations handbook", 250.0, 35.0, 210.0, 20.0, true),
+        text_item("Release status", 56.0, 80.0, 100.0, 14.0, true),
+        text_item("Support status", 56.0, 240.0, 105.0, 14.0, true),
+    ];
+    for (y, values) in [
+        (108.0, ["Channel", "Status"]),
+        (132.0, ["Stable", "Ready"]),
+        (156.0, ["Beta", "Testing"]),
+        (268.0, ["Region", "Window"]),
+        (292.0, ["East", "Morning"]),
+        (316.0, ["West", "Afternoon"]),
+    ] {
+        for ((text, x), width) in values.into_iter().zip([56.0, 206.0]).zip([80.0, 90.0]) {
+            text_items.push(text_item(text, x, y, width, 10.0, y == 108.0 || y == 268.0));
+        }
+    }
+
+    let mut graphics = ruled_grid(&[50.0, 200.0, 350.0], &[100.0, 124.0, 148.0, 172.0]);
+    graphics.extend(ruled_grid(
+        &[50.0, 200.0, 350.0],
+        &[260.0, 284.0, 308.0, 332.0],
+    ));
+
+    let markdown = markdown_for(text_items, graphics);
+    let expected = "# Operations handbook\n\n\
+## Release status\n\n\
+| Channel | Status |\n\
+|---|---|\n\
+| Stable | Ready |\n\
+| Beta | Testing |\n\n\
+---\n\n\
+### Support status\n\n\
+| Region | Window |\n\
+|---|---|\n\
+| East | Morning |\n\
+| West | Afternoon |";
+
+    assert_eq!(markdown, expected);
+}
+
+#[test]
+fn ordinary_two_column_prose_is_not_rendered_as_a_table() {
+    let mut text_items = vec![text_item(
+        "Two-column article",
+        270.0,
+        40.0,
+        180.0,
+        20.0,
+        true,
+    )];
+    for row in 0..5 {
+        let y = 110.0 + row as f32 * 18.0;
+        text_items.push(text_item(
+            &format!("Left paragraph sentence number {} continues.", row + 1),
+            50.0,
+            y,
+            270.0,
+            10.0,
+            false,
+        ));
+        text_items.push(text_item(
+            &format!("Right paragraph sentence number {} continues.", row + 1),
+            430.0,
+            y + 0.8,
+            270.0,
+            10.0,
+            false,
+        ));
+    }
+
+    let markdown = markdown_for(text_items, Vec::new());
+
+    assert!(!markdown.contains("|---"), "unexpected table:\n{markdown}");
+}
+
+#[test]
+fn spanning_heading_above_side_by_side_tables_remains_spanning() {
+    let mut text_items = vec![text_item(
+        "Shared service matrix",
+        250.0,
+        80.0,
+        290.0,
+        18.0,
+        true,
+    )];
+    for (y, left, right) in [
+        (
+            124.0,
+            ["Channel", "Status", "Owner"],
+            ["Region", "Window", "Contact"],
+        ),
+        (
+            148.0,
+            ["Stable", "Ready", "Team A"],
+            ["East", "Morning", "Desk 1"],
+        ),
+        (
+            172.0,
+            ["Beta", "Testing", "Team B"],
+            ["West", "Afternoon", "Desk 2"],
+        ),
+        (
+            196.0,
+            ["Nightly", "Active", "Team C"],
+            ["Central", "Evening", "Desk 3"],
+        ),
+    ] {
+        for ((text, x), width) in left
+            .into_iter()
+            .zip([56.0, 136.0, 216.0])
+            .zip([60.0, 65.0, 65.0])
+        {
+            text_items.push(text_item(text, x, y, width, 10.0, y == 124.0));
+        }
+        for ((text, x), width) in right
+            .into_iter()
+            .zip([426.0, 506.0, 586.0])
+            .zip([60.0, 65.0, 65.0])
+        {
+            text_items.push(text_item(text, x, y + 0.8, width, 10.0, y == 124.0));
+        }
+    }
+
+    let mut graphics = ruled_grid(
+        &[50.0, 130.0, 210.0, 290.0],
+        &[116.0, 140.0, 164.0, 188.0, 212.0],
+    );
+    graphics.extend(ruled_grid(
+        &[420.0, 500.0, 580.0, 660.0],
+        &[116.8, 140.8, 164.8, 188.8, 212.8],
+    ));
+
+    let markdown = markdown_for(text_items, graphics);
+    let expected = "# Shared service matrix\n\n\
+---\n\n\
+| Channel | Status | Owner |\n\
+|---|---|---|\n\
+| Stable | Ready | Team A |\n\
+| Beta | Testing | Team B |\n\
+| Nightly | Active | Team C |\n\n\
+| Region | Window | Contact |\n\
+|---|---|---|\n\
+| East | Morning | Desk 1 |\n\
+| West | Afternoon | Desk 2 |\n\
+| Central | Evening | Desk 3 |";
+
+    assert_eq!(markdown, expected);
+}


### PR DESCRIPTION
## Summary

This PR now fixes the published side-by-side ruled-table reproduction through
the public Markdown output path:

- keep horizontal rule segments separated across a whitespace gutter;
- keep same-y text and nearby table labels associated with their own ruled
  table rectangle;
- preserve left-to-right order within a side-by-side table band and
  top-to-bottom order across bands;
- add public-output regression coverage and adjacent non-regressions.

Fixes #414.

## Root cause

The visible failure had two stages:

```text
two independent side-by-side grids
-> horizontal segments merged across the gutter
-> one geometry component
-> one merged Markdown table
```

After the geometry component was fixed, a downstream stage was still wrong:

```text
two geometry components
-> same-y text from both tables grouped into shared projected lines
-> each ruled candidate sees adjacent-table overhang
-> ruled candidates rejected
-> fallback emits one merged table
```

The earlier version of this PR fixed only the first stage, which is why it did
not fix the document linked in the issue comment.

## Fix

The two commits keep the responsibilities explicit:

1. `9d740a4` changes horizontal segment clustering so collinear segments merge
   only when their x ranges overlap or nearly touch. The row-gap / stacked-grid
   behavior from #394 remains unchanged.
2. `26b79a6` passes detected ruled-table rectangles into projected-line
   construction. Same-y items owned by different table rectangles cannot
   become one projected line, and table-owned lines are ordered by independent
   table bands before table consumption.

Nearby labels are associated only when at least half of the label width belongs
to exactly one table rectangle and the vertical gap is small. A page-spanning
heading that overlaps multiple tables remains unowned. The patch does not
globally change y tolerance, table-confidence thresholds, or fallback logic.

## Public reproduction document

- [Preview / download](https://github.com/Chengyunlai/liteparse/blob/codex/repro-issue-414-side-by-side-tables/reproductions/issue-414/side-by-side-ruled-tables.pdf)
- [Raw PDF](https://raw.githubusercontent.com/Chengyunlai/liteparse/codex/repro-issue-414-side-by-side-tables/reproductions/issue-414/side-by-side-ruled-tables.pdf)
- SHA-256: `e9b56e7a3f1d990d9e1f1b63b46e5d89b8ce1afaa85c9e17a09d83d1f5563b8d`

This is a self-authored, synthetic one-page Word-to-PDF document containing no
customer, personal, credential, internal-project, or business-specific data.

The same command was used for all three versions:

```bash
lit parse /input.pdf \
  --no-ocr \
  --format markdown \
  --output /results/output.md \
  --quiet
```

## Before / after

| Version | Geometry | Public Markdown |
|---|---|---|
| `main@2fd644a` | one merged component | one 7-column table with an empty gutter column; headings merged |
| previous PR head `9d740a4` | two components | one 6-column fallback table; headings become table cells |
| current PR head `26b79a6` | two components | two independent headings and two independent 3-column tables |

Current output:

```markdown
## Release channels

| Channel | Status | Owner |
|---|---|---|
| Stable | Ready | Team A |
| Beta | Testing | Team B |
| Nightly | Active | Team C |

## Support windows

| Region | Window | Contact |
|---|---|---|
| East | Morning | Desk 1 |
| West | Afternoon | Desk 2 |
| Central | Evening | Desk 3 |
```

## Regression coverage

The public Markdown seam tests cover:

- the published side-by-side shape with independent nearby headings;
- one wide ruled table remaining one table;
- vertically stacked ruled tables preserving top-to-bottom order;
- ordinary two-column prose not becoming a table;
- one page-spanning heading above two tables remaining page-spanning.

Two focused ordering tests also cover:

- multiple side-by-side table bands ordered top-to-bottom;
- three-table overlap that must not form a transitive, incorrectly reordered
  band.

## Validation

- `cargo fmt --all -- --check`
- public-output integration tests: 5 passed
- table-band ordering tests: 2 passed
- `cargo clippy -p liteparse --all-targets`: passed with existing repository warnings
- projection regression tests: 18 passed
- core library suite in the validation container: 333 passed; the only failure
  was the existing LibreOffice-dependent `.doc` lifetime test because
  LibreOffice is not installed in that container
- end-to-end parse of the published PDF: exact expected two-heading,
  two-table output above

## Follow-up boundary

A smaller adjacent PDF with two same-y headings above two 3-row x 2-column
tables exposes a separate Markdown heading-continuation heuristic after the
tables are already correctly separated. It is documented with its own public
fixture and negative-test requirements in #418. This PR does not claim to fix
that distinct heading-classification case.
