### PR TITLE
docs: make the agent skill guide canonical and link it from the index

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ npx skills add run-llama/llamaparse-agent-skills --skill liteparse
 
 Or copy-pasting the [`SKILL.md`](https://github.com/run-llama/llamaparse-agent-skills/blob/main/skills/liteparse/SKILL.md) file to your own skills setup.
 
+See the [Agent Skill guide](https://developers.llamaindex.ai/liteparse/guides/agent-skill/?utm_source=github&utm_medium=liteparse) for requirements and usage patterns.
+
 ## CLI Usage
 
 The CLI is the same across all installations (`npm`, `pip`, `cargo install`).

--- a/docs/src/content/docs/liteparse/guides/agent-skill.md
+++ b/docs/src/content/docs/liteparse/guides/agent-skill.md
@@ -32,10 +32,9 @@ inside Claude Code or Codex.
 | --- | --- |
 | Node 18+ and `npm i -g @llamaindex/liteparse` | The `lit` CLI the skill drives — verify with `lit --version` |
 | [LibreOffice](https://www.libreoffice.org/) | Parsing Office files (DOCX, XLSX, PPTX) |
-| [ImageMagick](https://imagemagick.org/) | Parsing image files |
 | [`uv`](https://docs.astral.sh/uv/) | The bundled ranked-search helper |
 
-No API key is required — everything runs on your machine.
+No API key is required since everything runs on your machine.
 
 ## What the skill teaches
 

--- a/docs/src/content/docs/liteparse/guides/agent-skill.md
+++ b/docs/src/content/docs/liteparse/guides/agent-skill.md
@@ -5,19 +5,51 @@ sidebar:
   order: 11
 ---
 
-LiteParse can be installed as a **coding agent skill** using Vercel's [skills](https://github.com/vercel-labs/skills) utility. This gives your coding agent the ability to process documents, generate screenshots, and parse text from files, all locally.
+LiteParse ships as a **coding agent skill** — a self-contained capability that Claude Code, Cursor,
+Codex, and other compatible agents load on demand. Installing it gives your agent the ability to
+parse documents, extract text and bounding boxes, and generate screenshots, all locally and with no
+API key.
 
 ## Installation
 
-Add the LiteParse skill to your project:
+Add the LiteParse skill to your project with the [`skills`](https://github.com/vercel-labs/skills)
+CLI:
 
 ```bash
 npx skills add run-llama/llamaparse-agent-skills --skill liteparse
 ```
 
-This downloads a skill file that compatible coding agents (Claude Code, Cursor, etc.) will automatically pick up.
+This downloads a skill file that compatible coding agents pick up automatically.
 
-Once configured, your agent will be able to call the LiteParse CLI commands directly from its code execution environment. This means you can have your agent parse PDFs, pull out the text, and generate screenshots on the fly as part of its reasoning process.
+You can also copy [`SKILL.md`](https://github.com/run-llama/llamaparse-agent-skills/blob/main/skills/liteparse/SKILL.md)
+into your own skills setup by hand, or install the `liteparse` plugin from the
+[agent plugins marketplace](https://github.com/run-llama/llamaparse-agent-plugins) to enable it from
+inside Claude Code or Codex.
+
+### Requirements
+
+| Requirement | Needed for |
+| --- | --- |
+| Node 18+ and `npm i -g @llamaindex/liteparse` | The `lit` CLI the skill drives — verify with `lit --version` |
+| [LibreOffice](https://www.libreoffice.org/) | Parsing Office files (DOCX, XLSX, PPTX) |
+| [ImageMagick](https://imagemagick.org/) | Parsing image files |
+| [`uv`](https://docs.astral.sh/uv/) | The bundled ranked-search helper |
+
+No API key is required — everything runs on your machine.
+
+## What the skill teaches
+
+The skill is more than an install: it encodes the extraction patterns that keep an agent's context
+small and its runs cheap. Without it, agents commonly re-parse the same document on every search and
+dump entire pages into the conversation.
+
+- **Parse once to a file, then search that file.** Each `lit parse` re-extracts the whole document,
+  so the skill has the agent parse to a temp file and run all subsequent searches against it.
+- **Minimize round-trips.** Fetch a match and its surrounding context in a single command, and batch
+  independent lookups together rather than spending a turn per search term.
+- **Bound every output.** Results are capped so a single lookup can't flood the context window.
+- **Escalate to ranked search** when keyword matching stalls, instead of firing off keyword variants
+  one turn at a time.
 
 ## Example prompts
 
@@ -28,3 +60,9 @@ Once the skill is installed, you can ask your coding agent things like:
 - "Screenshot pages 1-5 of this PDF at 300 DPI"
 - "Parse this scanned document using the PaddleOCR server on localhost:8828"
 - "Get the bounding boxes for all text on page 3"
+
+## Related
+
+LiteParse is one of several ways to give an agent document-processing capabilities. For cloud parsing
+of complex documents, MCP servers, and workflow nodes, see
+[Using LlamaIndex with AI Agents](/for-agents/).

--- a/docs/src/content/docs/liteparse/index.md
+++ b/docs/src/content/docs/liteparse/index.md
@@ -31,5 +31,6 @@ LiteParse is designed specifically for use cases that require fast, accurate tex
 - [Document complexity](/liteparse/guides/complexity/): Detect scanned, multi-column, and table-heavy pages up front.
 - [Library usage](/liteparse/guides/library-usage/): Use LiteParse from TypeScript or Python code.
 - [Browser usage (WASM)](/liteparse/guides/browser-usage/): Run LiteParse in the browser with zero server dependencies.
+- [Agent skill](/liteparse/guides/agent-skill/): Give Claude Code, Cursor, or Codex the ability to parse documents locally.
 - [CLI reference](/liteparse/cli-reference/): Complete command and option reference.
 - [API reference](/liteparse/api/): Detailed API documentation (rust) for all public types and functions. The same types apply across all language bindings.


### PR DESCRIPTION
Part of the agent-tooling discoverability work (see run-llama/developers#145, run-llama/platform#23362).

The `liteparse` skill was documented in **two repos** — here and in the LlamaParse platform docs — with divergent prose, the same install command, and no link between them. Meanwhile this repo's own landing page never mentioned the skill at all: the only path in was one link from Getting Started.

This makes the LiteParse guide the canonical home, per the agreed split.

## Changes

**`guides/agent-skill.md`** — expanded from ~30 lines:
- Requirements table (Node 18+ / `lit --version`, LibreOffice for Office files, ImageMagick for images, `uv` for the ranked-search helper) — these were previously only in `SKILL.md` frontmatter
- The manual `SKILL.md` copy path and the `liteparse` agent plugin, neither of which was documented here
- A "What the skill teaches" section summarizing the extraction patterns the skill encodes (parse once to a file, minimize round-trips, bound output, escalate to ranked search) — the actual value of the skill, previously invisible
- A `Related` link out to the agent tooling hub

**`index.md`** — added the guide to the "Get started" list, between Browser usage and CLI reference.

**`README.md`** — linked the docs guide from the Agent Skill section.

## Verification

Rendered against a local build of the docs site: headings, the requirements table, and all links resolve; the index page links the guide from both the sidebar and the Get started list.

## Note

The `Related` section links `/for-agents/`, which is already live. It deliberately does **not** link the LlamaParse skills page directly — that page moves to `/llamaparse/for-agents/skills/` in run-llama/platform#23362, so linking the hub avoids a merge-order dependency. The hub routes onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vZtD6UvLVCEdWLRGd7Q32