### PR TITLE
feat: expose source document page count

### DIFF
--- a/crates/liteparse-napi/src/types.rs
+++ b/crates/liteparse-napi/src/types.rs
@@ -881,6 +881,8 @@ impl JsParsedPage {
 #[napi(object)]
 #[derive(Clone)]
 pub struct JsParseResult {
+    /// Total source-document pages before target/max-page filtering.
+    pub total_pages: u32,
     pub pages: Vec<JsParsedPage>,
     pub text: String,
     pub images: Vec<JsExtractedImage>,
@@ -1125,6 +1127,7 @@ impl JsPageComplexityStats {
 impl JsParseResult {
     pub fn from_rust(result: &ParseResult, config: &LiteParseConfig) -> Self {
         Self {
+            total_pages: result.total_pages,
             pages: result
                 .pages
                 .iter()

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -596,6 +596,9 @@ impl PyParsedPage {
 #[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 struct PyParseResult {
+    /// Total source-document pages before target/max-page filtering.
+    #[pyo3(get)]
+    total_pages: u32,
     #[pyo3(get)]
     pages: Vec<PyParsedPage>,
     #[pyo3(get)]
@@ -718,6 +721,7 @@ impl PyParseResult {
 impl PyParseResult {
     fn from_rust(result: liteparse::parser::ParseResult, extract_text_metadata: bool) -> Self {
         Self {
+            total_pages: result.total_pages,
             pages: result
                 .pages
                 .into_iter()

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -596,7 +596,6 @@ impl PyParsedPage {
 #[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 struct PyParseResult {
-    /// Total source-document pages before target/max-page filtering.
     #[pyo3(get)]
     total_pages: u32,
     #[pyo3(get)]

--- a/crates/liteparse-wasm/src/lib.rs
+++ b/crates/liteparse-wasm/src/lib.rs
@@ -614,6 +614,8 @@ impl StructureTreeElement {
 #[tsify(into_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct ParseResult {
+    /// Total source-document pages before target/max-page filtering.
+    pub total_pages: u32,
     pub pages: Vec<ParsedPage>,
     pub text: String,
     pub images: Vec<ExtractedImage>,
@@ -1048,6 +1050,7 @@ impl LiteParse {
             .collect();
 
         Ok(ParseResult {
+            total_pages: result.total_pages,
             pages,
             text: result.text.clone(),
             images,

--- a/crates/liteparse/src/output/json.rs
+++ b/crates/liteparse/src/output/json.rs
@@ -66,6 +66,7 @@ pub(crate) struct JsonPage {
 
 #[derive(Debug, Serialize)]
 pub(crate) struct ParseResultJson {
+    pub total_pages: u32,
     pub pages: Vec<JsonPage>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub images: Vec<JsonImage>,
@@ -104,6 +105,7 @@ pub(crate) struct JsonImage {
 /// Build structured JSON output from parsed pages.
 pub(crate) fn build_json(pages: &[ParsedPage], extract_text_metadata: bool) -> ParseResultJson {
     ParseResultJson {
+        total_pages: pages.len().min(u32::MAX as usize) as u32,
         images: Vec::new(),
         image_error_count: 0,
         form_type: None,
@@ -168,6 +170,7 @@ pub fn format_json_result(
     extract_text_metadata: bool,
 ) -> Result<String, serde_json::Error> {
     let mut json = build_json(&result.pages, extract_text_metadata);
+    json.total_pages = result.total_pages;
     json.images = result
         .images
         .iter()
@@ -387,6 +390,7 @@ mod tests {
             bytes: std::sync::Arc::new(vec![1, 2, 3]),
         };
         let result = crate::parser::ParseResult {
+            total_pages: 3,
             pages: vec![],
             text: String::new(),
             outline: vec![],
@@ -405,6 +409,7 @@ mod tests {
         };
         let value: serde_json::Value =
             serde_json::from_str(&format_json_result(&result, false).unwrap()).unwrap();
+        assert_eq!(value["total_pages"], 3);
         assert!(value.get("creator").is_none());
         assert!(value.get("producer").is_none());
         assert!(value.get("doc_meta").is_none());

--- a/crates/liteparse/src/parser.rs
+++ b/crates/liteparse/src/parser.rs
@@ -21,6 +21,9 @@ use pdfium::Library;
 
 /// Result of parsing a document.
 pub struct ParseResult {
+    /// Total number of pages in the source document, before `target_pages` or
+    /// `max_pages` limits are applied.
+    pub total_pages: u32,
     /// Parsed pages with projected text layout.
     pub pages: Vec<ParsedPage>,
     /// Full document text, concatenated from all pages.
@@ -441,6 +444,7 @@ impl LiteParse {
         #[allow(unused_mut)] // mutated only by the native image-output writer
         let (
             pages,
+            total_pages,
             ocr_rendered,
             outline,
             mut images,
@@ -470,6 +474,7 @@ impl LiteParse {
             #[cfg(target_arch = "wasm32")]
             let document_input = &validated_input;
             let document = extract::load_document_from_input(&lib, document_input, password)?;
+            let total_pages = document.page_count().max(0) as u32;
             let form_type = self
                 .config
                 .extract_form_fields
@@ -591,6 +596,7 @@ impl LiteParse {
             // `lib` is dropped here, releasing the PDFium lock.
             (
                 pages,
+                total_pages,
                 rendered,
                 outline,
                 images,
@@ -687,6 +693,7 @@ impl LiteParse {
         }
 
         Ok(ParseResult {
+            total_pages,
             pages: parsed_pages,
             text: full_text,
             outline,
@@ -709,6 +716,7 @@ impl LiteParse {
     /// is fully synchronous. Used when an external extractor (e.g. with its
     /// own font-recovery pipeline) owns text extraction.
     pub fn parse_from_pages(&self, pages: Vec<Page>, outline: Vec<OutlineTarget>) -> ParseResult {
+        let total_pages = pages.len().min(u32::MAX as usize) as u32;
         let mut parsed_pages = projection::project_pages_to_grid(pages);
 
         let full_text = if self.config.output_format == crate::config::OutputFormat::Markdown {
@@ -732,6 +740,7 @@ impl LiteParse {
         };
 
         ParseResult {
+            total_pages,
             pages: parsed_pages,
             text: full_text,
             outline,

--- a/crates/liteparse/tests/integration_test.rs
+++ b/crates/liteparse/tests/integration_test.rs
@@ -92,6 +92,26 @@ async fn test_parse_bytes_image_integration() {
         .await
         .expect("Should be able to parse");
     assert_eq!(parsed.pages.len(), 1);
+    assert_eq!(parsed.total_pages, 1);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_total_pages_precedes_target_page_filtering() {
+    let lit = LiteParse::new(LiteParseConfig {
+        ocr_enabled: false,
+        quiet: true,
+        target_pages: Some("2".into()),
+        ..LiteParseConfig::default()
+    });
+    let parsed = lit
+        .parse("../../integration_tests_data/filled_acroform.pdf")
+        .await
+        .expect("Should be able to parse a selected page");
+
+    assert_eq!(parsed.total_pages, 3);
+    assert_eq!(parsed.pages.len(), 1);
+    assert_eq!(parsed.pages[0].page_number, 2);
 }
 
 #[tokio::test]

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -18,6 +18,7 @@ import { LiteParse } from '@llamaindex/liteparse';
 const parser = new LiteParse();
 const result = await parser.parse('document.pdf');
 console.log(result.text);
+console.log(`Source document pages: ${result.totalPages}`);
 
 // Access structured data
 for (const page of result.pages) {

--- a/packages/node/native.d.ts
+++ b/packages/node/native.d.ts
@@ -311,6 +311,8 @@ export interface JsFormField {
   selectedOptions: Array<string>
 }
 export interface JsParseResult {
+  /** Total source-document pages before target/max-page filtering. */
+  totalPages: number
   pages: Array<JsParsedPage>
   text: string
   images: Array<JsExtractedImage>

--- a/packages/node/src/lib.ts
+++ b/packages/node/src/lib.ts
@@ -347,6 +347,8 @@ export interface ExtractedImage {
 }
 
 export interface ParseResult {
+  /** Total source-document pages before `targetPages` or `maxPages` filtering. */
+  totalPages: number;
   pages: ParsedPage[];
   text: string;
   /** Populated only when `extractImages` is true. */
@@ -608,6 +610,7 @@ export class LiteParse {
       typeof input === "string" ? input : Buffer.from(input);
     const result: NativeParseResult = await this._native.parse(nativeInput);
     return {
+      totalPages: result.totalPages,
       pages: result.pages.map(toPage),
       text: result.text,
       images: (result.images ?? []).map(toImage),
@@ -636,6 +639,7 @@ export class LiteParse {
     }));
     const result = this._native.parsePages(nativePages);
     return {
+      totalPages: result.totalPages,
       pages: result.pages.map(toPage),
       text: result.text,
       images: (result.images ?? []).map(toImage),

--- a/packages/node/src/native.ts
+++ b/packages/node/src/native.ts
@@ -234,6 +234,7 @@ export interface NativeExtractedImage {
 }
 
 export interface NativeParseResult {
+  totalPages: number;
   pages: NativeParsedPage[];
   text: string;
   images: NativeExtractedImage[];

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -18,6 +18,7 @@ from liteparse import LiteParse
 parser = LiteParse()
 result = parser.parse("document.pdf")
 print(result.text)
+print(f"Source document pages: {result.total_pages}")
 
 # Access structured data
 for page in result.pages:

--- a/packages/python/liteparse/parser.py
+++ b/packages/python/liteparse/parser.py
@@ -339,6 +339,7 @@ def _convert_native_result(native_result: Any) -> ParseResult:
     return ParseResult(
         pages=pages,
         text=native_result.text,
+        total_pages=getattr(native_result, "total_pages", len(pages)),
         images=images,
         image_error_count=getattr(native_result, "image_error_count", 0),
         form_type=getattr(native_result, "form_type", None),

--- a/packages/python/liteparse/types.py
+++ b/packages/python/liteparse/types.py
@@ -248,6 +248,8 @@ class ParseResult:
     """Result of parsing a document."""
     pages: List[ParsedPage]
     text: str
+    #: Total source-document pages before target/max-page filtering.
+    total_pages: int = 0
     images: List[ExtractedImage] = field(default_factory=list)
     image_error_count: int = 0
     #: PDFium form type, present only when ``extract_form_fields=True``.


### PR DESCRIPTION
Expose the source document page count on ParseResult before target_pages or max_pages filtering. This lets consumers distinguish the complete document size from the selected pages without opening the PDF a second time.

The field is available in Rust/JSON, Node as totalPages, and Python/WASM as total_pages with language-appropriate serialization. parse_from_pages reports the supplied page count.

Tests: cargo test -p liteparse; cargo check for napi, Python, and WASM bindings; Node TypeScript build; cargo clippy.