### PR TITLE
feat: link extract_blocks output back to textItems

### DIFF
--- a/crates/liteparse-napi/src/types.rs
+++ b/crates/liteparse-napi/src/types.rs
@@ -866,6 +866,9 @@ impl JsDocumentAnnotation {
 pub struct JsLayoutCell {
     pub text: String,
     pub bbox: Option<JsAnnotationRect>,
+    /// Indices into the page's returned `textItems`, in reading order, never
+    /// repeating within one cell; empty for padding cells.
+    pub text_item_indices: Vec<u32>,
 }
 
 /// A classified block plus where it sits on the page. Flat by design — `kind`
@@ -877,6 +880,10 @@ pub struct JsLayoutBlock {
     /// One of `heading`, `paragraph`, `list_item`, `code`, `table`,
     /// `grid_fallback`, `rule`, `figure`.
     pub kind: String,
+    /// Indices into the page's returned `textItems`, sorted and deduped;
+    /// empty for text-less blocks. For a `table` block, the union of its
+    /// cells' indices.
+    pub text_item_indices: Vec<u32>,
     /// Rendered text for the text-bearing kinds (`heading`, `paragraph`,
     /// `list_item`). Table text lives in `header`/`rows`; code and grid text in
     /// `lines`.
@@ -913,6 +920,7 @@ impl JsLayoutCell {
         Self {
             text: cell.text.clone(),
             bbox: cell.bbox.as_ref().map(JsAnnotationRect::from_rust),
+            text_item_indices: cell.text_item_indices.iter().map(|&i| i as u32).collect(),
         }
     }
 }
@@ -922,6 +930,7 @@ impl JsLayoutBlock {
         let cells = |row: &Vec<LayoutCell>| row.iter().map(JsLayoutCell::from_rust).collect();
         Self {
             kind: block.kind.to_string(),
+            text_item_indices: block.text_item_indices.iter().map(|&i| i as u32).collect(),
             text: block.text.clone(),
             level: block.level,
             bold: block.bold,

--- a/crates/liteparse-napi/src/types.rs
+++ b/crates/liteparse-napi/src/types.rs
@@ -102,7 +102,9 @@ pub struct JsLiteParseConfig {
     pub ocr_hedge_delays_ms: Option<Vec<u32>>,
     /// Emit per-word sub-boxes on each text item (`TextItem.words`). Default
     /// false. Word boxes roughly double the text-item payload, so enable only
-    /// for word-level bbox attribution.
+    /// for word-level bbox attribution. With `extractBlocks` on, word geometry
+    /// is always computed internally as a table-detection input, but `words`
+    /// is only returned when this is set.
     pub emit_word_boxes: Option<bool>,
     /// Include rich PDF text metadata on returned text items. Default false.
     pub extract_text_metadata: Option<bool>,
@@ -444,9 +446,24 @@ impl JsTextItem {
     /// `from_rust` with the rich-metadata fields taken from the core-gated
     /// [`liteparse::types::TextMetadata`] view, so the "what counts as text
     /// metadata" list lives in one place instead of per binding.
-    fn from_rust_for_output(item: &TextItem, extract_text_metadata: bool) -> Self {
+    ///
+    /// `serialize_words` is whether `TextItem::words` goes out to JS: core
+    /// forces word-box extraction when `extract_blocks` is on (a
+    /// table-detection input), but those unrequested boxes roughly double the
+    /// text-item payload, so they are only returned when the caller asked —
+    /// see [`JsParseResult::from_rust`].
+    fn from_rust_for_output(
+        item: &TextItem,
+        extract_text_metadata: bool,
+        serialize_words: bool,
+    ) -> Self {
         let meta = item.text_metadata(extract_text_metadata);
         Self {
+            words: if serialize_words {
+                item.words.iter().map(JsWordBox::from_rust).collect()
+            } else {
+                Vec::new()
+            },
             font_height: meta.font_height.map(|v| v as f64),
             font_ascent: meta.font_ascent.map(|v| v as f64),
             font_descent: meta.font_descent.map(|v| v as f64),
@@ -952,7 +969,7 @@ impl JsLayoutBlock {
 }
 
 impl JsParsedPage {
-    pub fn from_rust(page: &ParsedPage, extract_text_metadata: bool) -> Self {
+    pub fn from_rust(page: &ParsedPage, extract_text_metadata: bool, serialize_words: bool) -> Self {
         Self {
             page_num: page.page_number as u32,
             width: page.page_width as f64,
@@ -968,7 +985,9 @@ impl JsParsedPage {
             text_items: page
                 .text_items
                 .iter()
-                .map(|item| JsTextItem::from_rust_for_output(item, extract_text_metadata))
+                .map(|item| {
+                    JsTextItem::from_rust_for_output(item, extract_text_metadata, serialize_words)
+                })
                 .collect(),
             complexity: page
                 .complexity
@@ -1286,12 +1305,22 @@ impl JsPageComplexityStats {
 
 impl JsParseResult {
     pub fn from_rust(result: &ParseResult, config: &LiteParseConfig) -> Self {
+        // Whether `TextItem::words` goes out to JS: always when the caller
+        // asked for word boxes; with `extract_blocks` off, whatever core
+        // populated (stock behavior); with `extract_blocks` on and no
+        // request, never — core forces word-box extraction as a
+        // table-detection input, and shipping those unrequested boxes is
+        // pure payload. `config` is the caller's requested config (core's
+        // forcing never mutates it), so this reads the caller's own value.
+        let serialize_words = config.emit_word_boxes || !config.extract_blocks;
         Self {
             total_pages: result.total_pages,
             pages: result
                 .pages
                 .iter()
-                .map(|page| JsParsedPage::from_rust(page, config.extract_text_metadata))
+                .map(|page| {
+                    JsParsedPage::from_rust(page, config.extract_text_metadata, serialize_words)
+                })
                 .collect(),
             page_errors: result
                 .page_errors
@@ -1369,7 +1398,7 @@ mod tests {
         assert_eq!(js.trailing_space_generated, Some(true));
         assert_eq!(js.fill_color.as_deref(), Some("ff112233"));
 
-        let lightweight = JsTextItem::from_rust_for_output(&item, false);
+        let lightweight = JsTextItem::from_rust_for_output(&item, false, true);
         assert_eq!(lightweight.font_height, None);
         assert_eq!(lightweight.font_is_buggy, None);
         assert_eq!(lightweight.char_codes, None);
@@ -1386,6 +1415,66 @@ mod tests {
         assert_eq!(round_trip.stroke_color.as_deref(), Some("ff445566"));
         assert_eq!(round_trip.char_codes, vec![65, 32]);
         assert!(round_trip.trailing_space_generated);
+    }
+
+    /// Core forces word-box extraction when `extract_blocks` is on (a
+    /// table-detection input), so the DTO layer must strip the unrequested
+    /// boxes: `words` goes out only when the caller asked, or when
+    /// `extract_blocks` is off (stock behavior — core then populates words
+    /// only on request or for markdown output, and whatever it populated is
+    /// passed through).
+    #[test]
+    fn words_serialized_only_when_requested_under_extract_blocks() {
+        let item = TextItem {
+            text: "two words".into(),
+            words: vec![
+                liteparse::types::WordBox {
+                    text: "two".into(),
+                    x: 0.0,
+                    y: 0.0,
+                    width: 10.0,
+                    height: 5.0,
+                },
+                liteparse::types::WordBox {
+                    text: "words".into(),
+                    x: 12.0,
+                    y: 0.0,
+                    width: 16.0,
+                    height: 5.0,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let stripped = JsTextItem::from_rust_for_output(&item, false, false);
+        assert!(
+            stripped.words.is_empty(),
+            "forced word boxes must not ship when the caller didn't ask"
+        );
+
+        let kept = JsTextItem::from_rust_for_output(&item, false, true);
+        assert_eq!(kept.words.len(), 2);
+        assert_eq!(kept.words[0].text, "two");
+        assert_eq!(kept.words[1].text, "words");
+    }
+
+    /// The requested-vs-forced resolution: `words` is serialized unless
+    /// `extract_blocks` forced them on an unwilling caller.
+    #[test]
+    fn serialize_words_resolution_matches_wasm_binding() {
+        let case = |emit_word_boxes: bool, extract_blocks: bool| {
+            let config = LiteParseConfig {
+                emit_word_boxes,
+                extract_blocks,
+                ..Default::default()
+            };
+            // The same expression `JsParseResult::from_rust` computes.
+            config.emit_word_boxes || !config.extract_blocks
+        };
+        assert!(case(false, false), "stock path: pass through core output");
+        assert!(case(true, false), "explicit request honored");
+        assert!(case(true, true), "explicit request honored under blocks");
+        assert!(!case(false, true), "forced-only word boxes are stripped");
     }
 
     #[test]

--- a/crates/liteparse-napi/src/types.rs
+++ b/crates/liteparse-napi/src/types.rs
@@ -969,7 +969,11 @@ impl JsLayoutBlock {
 }
 
 impl JsParsedPage {
-    pub fn from_rust(page: &ParsedPage, extract_text_metadata: bool, serialize_words: bool) -> Self {
+    pub fn from_rust(
+        page: &ParsedPage,
+        extract_text_metadata: bool,
+        serialize_words: bool,
+    ) -> Self {
         Self {
             page_num: page.page_number as u32,
             width: page.page_width as f64,

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -99,7 +99,9 @@ struct PyTextItem {
     #[pyo3(get)]
     rotation: f64,
     /// Per-word sub-boxes for attribution. Empty unless the parse was
-    /// configured with `emit_word_boxes=True`.
+    /// configured with `emit_word_boxes=True`. With `extract_blocks=True`,
+    /// word geometry is always computed internally as a table-detection
+    /// input, but it is only returned here when `emit_word_boxes` asked.
     #[pyo3(get)]
     words: Vec<PyWordBox>,
 }
@@ -500,7 +502,20 @@ impl PyTextItem {
     /// `from_rust` with the rich-metadata fields taken from the core-gated
     /// [`liteparse::types::TextMetadata`] view, so the "what counts as text
     /// metadata" list lives in one place instead of per binding.
-    fn from_rust_for_output(item: liteparse::types::TextItem, extract_text_metadata: bool) -> Self {
+    ///
+    /// `serialize_words` is whether `TextItem::words` goes out to Python:
+    /// core forces word-box extraction when `extract_blocks` is on (a
+    /// table-detection input), but those unrequested boxes roughly double
+    /// the text-item payload, so they are only returned when the caller
+    /// asked — see [`PyParseResult::from_rust`].
+    fn from_rust_for_output(
+        mut item: liteparse::types::TextItem,
+        extract_text_metadata: bool,
+        serialize_words: bool,
+    ) -> Self {
+        if !serialize_words {
+            item.words = Vec::new();
+        }
         let meta = item.text_metadata(extract_text_metadata);
         let (fill_color, stroke_color, char_codes) = (
             meta.fill_color.map(str::to_owned),
@@ -670,7 +685,11 @@ impl PyParsedPage {
 }
 
 impl PyParsedPage {
-    fn from_rust(page: liteparse::types::ParsedPage, extract_text_metadata: bool) -> Self {
+    fn from_rust(
+        page: liteparse::types::ParsedPage,
+        extract_text_metadata: bool,
+        serialize_words: bool,
+    ) -> Self {
         Self {
             page_num: page.page_number as u32,
             width: page.page_width as f64,
@@ -686,7 +705,9 @@ impl PyParsedPage {
             text_items: page
                 .text_items
                 .into_iter()
-                .map(|item| PyTextItem::from_rust_for_output(item, extract_text_metadata))
+                .map(|item| {
+                    PyTextItem::from_rust_for_output(item, extract_text_metadata, serialize_words)
+                })
                 .collect(),
             complexity: page
                 .complexity
@@ -854,13 +875,25 @@ impl PyParseResult {
 }
 
 impl PyParseResult {
-    fn from_rust(result: liteparse::parser::ParseResult, extract_text_metadata: bool) -> Self {
+    /// `serialize_words` is whether `TextItem::words` goes out to Python:
+    /// always when the caller asked for word boxes; with `extract_blocks`
+    /// off, whatever core populated (stock behavior); with `extract_blocks`
+    /// on and no request, never — core forces word-box extraction as a
+    /// table-detection input, and shipping those unrequested boxes is pure
+    /// payload. Callers compute it as `emit_word_boxes || !extract_blocks`
+    /// from the requested config (core's forcing never mutates it) — see
+    /// [`LiteParse::serialize_words`].
+    fn from_rust(
+        result: liteparse::parser::ParseResult,
+        extract_text_metadata: bool,
+        serialize_words: bool,
+    ) -> Self {
         Self {
             total_pages: result.total_pages,
             pages: result
                 .pages
                 .into_iter()
-                .map(|page| PyParsedPage::from_rust(page, extract_text_metadata))
+                .map(|page| PyParsedPage::from_rust(page, extract_text_metadata, serialize_words))
                 .collect(),
             text: result.text,
             images: result
@@ -1384,6 +1417,8 @@ struct PyParseSession {
     inner: liteparse::ParseSession,
     runtime: std::sync::Arc<tokio::runtime::Runtime>,
     extract_text_metadata: bool,
+    /// See [`LiteParse::serialize_words`] — resolved once at session open.
+    serialize_words: bool,
 }
 
 #[pymethods]
@@ -1406,7 +1441,11 @@ impl PyParseSession {
         Ok(batch.map(|batch| PyParseBatch {
             start_page: batch.start_page,
             end_page: batch.end_page,
-            result: PyParseResult::from_rust(batch.result, self.extract_text_metadata),
+            result: PyParseResult::from_rust(
+                batch.result,
+                self.extract_text_metadata,
+                self.serialize_words,
+            ),
         }))
     }
 
@@ -1661,6 +1700,7 @@ impl LiteParse {
         Ok(PyParseResult::from_rust(
             result,
             self.config.extract_text_metadata,
+            self.serialize_words(),
         ))
     }
 
@@ -1702,6 +1742,7 @@ impl LiteParse {
         Ok(PyParseResult::from_rust(
             result,
             self.config.extract_text_metadata,
+            self.serialize_words(),
         ))
     }
 
@@ -1806,7 +1847,18 @@ impl LiteParse {
             inner: session,
             runtime: self.runtime.clone(),
             extract_text_metadata: self.config.extract_text_metadata,
+            serialize_words: self.serialize_words(),
         })
+    }
+
+    /// Whether `TextItem::words` goes out to Python: always when the caller
+    /// asked for word boxes; with `extract_blocks` off, whatever core
+    /// populated (stock behavior); with `extract_blocks` on and no request,
+    /// never — core forces word-box extraction as a table-detection input
+    /// without mutating the config, so `self.config` reads the caller's own
+    /// request.
+    fn serialize_words(&self) -> bool {
+        self.config.emit_word_boxes || !self.config.extract_blocks
     }
 }
 
@@ -1951,6 +2003,66 @@ mod tests {
         assert_eq!(round_trip.stroke_color.as_deref(), Some("ff445566"));
         assert_eq!(round_trip.char_codes, vec![65, 32]);
         assert!(round_trip.trailing_space_generated);
+    }
+
+    /// Core forces word-box extraction when `extract_blocks` is on (a
+    /// table-detection input), so the DTO layer must strip the unrequested
+    /// boxes: `words` goes out only when the caller asked, or when
+    /// `extract_blocks` is off (stock behavior — core then populates words
+    /// only on request or for markdown output, and whatever it populated is
+    /// passed through).
+    #[test]
+    fn words_serialized_only_when_requested_under_extract_blocks() {
+        let item = || liteparse::types::TextItem {
+            text: "two words".into(),
+            words: vec![
+                liteparse::types::WordBox {
+                    text: "two".into(),
+                    x: 0.0,
+                    y: 0.0,
+                    width: 10.0,
+                    height: 5.0,
+                },
+                liteparse::types::WordBox {
+                    text: "words".into(),
+                    x: 12.0,
+                    y: 0.0,
+                    width: 16.0,
+                    height: 5.0,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let stripped = PyTextItem::from_rust_for_output(item(), false, false);
+        assert!(
+            stripped.words.is_empty(),
+            "forced word boxes must not ship when the caller didn't ask"
+        );
+
+        let kept = PyTextItem::from_rust_for_output(item(), false, true);
+        assert_eq!(kept.words.len(), 2);
+        assert_eq!(kept.words[0].text, "two");
+        assert_eq!(kept.words[1].text, "words");
+    }
+
+    /// The requested-vs-forced resolution: `words` is serialized unless
+    /// `extract_blocks` forced them on an unwilling caller.
+    #[test]
+    fn serialize_words_resolution_matches_wasm_binding() {
+        let case = |emit_word_boxes: bool, extract_blocks: bool| {
+            let config = LiteParseConfig {
+                emit_word_boxes,
+                extract_blocks,
+                ..Default::default()
+            };
+            // The same expression `LiteParse::serialize_words` computes.
+            config.emit_word_boxes || !config.extract_blocks
+        };
+        assert!(case(false, false), "stock path: pass through core output");
+        assert!(case(true, false), "explicit request honored");
+        assert!(case(true, true), "explicit request honored under blocks");
+        assert!(!case(false, true), "forced-only word boxes are stripped");
     }
 
     #[test]

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -275,6 +275,10 @@ struct PyLayoutCell {
     text: String,
     #[pyo3(get)]
     bbox: Option<PyAnnotationRect>,
+    /// Indices into the page's returned `text_items`, in reading order,
+    /// never repeating within one cell; empty for padding cells.
+    #[pyo3(get)]
+    text_item_indices: Vec<usize>,
 }
 
 impl PyLayoutCell {
@@ -282,6 +286,7 @@ impl PyLayoutCell {
         Self {
             text: cell.text,
             bbox: cell.bbox.map(PyAnnotationRect::from_rust),
+            text_item_indices: cell.text_item_indices,
         }
     }
 }
@@ -298,6 +303,11 @@ struct PyLayoutBlock {
     /// `grid_fallback`, `rule`, `figure`.
     #[pyo3(get)]
     kind: String,
+    /// Indices into the page's returned `text_items`, sorted and deduped;
+    /// empty for text-less blocks. For a `table` block, the union of its
+    /// cells' indices.
+    #[pyo3(get)]
+    text_item_indices: Vec<usize>,
     /// Rendered text for the text-bearing kinds (`heading`, `paragraph`,
     /// `list_item`). Table text lives in `header`/`rows`; code and grid text in
     /// `lines`.
@@ -347,6 +357,7 @@ impl PyLayoutBlock {
     fn from_rust(block: liteparse::layout::LayoutBlock) -> Self {
         Self {
             kind: block.kind.to_string(),
+            text_item_indices: block.text_item_indices,
             text: block.text,
             level: block.level,
             bold: block.bold,

--- a/crates/liteparse-wasm/src/lib.rs
+++ b/crates/liteparse-wasm/src/lib.rs
@@ -1466,7 +1466,11 @@ impl ParseSession {
         Ok(batch.map(|batch| ParseBatch {
             start_page: batch.start_page,
             end_page: batch.end_page,
-            result: to_js_result(&batch.result, self.extract_text_metadata, self.serialize_words),
+            result: to_js_result(
+                &batch.result,
+                self.extract_text_metadata,
+                self.serialize_words,
+            ),
         }))
     }
 }

--- a/crates/liteparse-wasm/src/lib.rs
+++ b/crates/liteparse-wasm/src/lib.rs
@@ -511,6 +511,12 @@ pub struct LayoutCell {
     pub text: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bbox: Option<AnnotationRect>,
+    /// Indices into the page's `textItems` array (the order the caller
+    /// receives it), in reading order. Always present; `[]` for padding
+    /// cells inserted to square off a ragged grid. An index never repeats
+    /// within one cell but may appear in several cells (a merged span split
+    /// across column tracks attributes each fragment to the whole span).
+    pub text_item_indices: Vec<u32>,
 }
 
 /// A classified block plus where it sits on the page.
@@ -525,6 +531,11 @@ pub struct LayoutBlock {
     /// One of `heading`, `paragraph`, `list_item`, `code`, `table`,
     /// `grid_fallback`, `rule`, `figure`.
     pub kind: String,
+    /// Indices into the page's `textItems` array (the order the caller
+    /// receives it), sorted and deduped. Always present; `[]` for text-less
+    /// blocks (vector `rule`s, `figure`s). For a `table` block this is the
+    /// union of all cell indices.
+    pub text_item_indices: Vec<u32>,
     /// Rendered text for the text-bearing kinds (`heading`, `paragraph`,
     /// `list_item`). Table text lives in `header`/`rows`; code and grid text
     /// in `lines`.
@@ -579,11 +590,19 @@ fn to_annotation_rect(rect: &liteparse::types::Rect) -> AnnotationRect {
     }
 }
 
+/// Narrow core `usize` provenance indices to the `u32` the JS DTO carries.
+/// Lossless in practice: indices address a page's `textItems` array, which
+/// never approaches `u32::MAX` entries.
+fn to_js_indices(indices: &[usize]) -> Vec<u32> {
+    indices.iter().map(|&i| i as u32).collect()
+}
+
 impl LayoutCell {
     fn from_rust(cell: &liteparse::layout::LayoutCell) -> Self {
         Self {
             text: cell.text.clone(),
             bbox: cell.bbox.as_ref().map(to_annotation_rect),
+            text_item_indices: to_js_indices(&cell.text_item_indices),
         }
     }
 }
@@ -595,6 +614,7 @@ impl LayoutBlock {
         };
         Self {
             kind: block.kind.to_string(),
+            text_item_indices: to_js_indices(&block.text_item_indices),
             text: block.text.clone(),
             level: block.level,
             bold: block.bold,

--- a/crates/liteparse-wasm/src/lib.rs
+++ b/crates/liteparse-wasm/src/lib.rs
@@ -254,6 +254,11 @@ impl LiteParseConfig {
         Ok(cfg)
     }
 
+    /// Rebuild the JS-facing config from the resolved core config. Core's
+    /// `extract_blocks` word-box forcing never mutates the config (it applies
+    /// at extraction time), so `cfg.emit_word_boxes` is always the caller's
+    /// own `emitWordBoxes` request — which is also what the serialized output
+    /// honors.
     fn from_core(cfg: &CoreConfig) -> Self {
         Self {
             ocr_language: Some(cfg.ocr_language.clone()),
@@ -1074,6 +1079,10 @@ extern "C" {
 #[wasm_bindgen]
 pub struct LiteParse {
     inner: CoreLiteParse,
+    /// The resolved config as the caller requested it. Core's
+    /// `extract_blocks` word-box forcing happens at extraction time without
+    /// mutating the config, so `config.emit_word_boxes` here is always the
+    /// caller's own `emitWordBoxes` value — see [`Self::serialize_words`].
     config: CoreConfig,
 }
 
@@ -1099,6 +1108,10 @@ impl LiteParse {
                 .map_err(|e| JsError::new(&format!("invalid config: {}", e)))?
         };
         let core_cfg = js_cfg.into_core()?;
+        // With `extractBlocks` on, core forces word-box extraction internally
+        // as a table-detection input (word-anchored straddle splits) without
+        // mutating the config; the DTO mapping still omits `words` unless the
+        // caller requested them — see `serialize_words`.
         let mut parser = CoreLiteParse::new(core_cfg.clone());
         if let Some(js_engine) = ocr_engine_js {
             parser = parser.with_ocr_engine(std::sync::Arc::new(JsOcrEngine::new(js_engine)));
@@ -1126,7 +1139,21 @@ impl LiteParse {
         Ok(to_js_result(
             &result,
             self.inner.config().extract_text_metadata,
+            self.serialize_words(),
         ))
+    }
+}
+
+impl LiteParse {
+    /// Whether `TextItem::words` goes out to JS: always when the caller asked
+    /// for word boxes; with `extractBlocks` off, whatever core populated
+    /// (stock behavior — byte-identity contract); with `extractBlocks` on and
+    /// no request, never — core forces word-box extraction as a
+    /// table-detection input, but serializing those unrequested boxes
+    /// measurably bloats the `textItems` payload (2.3x on an 80-page text
+    /// PDF).
+    fn serialize_words(&self) -> bool {
+        self.config.emit_word_boxes || !self.config.extract_blocks
     }
 }
 
@@ -1134,7 +1161,16 @@ impl LiteParse {
 ///
 /// Shared by `parse()` and `ParseSession::nextBatch()` so a batch is mapped
 /// exactly the same way a whole-document result is.
-fn to_js_result(result: &liteparse::ParseResult, extract_text_metadata: bool) -> ParseResult {
+///
+/// `emit_words` is the caller's own `emitWordBoxes` request: core may have
+/// populated `TextItem::words` anyway (markdown output and `extractBlocks`
+/// both enable extraction as a table-detection input), but shipping them
+/// unrequested is pure payload.
+fn to_js_result(
+    result: &liteparse::ParseResult,
+    extract_text_metadata: bool,
+    emit_words: bool,
+) -> ParseResult {
     let pages: Vec<ParsedPage> = result
         .pages
         .iter()
@@ -1181,7 +1217,7 @@ fn to_js_result(result: &liteparse::ParseResult, extract_text_metadata: bool) ->
                             .filter(|codes| !codes.is_empty())
                             .map(<[u32]>::to_vec),
                         trailing_space_generated: meta.trailing_space_generated,
-                        words: if i.words.is_empty() {
+                        words: if !emit_words || i.words.is_empty() {
                             None
                         } else {
                             Some(
@@ -1374,6 +1410,7 @@ impl LiteParse {
 
         Ok(ParseSession {
             extract_text_metadata: self.inner.config().extract_text_metadata,
+            serialize_words: self.serialize_words(),
             inner: session,
         })
     }
@@ -1401,6 +1438,8 @@ pub struct ParseBatch {
 pub struct ParseSession {
     inner: liteparse::ParseSession,
     extract_text_metadata: bool,
+    /// See [`LiteParse::serialize_words`] — resolved once at session open.
+    serialize_words: bool,
 }
 
 #[wasm_bindgen]
@@ -1427,7 +1466,7 @@ impl ParseSession {
         Ok(batch.map(|batch| ParseBatch {
             start_page: batch.start_page,
             end_page: batch.end_page,
-            result: to_js_result(&batch.result, self.extract_text_metadata),
+            result: to_js_result(&batch.result, self.extract_text_metadata, self.serialize_words),
         }))
     }
 }

--- a/crates/liteparse/src/layout.rs
+++ b/crates/liteparse/src/layout.rs
@@ -11,6 +11,24 @@
 //! Every field that doesn't apply to a block's `kind` is `None` and is skipped
 //! during serialization, so a heading serializes as `{kind, text, level, bbox}`
 //! rather than a wall of nulls.
+//!
+//! # Provenance (fork)
+//!
+//! Every block and every table cell additionally carries
+//! `text_item_indices`: indices into the page's RETURNED `text_items` array
+//! (post-projection order — the order the caller receives, not PDF paint
+//! order). The field is always serialized, `[]` when empty. Contract:
+//!
+//! - block indices are sorted and deduped; for a `table` block they equal the
+//!   union of its cells' indices;
+//! - cell indices are in insertion order (reading order: line order,
+//!   x-ascending within a line) and never repeat within one cell — but one
+//!   index may appear in several cells (a merged span split across column
+//!   tracks attributes each fragment to the whole source span);
+//! - `rule` blocks from vector strokes and `figure` blocks (no text behind
+//!   them) carry `[]`, as do padding cells inserted to square off a ragged
+//!   grid; a `rule` detected from a decorative text flourish (`* * *`)
+//!   carries the flourish line's items.
 
 use serde::Serialize;
 
@@ -27,13 +45,24 @@ pub struct LayoutCell {
     pub text: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bbox: Option<Rect>,
+    /// Indices into the page's returned `text_items`, in reading order,
+    /// never repeating within the cell (see the module docs). Always
+    /// serialized; `[]` for padding cells.
+    pub text_item_indices: Vec<usize>,
 }
 
 impl From<&Cell> for LayoutCell {
     fn from(c: &Cell) -> Self {
+        // Insertion order preserved; belt-and-suspenders dedup upholds the
+        // "never twice within one cell" contract even if an accumulation
+        // path double-pushed.
+        let mut indices = c.text_item_indices.clone();
+        let mut seen = std::collections::HashSet::new();
+        indices.retain(|i| seen.insert(*i));
         LayoutCell {
             text: c.text.clone(),
             bbox: c.bbox.clone(),
+            text_item_indices: indices,
         }
     }
 }
@@ -48,6 +77,9 @@ pub struct LayoutBlock {
     /// One of `heading`, `paragraph`, `list_item`, `code`, `table`,
     /// `grid_fallback`, `rule`, `figure`.
     pub kind: &'static str,
+    /// Indices into the page's returned `text_items`, sorted and deduped
+    /// (see the module docs). Always serialized; `[]` for text-less blocks.
+    pub text_item_indices: Vec<usize>,
     /// Rendered text for the text-bearing kinds (`heading`, `paragraph`,
     /// `list_item`). Table text lives in `header`/`rows`; code and grid text in
     /// `lines`.
@@ -99,6 +131,7 @@ impl LayoutBlock {
     fn of(kind: &'static str, bbox: Option<Rect>) -> Self {
         LayoutBlock {
             kind,
+            text_item_indices: Vec::new(),
             text: None,
             level: None,
             bold: false,
@@ -123,7 +156,29 @@ fn cells(row: &[Cell]) -> Vec<LayoutCell> {
 impl From<&PositionedBlock> for LayoutBlock {
     fn from(pb: &PositionedBlock) -> Self {
         let bbox = pb.bbox.clone();
-        match &pb.block {
+        // Block-level indices are sorted + deduped at this public boundary;
+        // insertion order (a classifier-internal detail) is not part of the
+        // block-level contract.
+        let mut text_item_indices = pb.text_item_indices.clone();
+        text_item_indices.sort_unstable();
+        text_item_indices.dedup();
+        // A table block's indices must be exactly the union of its cells'.
+        #[cfg(debug_assertions)]
+        if let Block::Table { header, rows } = &pb.block {
+            let mut cell_union: Vec<usize> = header
+                .iter()
+                .flatten()
+                .chain(rows.iter().flatten())
+                .flat_map(|c| c.text_item_indices.iter().copied())
+                .collect();
+            cell_union.sort_unstable();
+            cell_union.dedup();
+            debug_assert_eq!(
+                text_item_indices, cell_union,
+                "table block indices must equal the union of its cell indices"
+            );
+        }
+        let mut out = match &pb.block {
             Block::Heading { level, text } => LayoutBlock {
                 text: Some(text.clone()),
                 level: Some(*level),
@@ -171,6 +226,37 @@ impl From<&PositionedBlock> for LayoutBlock {
                 format: Some(format.clone()),
                 ..LayoutBlock::of("figure", bbox)
             },
-        }
+        };
+        out.text_item_indices = text_item_indices;
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_indices_are_sorted_and_deduped_at_the_boundary() {
+        let pb = PositionedBlock::new(
+            Block::Paragraph {
+                text: "x".into(),
+                bold: false,
+                italic: false,
+            },
+            None,
+            vec![5, 2, 5, 9, 2],
+        );
+        let lb = LayoutBlock::from(&pb);
+        assert_eq!(lb.text_item_indices, vec![2, 5, 9]);
+    }
+
+    #[test]
+    fn cell_indices_keep_reading_order() {
+        let mut c = Cell::from("a b");
+        c.add_indices([9, 3, 9, 7]);
+        let lc = LayoutCell::from(&c);
+        // Insertion order preserved, repeats dropped — never re-sorted.
+        assert_eq!(lc.text_item_indices, vec![9, 3, 7]);
     }
 }

--- a/crates/liteparse/src/markdown_layout/blocks.rs
+++ b/crates/liteparse/src/markdown_layout/blocks.rs
@@ -12,15 +12,46 @@ use crate::types::Rect;
 pub struct Cell {
     pub text: String,
     pub bbox: Option<Rect>,
+    /// Indices of the source items this cell's text was read from, into the
+    /// page's *returned* `text_items` array (see
+    /// `ProjectedLine::span_item_indices` for the index contract). Insertion
+    /// order is reading order (line order, x-ascending within a line) and is
+    /// preserved as-is — never sorted or deduped at cell level, because
+    /// consumers use it as the cell's canonical word order. One index may
+    /// legitimately appear in several cells (a merged span split across
+    /// column tracks attributes to each), but never twice within one cell.
+    /// Empty for padding cells and cells synthesized without page content.
+    pub text_item_indices: Vec<usize>,
 }
 
 impl Cell {
-    /// Cell carrying text and the region it was read from.
+    /// Cell carrying text and the region it was read from, with no
+    /// source-item attribution (tests and legacy paths).
     pub fn located(text: impl Into<String>, bbox: Rect) -> Self {
         Cell {
             text: text.into(),
             bbox: Some(bbox),
+            text_item_indices: Vec::new(),
         }
+    }
+
+    /// Cell carrying text, the region it was read from, and the returned
+    /// text-item indices that produced it.
+    pub fn located_with(
+        text: impl Into<String>,
+        bbox: Rect,
+        text_item_indices: Vec<usize>,
+    ) -> Self {
+        Cell {
+            text: text.into(),
+            bbox: Some(bbox),
+            text_item_indices,
+        }
+    }
+
+    /// Append more contributing source-item indices, keeping insertion order.
+    pub fn add_indices(&mut self, indices: impl IntoIterator<Item = usize>) {
+        self.text_item_indices.extend(indices);
     }
 
     /// Borrow the cell's text. Lets call sites that only care about content
@@ -36,13 +67,18 @@ impl From<&str> for Cell {
         Cell {
             text: text.to_string(),
             bbox: None,
+            text_item_indices: Vec::new(),
         }
     }
 }
 
 impl From<String> for Cell {
     fn from(text: String) -> Self {
-        Cell { text, bbox: None }
+        Cell {
+            text,
+            bbox: None,
+            text_item_indices: Vec::new(),
+        }
     }
 }
 
@@ -181,16 +217,31 @@ fn wrap_emphasis(text: &str, bold: bool, italic: bool) -> String {
 pub struct PositionedBlock {
     pub block: Block,
     pub bbox: Option<Rect>,
+    /// Indices of the source items this block's content was read from, into
+    /// the page's *returned* `text_items` array (see
+    /// `ProjectedLine::span_item_indices` for the index contract).
+    /// Accumulated in insertion order here; the public `LayoutBlock`
+    /// conversion sorts + dedups. Empty for blocks with no text behind them
+    /// (rules, figures) and for paths not yet attributing provenance.
+    pub text_item_indices: Vec<usize>,
 }
 
 impl PositionedBlock {
-    pub fn new(block: Block, bbox: Option<Rect>) -> Self {
-        PositionedBlock { block, bbox }
+    pub fn new(block: Block, bbox: Option<Rect>, text_item_indices: Vec<usize>) -> Self {
+        PositionedBlock {
+            block,
+            bbox,
+            text_item_indices,
+        }
     }
 
-    /// A block with no known geometry.
+    /// A block with no known geometry (and no source-item attribution).
     pub fn unlocated(block: Block) -> Self {
-        PositionedBlock { block, bbox: None }
+        PositionedBlock {
+            block,
+            bbox: None,
+            text_item_indices: Vec::new(),
+        }
     }
 
     /// Grow this block's box to also cover `other`.
@@ -198,6 +249,12 @@ impl PositionedBlock {
         if let Some(r) = other {
             Rect::extend(&mut self.bbox, r);
         }
+    }
+
+    /// Union another block's source-item indices into this one (used when a
+    /// pass fuses two blocks into one — the survivor covers both sources).
+    fn absorb_indices(&mut self, other: &[usize]) {
+        self.text_item_indices.extend_from_slice(other);
     }
 }
 
@@ -242,6 +299,7 @@ pub fn splice_soft_hyphens(blocks: Vec<PositionedBlock>) -> Vec<PositionedBlock>
                 text.push_str(&tail);
             }
             prev.absorb(&pb.bbox);
+            prev.absorb_indices(&pb.text_item_indices);
             continue;
         }
         out.push(pb);
@@ -543,12 +601,14 @@ mod tests {
             height: 12.0,
         };
         let joined = splice_soft_hyphens(vec![
-            PositionedBlock::new(p("they dis-"), Some(r(50.0))),
-            PositionedBlock::new(p("lodged the part"), Some(r(70.0))),
+            PositionedBlock::new(p("they dis-"), Some(r(50.0)), vec![0, 1]),
+            PositionedBlock::new(p("lodged the part"), Some(r(70.0)), vec![2, 3]),
         ]);
         assert_eq!(joined.len(), 1);
         let bbox = joined[0].bbox.clone().expect("merged block keeps geometry");
         assert_eq!((bbox.y, bbox.height), (50.0, 32.0));
+        // The survivor also absorbs the spliced block's source items.
+        assert_eq!(joined[0].text_item_indices, vec![0, 1, 2, 3]);
     }
 
     #[test]

--- a/crates/liteparse/src/markdown_layout/classify.rs
+++ b/crates/liteparse/src/markdown_layout/classify.rs
@@ -409,7 +409,9 @@ pub fn classify_page_with_filters(
 /// stay identical.
 fn positioned_interruption(kind: Interruption) -> PositionedBlock {
     match kind {
-        Interruption::Hr(rect) => PositionedBlock::new(Block::HorizontalRule, Some(rect), Vec::new()),
+        Interruption::Hr(rect) => {
+            PositionedBlock::new(Block::HorizontalRule, Some(rect), Vec::new())
+        }
         Interruption::Figure(r) => PositionedBlock::new(
             Block::Figure {
                 id: r.id,
@@ -452,7 +454,11 @@ impl FlowState {
         {
             let bbox = acc.bbox.clone();
             let indices = std::mem::take(&mut acc.item_indices);
-            blocks.push(PositionedBlock::new(paragraph_from_accum(acc), bbox, indices));
+            blocks.push(PositionedBlock::new(
+                paragraph_from_accum(acc),
+                bbox,
+                indices,
+            ));
         }
     }
 
@@ -462,7 +468,11 @@ impl FlowState {
             && !lines.is_empty()
         {
             let lang = detect_code_language(&lines);
-            blocks.push(PositionedBlock::new(Block::CodeBlock { lines, lang }, bbox, indices));
+            blocks.push(PositionedBlock::new(
+                Block::CodeBlock { lines, lang },
+                bbox,
+                indices,
+            ));
         }
     }
 
@@ -1618,8 +1628,14 @@ mod tests {
         // final paragraph from line 3. Each block must report exactly its own
         // source lines' indices, in reading order.
         let p = page(vec![
-            tag(line("Title of the document goes here", 50.0, 50.0, 18.0, 18.0), 0),
-            tag(line("First sentence of the para-", 50.0, 80.0, 10.0, 10.0), 1),
+            tag(
+                line("Title of the document goes here", 50.0, 50.0, 18.0, 18.0),
+                0,
+            ),
+            tag(
+                line("First sentence of the para-", 50.0, 80.0, 10.0, 10.0),
+                1,
+            ),
             tag(line("graph continues here.", 50.0, 92.0, 10.0, 10.0), 2),
             tag(line("Another paragraph.", 50.0, 130.0, 10.0, 10.0), 3),
         ]);
@@ -1714,7 +1730,10 @@ mod tests {
         // Two xy_cut leaves: the paragraph's tail lands in the second leaf.
         // The stitcher fuses them (prev ends open, next starts lowercase) and
         // must union the provenance along with the text/bbox.
-        let mut a = tag(line("The sentence continues without", 50.0, 700.0, 10.0, 10.0), 0);
+        let mut a = tag(
+            line("The sentence continues without", 50.0, 700.0, 10.0, 10.0),
+            0,
+        );
         a.region_path = vec![0];
         let mut b = tag(line("ending punctuation here.", 320.0, 50.0, 10.0, 10.0), 1);
         b.region_path = vec![1];

--- a/crates/liteparse/src/markdown_layout/classify.rs
+++ b/crates/liteparse/src/markdown_layout/classify.rs
@@ -426,7 +426,7 @@ fn positioned_interruption(kind: Interruption) -> PositionedBlock {
 #[derive(Default)]
 struct FlowState {
     paragraph: Option<ParaAccum>,
-    code: Option<(Vec<String>, Option<Rect>)>,
+    code: Option<(Vec<String>, Option<Rect>, Vec<usize>)>,
     list_base_indent: Option<f32>,
     last_list_item_idx: Option<usize>,
     last_list_line: Option<usize>,
@@ -443,21 +443,22 @@ impl FlowState {
 
     /// Emit the active paragraph (if it has non-blank content) and clear it.
     fn flush_paragraph(&mut self, blocks: &mut Vec<PositionedBlock>) {
-        if let Some(acc) = self.paragraph.take()
+        if let Some(mut acc) = self.paragraph.take()
             && !acc.raw.trim().is_empty()
         {
             let bbox = acc.bbox.clone();
-            blocks.push(PositionedBlock::new(paragraph_from_accum(acc), bbox, Vec::new()));
+            let indices = std::mem::take(&mut acc.item_indices);
+            blocks.push(PositionedBlock::new(paragraph_from_accum(acc), bbox, indices));
         }
     }
 
     /// Emit the active code run (if non-empty) and clear it.
     fn flush_code(&mut self, blocks: &mut Vec<PositionedBlock>) {
-        if let Some((lines, bbox)) = self.code.take()
+        if let Some((lines, bbox, indices)) = self.code.take()
             && !lines.is_empty()
         {
             let lang = detect_code_language(&lines);
-            blocks.push(PositionedBlock::new(Block::CodeBlock { lines, lang }, bbox, Vec::new()));
+            blocks.push(PositionedBlock::new(Block::CodeBlock { lines, lang }, bbox, indices));
         }
     }
 
@@ -610,6 +611,7 @@ fn classify_region(
             let code = state.code.get_or_insert_with(Default::default);
             code.0.push(line.text.trim_end().to_string());
             Rect::extend(&mut code.1, &line.bbox);
+            code.2.extend(line.span_item_indices.iter().copied());
             continue;
         }
         // Any non-mono line ends the current code block (if any).
@@ -626,7 +628,9 @@ fn classify_region(
                 blocks.push(PositionedBlock::new(
                     Block::HorizontalRule,
                     Some(line.bbox.clone()),
-                    Vec::new(),
+                    // The flourish IS text-bearing (`* * *` glyphs) — carry
+                    // its source items even though the kind is `rule`.
+                    line.span_item_indices.clone(),
                 ));
             }
             if debug {
@@ -766,6 +770,7 @@ fn classify_region(
                         text: htext,
                     },
                 bbox: heading_bbox,
+                text_item_indices: hindices,
                 ..
             }) = blocks.last_mut()
             && *last_level == *run_level
@@ -787,6 +792,7 @@ fn classify_region(
                     );
                 }
                 append_inline_continuation(htext, text, &collapse_whitespace(text));
+                hindices.extend(line.span_item_indices.iter().copied());
                 heading_run = Some((run_level, line_idx));
                 continue;
             }
@@ -806,6 +812,7 @@ fn classify_region(
                             level: last_level,
                             text: htext,
                         },
+                    text_item_indices: hindices,
                     ..
                 }) = blocks.last_mut()
                 && *last_level == level
@@ -822,6 +829,11 @@ fn classify_region(
                 let combined_chars = htext.chars().count() + 1 + text.chars().count();
                 if combined_chars > HEADING_MAX_TEXT_CHARS {
                     let demoted = std::mem::take(htext);
+                    // Move the heading's accumulated provenance into the new
+                    // paragraph — the demoted text may span several wrapped
+                    // lines, so rebuilding from the run line alone would drop
+                    // the earlier contributors.
+                    let demoted_indices = std::mem::take(hindices);
                     blocks.pop();
                     state.paragraph = Some(ParaAccum {
                         raw: demoted.clone(),
@@ -829,11 +841,13 @@ fn classify_region(
                         last: lines[*run_idx].clone(),
                         uniform: None,
                         bbox: Some(lines[*run_idx].bbox.clone()),
+                        item_indices: demoted_indices,
                     });
                     heading_run = None;
                     demoted_heading = true;
                 } else {
                     append_inline_continuation(htext, text, &collapse_whitespace(text));
+                    hindices.extend(line.span_item_indices.iter().copied());
                     heading_run = Some((level, line_idx));
                     continue;
                 }
@@ -856,7 +870,7 @@ fn classify_region(
                         text: collapse_whitespace(text),
                     },
                     Some(line.bbox.clone()),
-                    Vec::new(),
+                    line.span_item_indices.clone(),
                 ));
                 heading_run = Some((level, line_idx));
                 continue;
@@ -905,7 +919,7 @@ fn classify_region(
                         text: collapse_whitespace(text),
                     },
                     Some(line.bbox.clone()),
-                    Vec::new(),
+                    line.span_item_indices.clone(),
                 ));
                 continue;
             }
@@ -932,7 +946,7 @@ fn classify_region(
                     italic: false,
                 },
                 Some(line.bbox.clone()),
-                Vec::new(),
+                line.span_item_indices.clone(),
             ));
             continue;
         }
@@ -953,8 +967,11 @@ fn classify_region(
             // inline-styled continuation.
             let cont_inline = render_line_inline(line);
             append_inline_continuation(prev_text, text, &cont_inline);
-            // The wrapped line belongs to the same item, so it grows its box.
+            // The wrapped line belongs to the same item, so it grows its box
+            // and its provenance.
             Rect::extend(&mut item.bbox, &line.bbox);
+            item.text_item_indices
+                .extend(line.span_item_indices.iter().copied());
             state.last_list_line = Some(line_idx);
             continue;
         }
@@ -992,7 +1009,7 @@ fn classify_region(
                     text: collapse_whitespace(text),
                 },
                 Some(line.bbox.clone()),
-                Vec::new(),
+                line.span_item_indices.clone(),
             ));
             // Arm the heading_run so a wrapped continuation on the next line
             // merges into this heading instead of emitting as a second one.
@@ -1021,6 +1038,7 @@ fn classify_region(
                     bbox: Some(line.bbox.clone()),
                     last: line.clone(),
                     uniform,
+                    item_indices: line.span_item_indices.clone(),
                 });
             }
         }
@@ -1198,6 +1216,8 @@ fn stitch_regions(blocks: Vec<PositionedBlock>, region_starts: &[usize]) -> Vec<
                 prev_text.pop(); // the '-'
                 prev_text.push_str(cur_text.trim_start());
                 prev.bbox = merged_bbox;
+                prev.text_item_indices
+                    .extend_from_slice(&block.text_item_indices);
                 continue;
             }
             let ends_open = !prev_trim.ends_with(|c: char| {
@@ -1210,6 +1230,8 @@ fn stitch_regions(blocks: Vec<PositionedBlock>, region_starts: &[usize]) -> Vec<
                 prev_text.push(' ');
                 prev_text.push_str(cur_text.trim_start());
                 prev.bbox = merged_bbox;
+                prev.text_item_indices
+                    .extend_from_slice(&block.text_item_indices);
                 continue;
             }
         }
@@ -1576,5 +1598,124 @@ mod tests {
         // HR must land between the two paragraphs, not before/after both.
         let pos = has_hr.unwrap();
         assert!(pos > 0 && pos < blocks.len() - 1);
+    }
+
+    /// Give a synthetic line a distinct single source-item index so block
+    /// provenance can be asserted line-by-line.
+    fn tag(mut l: crate::types::ProjectedLine, idx: usize) -> crate::types::ProjectedLine {
+        l.span_item_indices = vec![idx];
+        l
+    }
+
+    #[test]
+    fn heading_and_paragraph_blocks_carry_item_indices() {
+        // Heading from line 0; a wrapped 2-line paragraph from lines 1-2; a
+        // final paragraph from line 3. Each block must report exactly its own
+        // source lines' indices, in reading order.
+        let p = page(vec![
+            tag(line("Title of the document goes here", 50.0, 50.0, 18.0, 18.0), 0),
+            tag(line("First sentence of the para-", 50.0, 80.0, 10.0, 10.0), 1),
+            tag(line("graph continues here.", 50.0, 92.0, 10.0, 10.0), 2),
+            tag(line("Another paragraph.", 50.0, 130.0, 10.0, 10.0), 3),
+        ]);
+        let pages = vec![p];
+        let body = compute_body_size(&pages);
+        let map = build_heading_map(&pages, body);
+        let blocks = classify_page(&pages[0], &map);
+        assert_eq!(blocks.len(), 3);
+        assert!(matches!(blocks[0].block, Block::Heading { .. }));
+        assert_eq!(blocks[0].text_item_indices, vec![0]);
+        assert_eq!(blocks[1].text_item_indices, vec![1, 2]);
+        assert_eq!(blocks[2].text_item_indices, vec![3]);
+    }
+
+    #[test]
+    fn demoted_heading_carries_indices_into_the_paragraph() {
+        // A size-promoted first line under the length cap merges a
+        // continuation that tips the run over HEADING_MAX_TEXT_CHARS: the
+        // heading demotes back to a paragraph, which must carry BOTH lines'
+        // indices — the demoted block's accumulated provenance plus the
+        // continuation appended to the revived accumulator.
+        let long_a = "A rather long citation-style opening line that scores as a heading on its own because it stays just under the cap";
+        let long_b = "But the continuation line pushes the combined run far over the limit";
+        assert!(long_a.chars().count() <= HEADING_MAX_TEXT_CHARS);
+        assert!(long_a.chars().count() + 1 + long_b.chars().count() > HEADING_MAX_TEXT_CHARS);
+        let mut lines_v = vec![
+            tag(line(long_a, 50.0, 50.0, 14.0, 14.0), 0),
+            tag(line(long_b, 50.0, 66.0, 14.0, 14.0), 1),
+        ];
+        // Enough 10pt body text that 10pt wins the body-size histogram and
+        // 14pt maps to a heading level.
+        for i in 0..10 {
+            lines_v.push(tag(
+                line(
+                    "plain body text keeps the size map honest and body-dominant here.",
+                    50.0,
+                    300.0 + i as f32 * 12.0,
+                    10.0,
+                    10.0,
+                ),
+                2 + i,
+            ));
+        }
+        let p = page(lines_v.clone());
+        let pages = vec![p];
+        let body = compute_body_size(&pages);
+        let map = build_heading_map(&pages, body);
+        // Fixture sanity: without the continuation line, the 14pt line IS a
+        // heading — so the full fixture genuinely exercises the demotion path
+        // rather than plain paragraph accumulation.
+        let mut solo = lines_v.clone();
+        solo.remove(1);
+        let solo_blocks = classify_page(&page(solo), &map);
+        assert!(
+            matches!(solo_blocks[0].block, Block::Heading { .. }),
+            "fixture must promote the first line on its own, got {:?}",
+            solo_blocks[0].block
+        );
+        let blocks = classify_page(&pages[0], &map);
+        // No heading survives; the first block is the demoted paragraph.
+        let first = &blocks[0];
+        match &first.block {
+            Block::Paragraph { text, .. } => {
+                assert!(text.contains("citation-style opening"), "got: {text}");
+                assert!(text.contains("continuation line"), "got: {text}");
+            }
+            other => panic!("expected demoted paragraph, got {other:?}"),
+        }
+        assert_eq!(first.text_item_indices, vec![0, 1]);
+    }
+
+    #[test]
+    fn list_continuation_extends_item_indices() {
+        let p = page(vec![
+            tag(line("Intro line.", 50.0, 50.0, 10.0, 10.0), 0),
+            tag(line("• bullet starts here and", 60.0, 80.0, 10.0, 10.0), 1),
+            tag(line("wraps onto a second line", 60.0, 92.0, 10.0, 10.0), 2),
+        ]);
+        let pages = vec![p];
+        let body = compute_body_size(&pages);
+        let map = build_heading_map(&pages, body);
+        let blocks = classify_page(&pages[0], &map);
+        let item = blocks
+            .iter()
+            .find(|b| matches!(b.block, Block::ListItem { .. }))
+            .expect("expected a list item");
+        assert_eq!(item.text_item_indices, vec![1, 2]);
+    }
+
+    #[test]
+    fn stitch_regions_unions_indices_across_leaves() {
+        // Two xy_cut leaves: the paragraph's tail lands in the second leaf.
+        // The stitcher fuses them (prev ends open, next starts lowercase) and
+        // must union the provenance along with the text/bbox.
+        let mut a = tag(line("The sentence continues without", 50.0, 700.0, 10.0, 10.0), 0);
+        a.region_path = vec![0];
+        let mut b = tag(line("ending punctuation here.", 320.0, 50.0, 10.0, 10.0), 1);
+        b.region_path = vec![1];
+        let p = page(vec![a, b]);
+        let blocks = classify_page(&p, &[]);
+        assert_eq!(blocks.len(), 1, "expected a single stitched paragraph");
+        assert_eq!(blocks[0].text_item_indices, vec![0, 1]);
     }
 }

--- a/crates/liteparse/src/markdown_layout/classify.rs
+++ b/crates/liteparse/src/markdown_layout/classify.rs
@@ -234,7 +234,11 @@ pub fn classify_page_with_filters(
             .iter()
             .map(|&i| lines[i].bbox.y)
             .fold(f32::INFINITY, f32::min);
-        global_ruled_tables.push((top_y, PositionedBlock::new(run.block, run.bbox, Vec::new())));
+        let block_indices = run.block_item_indices();
+        global_ruled_tables.push((
+            top_y,
+            PositionedBlock::new(run.block, run.bbox, block_indices),
+        ));
         global_ruled_consumed.extend(consumed);
     }
     let global_ruled_owned: Option<Vec<ProjectedLine>> = if global_ruled_consumed.is_empty() {
@@ -570,7 +574,8 @@ fn classify_region(
             state.flush_code(&mut blocks);
             state.reset_list();
             let run = table_iter.next().unwrap();
-            blocks.push(PositionedBlock::new(run.block, run.bbox, Vec::new()));
+            let block_indices = run.block_item_indices();
+            blocks.push(PositionedBlock::new(run.block, run.bbox, block_indices));
             idx = run.end;
             continue;
         }

--- a/crates/liteparse/src/markdown_layout/classify.rs
+++ b/crates/liteparse/src/markdown_layout/classify.rs
@@ -234,7 +234,7 @@ pub fn classify_page_with_filters(
             .iter()
             .map(|&i| lines[i].bbox.y)
             .fold(f32::INFINITY, f32::min);
-        global_ruled_tables.push((top_y, PositionedBlock::new(run.block, run.bbox)));
+        global_ruled_tables.push((top_y, PositionedBlock::new(run.block, run.bbox, Vec::new())));
         global_ruled_consumed.extend(consumed);
     }
     let global_ruled_owned: Option<Vec<ProjectedLine>> = if global_ruled_consumed.is_empty() {
@@ -405,13 +405,14 @@ pub fn classify_page_with_filters(
 /// stay identical.
 fn positioned_interruption(kind: Interruption) -> PositionedBlock {
     match kind {
-        Interruption::Hr(rect) => PositionedBlock::new(Block::HorizontalRule, Some(rect)),
+        Interruption::Hr(rect) => PositionedBlock::new(Block::HorizontalRule, Some(rect), Vec::new()),
         Interruption::Figure(r) => PositionedBlock::new(
             Block::Figure {
                 id: r.id,
                 format: r.format,
             },
             Some(r.bbox),
+            Vec::new(),
         ),
         Interruption::Table(b) => b,
     }
@@ -446,7 +447,7 @@ impl FlowState {
             && !acc.raw.trim().is_empty()
         {
             let bbox = acc.bbox.clone();
-            blocks.push(PositionedBlock::new(paragraph_from_accum(acc), bbox));
+            blocks.push(PositionedBlock::new(paragraph_from_accum(acc), bbox, Vec::new()));
         }
     }
 
@@ -456,7 +457,7 @@ impl FlowState {
             && !lines.is_empty()
         {
             let lang = detect_code_language(&lines);
-            blocks.push(PositionedBlock::new(Block::CodeBlock { lines, lang }, bbox));
+            blocks.push(PositionedBlock::new(Block::CodeBlock { lines, lang }, bbox, Vec::new()));
         }
     }
 
@@ -568,7 +569,7 @@ fn classify_region(
             state.flush_code(&mut blocks);
             state.reset_list();
             let run = table_iter.next().unwrap();
-            blocks.push(PositionedBlock::new(run.block, run.bbox));
+            blocks.push(PositionedBlock::new(run.block, run.bbox, Vec::new()));
             idx = run.end;
             continue;
         }
@@ -625,6 +626,7 @@ fn classify_region(
                 blocks.push(PositionedBlock::new(
                     Block::HorizontalRule,
                     Some(line.bbox.clone()),
+                    Vec::new(),
                 ));
             }
             if debug {
@@ -854,6 +856,7 @@ fn classify_region(
                         text: collapse_whitespace(text),
                     },
                     Some(line.bbox.clone()),
+                    Vec::new(),
                 ));
                 heading_run = Some((level, line_idx));
                 continue;
@@ -902,6 +905,7 @@ fn classify_region(
                         text: collapse_whitespace(text),
                     },
                     Some(line.bbox.clone()),
+                    Vec::new(),
                 ));
                 continue;
             }
@@ -928,6 +932,7 @@ fn classify_region(
                     italic: false,
                 },
                 Some(line.bbox.clone()),
+                Vec::new(),
             ));
             continue;
         }
@@ -987,6 +992,7 @@ fn classify_region(
                     text: collapse_whitespace(text),
                 },
                 Some(line.bbox.clone()),
+                Vec::new(),
             ));
             // Arm the heading_run so a wrapped continuation on the next line
             // merges into this heading instead of emitting as a second one.

--- a/crates/liteparse/src/markdown_layout/cross_region.rs
+++ b/crates/liteparse/src/markdown_layout/cross_region.rs
@@ -281,13 +281,29 @@ fn fuse_cluster(cluster: &Cluster, path: &[u16]) -> ProjectedLine {
     }
     // Sort spans by x together with their source indices — sorting the two
     // vectors independently would silently break the positional alignment.
-    let mut zipped: Vec<(TextItem, usize)> = fused
-        .spans
-        .drain(..)
-        .zip(fused.span_item_indices.drain(..))
-        .collect();
-    zipped.sort_by(|a, b| a.0.x.total_cmp(&b.0.x));
-    (fused.spans, fused.span_item_indices) = zipped.into_iter().unzip();
+    // Guard the zip on equal lengths first: zip truncates to the shorter
+    // vector, so a misaligned line fed through here would silently DROP
+    // spans — table cell text, not just provenance. Every other consumer
+    // degrades to unattributed spans via `.get(i)` (text fidelity outranks
+    // provenance); mirror that policy here.
+    if fused.spans.len() == fused.span_item_indices.len() {
+        let mut zipped: Vec<(TextItem, usize)> = fused
+            .spans
+            .drain(..)
+            .zip(fused.span_item_indices.drain(..))
+            .collect();
+        zipped.sort_by(|a, b| a.0.x.total_cmp(&b.0.x));
+        (fused.spans, fused.span_item_indices) = zipped.into_iter().unzip();
+    } else {
+        debug_assert!(
+            false,
+            "fuse_cluster: spans/span_item_indices length mismatch ({} vs {})",
+            fused.spans.len(),
+            fused.span_item_indices.len()
+        );
+        fused.span_item_indices.clear();
+        fused.spans.sort_by(|a, b| a.x.total_cmp(&b.x));
+    }
     fused
 }
 

--- a/crates/liteparse/src/markdown_layout/cross_region.rs
+++ b/crates/liteparse/src/markdown_layout/cross_region.rs
@@ -470,6 +470,7 @@ fn try_two_col_direct(clusters: &[Cluster], merged_len: usize, tol: f32) -> Opti
         body_start: if header.is_some() { 1 } else { 0 },
         bbox,
         block: Block::Table { header, rows: body },
+        block_indices: Vec::new(),
     }])
 }
 

--- a/crates/liteparse/src/markdown_layout/cross_region.rs
+++ b/crates/liteparse/src/markdown_layout/cross_region.rs
@@ -12,7 +12,7 @@
 
 use super::blocks::{Block, Cell};
 use super::tables::{TableRun, detect_tables};
-use crate::types::{ProjectedLine, Rect};
+use crate::types::{ProjectedLine, Rect, TextItem};
 
 /// Union of the boxes of every line in `lines`, or `None` when empty.
 fn union_line_rects(lines: &[&ProjectedLine]) -> Option<Rect> {
@@ -264,6 +264,9 @@ fn fuse_cluster(cluster: &Cluster, path: &[u16]) -> ProjectedLine {
         fused.text.push_str(&" ".repeat(n_spaces));
         fused.text.push_str(&m.text);
         fused.spans.extend(m.spans.iter().cloned());
+        fused
+            .span_item_indices
+            .extend(m.span_item_indices.iter().copied());
         let x1 = (fused.bbox.x + fused.bbox.width).max(m.bbox.x + m.bbox.width);
         let y1 = (fused.bbox.y + fused.bbox.height).max(m.bbox.y + m.bbox.height);
         fused.bbox.x = fused.bbox.x.min(m.bbox.x);
@@ -276,7 +279,15 @@ fn fuse_cluster(cluster: &Cluster, path: &[u16]) -> ProjectedLine {
         fused.all_strike &= m.all_strike;
         fused.font_size_is_estimated |= m.font_size_is_estimated;
     }
-    fused.spans.sort_by(|a, b| a.x.total_cmp(&b.x));
+    // Sort spans by x together with their source indices — sorting the two
+    // vectors independently would silently break the positional alignment.
+    let mut zipped: Vec<(TextItem, usize)> = fused
+        .spans
+        .drain(..)
+        .zip(fused.span_item_indices.drain(..))
+        .collect();
+    zipped.sort_by(|a, b| a.0.x.total_cmp(&b.0.x));
+    (fused.spans, fused.span_item_indices) = zipped.into_iter().unzip();
     fused
 }
 
@@ -708,6 +719,53 @@ mod tests {
         assert!(m.merged[0].text.contains("MANILA"));
         assert!(m.merged[0].text.contains("2454"));
         assert!(m.merged[0].text.contains("6125"));
+    }
+
+    /// Fusion must keep `span_item_indices` positionally aligned with
+    /// `spans` — the fused spans are re-sorted by x, so sorting the two
+    /// vectors independently would scramble the pairing. Give every span a
+    /// globally distinct source index and check each fused span still sits
+    /// beside the index of its own source item.
+    #[test]
+    fn fused_lines_keep_span_item_indices_aligned() {
+        let mut lines = Vec::new();
+        let mut source_texts: Vec<String> = Vec::new();
+        // Left leaf: row labels (one span each).
+        for (i, label) in ["MANILA", "CEBU", "CAGAYAN DE ORO", "SUBIC"]
+            .iter()
+            .enumerate()
+        {
+            let y = 100.0 + i as f32 * 20.0;
+            let mut l = at_region(line_with_spans(&[(label, 50.0)], y, 10.0), &[0, 0]);
+            l.span_item_indices = vec![source_texts.len()];
+            source_texts.push((*label).into());
+            lines.push(l);
+        }
+        // Right leaf: two numeric columns per row (two spans each).
+        for (i, (a, b)) in [
+            ("2454", "6125"),
+            ("1138", "79500"),
+            ("958", "13196"),
+            ("313", "136"),
+        ]
+        .iter()
+        .enumerate()
+        {
+            let y = 100.0 + i as f32 * 20.0;
+            let mut l = at_region(line_with_spans(&[(a, 200.0), (b, 280.0)], y, 10.0), &[0, 1]);
+            l.span_item_indices = vec![source_texts.len(), source_texts.len() + 1];
+            source_texts.push((*a).into());
+            source_texts.push((*b).into());
+            lines.push(l);
+        }
+        let m = find_cross_region_table_merge(&lines).expect("should merge");
+        assert_eq!(m.merged.len(), 4);
+        for fused in &m.merged {
+            assert_eq!(fused.spans.len(), fused.span_item_indices.len());
+            for (span, &idx) in fused.spans.iter().zip(&fused.span_item_indices) {
+                assert_eq!(source_texts[idx], span.text);
+            }
+        }
     }
 
     /// Two side-by-side prose columns with coincidentally aligned baselines

--- a/crates/liteparse/src/markdown_layout/cross_region.rs
+++ b/crates/liteparse/src/markdown_layout/cross_region.rs
@@ -371,12 +371,18 @@ fn try_two_col_direct(clusters: &[Cluster], merged_len: usize, tol: f32) -> Opti
                 _ => false,
             };
             let left_rect = union_line_rects(&cluster.left);
+            let left_indices: Vec<usize> = cluster
+                .left
+                .iter()
+                .flat_map(|l| l.span_item_indices.iter().copied())
+                .collect();
             if wraps {
                 let row = rows.last_mut().unwrap();
                 if !row.0.text.is_empty() {
                     row.0.text.push(' ');
                 }
                 row.0.text.push_str(&text);
+                row.0.add_indices(left_indices);
                 if let Some(r) = &left_rect {
                     Rect::extend(&mut row.0.bbox, r);
                 }
@@ -386,7 +392,7 @@ fn try_two_col_direct(clusters: &[Cluster], merged_len: usize, tol: f32) -> Opti
                     Cell {
                         text,
                         bbox: left_rect,
-                        text_item_indices: Vec::new(),
+                        text_item_indices: left_indices,
                     },
                     Cell::default(),
                     bold,
@@ -409,6 +415,12 @@ fn try_two_col_direct(clusters: &[Cluster], merged_len: usize, tol: f32) -> Opti
                 row.1.text.push(' ');
             }
             row.1.text.push_str(&text);
+            row.1.add_indices(
+                cluster
+                    .right
+                    .iter()
+                    .flat_map(|l| l.span_item_indices.iter().copied()),
+            );
             if let Some(r) = &union_line_rects(&cluster.right) {
                 Rect::extend(&mut row.1.bbox, r);
             }

--- a/crates/liteparse/src/markdown_layout/cross_region.rs
+++ b/crates/liteparse/src/markdown_layout/cross_region.rs
@@ -386,6 +386,7 @@ fn try_two_col_direct(clusters: &[Cluster], merged_len: usize, tol: f32) -> Opti
                     Cell {
                         text,
                         bbox: left_rect,
+                        text_item_indices: Vec::new(),
                     },
                     Cell::default(),
                     bold,

--- a/crates/liteparse/src/markdown_layout/paragraphs.rs
+++ b/crates/liteparse/src/markdown_layout/paragraphs.rs
@@ -269,6 +269,10 @@ pub(super) struct ParaAccum {
     /// Union of every line folded into this paragraph, so the emitted block
     /// reports the whole band it covers rather than its last line.
     pub(super) bbox: Option<crate::types::Rect>,
+    /// Source-item indices of every line folded into this paragraph, in
+    /// insertion (reading) order — the returned-text-items contract of
+    /// `ProjectedLine::span_item_indices`. Grown exactly where `bbox` grows.
+    pub(super) item_indices: Vec<usize>,
 }
 
 /// Append `next_line` to a paragraph accumulator. Maintains both the `raw` and
@@ -287,6 +291,9 @@ pub(super) fn append_to_paragraph(accum: &mut ParaAccum, next_line: &ProjectedLi
     let next_uniform: Option<SpanStyle> = line_uniform_style(next_line).filter(|s| !s.strike);
 
     crate::types::Rect::extend(&mut accum.bbox, &next_line.bbox);
+    accum
+        .item_indices
+        .extend(next_line.span_item_indices.iter().copied());
 
     if accum.raw.is_empty() {
         accum.raw.push_str(&next_raw);

--- a/crates/liteparse/src/markdown_layout/tables.rs
+++ b/crates/liteparse/src/markdown_layout/tables.rs
@@ -90,6 +90,13 @@ pub(super) struct SpanPiece<'a> {
     /// were verified to reconstruct `text` exactly. Empty otherwise, so a
     /// consumer can treat non-empty as "real geometry for every word here".
     pub(super) words: Vec<&'a crate::types::WordBox>,
+    /// Index of the run's source item in the page's *returned* `text_items`
+    /// array (the `ProjectedLine::span_item_indices` contract). Stamped by
+    /// `line_pieces` from the owning line; `None` when the piece was built
+    /// without line context (or the line's index vector was misaligned, in
+    /// which case the piece degrades to carrying no attribution rather than
+    /// dropping the span).
+    pub(super) source_index: Option<usize>,
 }
 
 /// A run's own word boxes, in reading order, but only when they reconstruct the
@@ -145,6 +152,7 @@ pub(super) fn split_span_at_gutters(span: &TextItem) -> Vec<SpanPiece<'_>> {
             text: collapse_whitespace(span.text.trim()),
             span,
             words: words.clone(),
+            source_index: None,
         }]
     };
     // Two words give exactly one gap, which is trivially "the largest": no
@@ -223,18 +231,27 @@ fn piece_from_words<'a>(words: &[&'a crate::types::WordBox], span: &'a TextItem)
         ),
         span,
         words: words.to_vec(),
+        source_index: None,
     }
 }
 
 /// All column pieces on a line, left to right. This is the tabular view of a
 /// row: what PDFium calls a run is not what the page calls a cell.
 pub(super) fn line_pieces(line: &ProjectedLine) -> Vec<SpanPiece<'_>> {
-    let mut pieces: Vec<SpanPiece<'_>> = line
-        .spans
-        .iter()
-        .filter(|s| !s.text.trim().is_empty())
-        .flat_map(split_span_at_gutters)
-        .collect();
+    let mut pieces: Vec<SpanPiece<'_>> = Vec::new();
+    for (i, s) in line.spans.iter().enumerate() {
+        if s.text.trim().is_empty() {
+            continue;
+        }
+        // Positional zip with the aligned index vector. `.get` so a length
+        // mismatch degrades to an unattributed piece instead of dropping the
+        // span (or panicking) — text fidelity outranks provenance.
+        let source_index = line.span_item_indices.get(i).copied();
+        for mut piece in split_span_at_gutters(s) {
+            piece.source_index = source_index;
+            pieces.push(piece);
+        }
+    }
     pieces.sort_by(|a, b| a.x.total_cmp(&b.x));
     pieces
 }
@@ -258,6 +275,12 @@ pub(super) struct TableCell {
     pub(super) end_x: f32,
     pub(super) text: String,
     pub(super) bold: bool,
+    /// Source-item indices of the spans/pieces aggregated into this cell, in
+    /// insertion (reading) order — the returned-text-items contract of
+    /// `ProjectedLine::span_item_indices`. A piece split across tracks
+    /// duplicates its index into each receiving cell; padding cells carry
+    /// none.
+    pub(super) text_item_indices: Vec<usize>,
 }
 
 /// A contiguous tabular run: line indices `[start, end)` plus the detected
@@ -277,6 +300,37 @@ pub(super) struct TableRun {
     /// consumed. `None` when the run was built without geometry (tests, and
     /// synthetic merges with nothing to measure).
     pub(super) bbox: Option<Rect>,
+    /// Block-level source-item indices for runs whose block does NOT carry
+    /// cells (`GridFallback`): the union of the consumed lines' indices.
+    /// Empty for `Table` runs — their block indices derive from the cells via
+    /// [`TableRun::block_item_indices`], so there is no second copy to fall
+    /// out of sync.
+    pub(super) block_indices: Vec<usize>,
+}
+
+impl TableRun {
+    /// Source-item indices the emitted block should carry: for `Table`, the
+    /// concatenation of every header/body cell's indices (dedup happens at
+    /// the public-DTO conversion); otherwise the run-carried union.
+    pub(super) fn block_item_indices(&self) -> Vec<usize> {
+        match &self.block {
+            Block::Table { header, rows } => {
+                let mut out: Vec<usize> = Vec::new();
+                if let Some(h) = header {
+                    for c in h {
+                        out.extend_from_slice(&c.text_item_indices);
+                    }
+                }
+                for row in rows {
+                    for c in row {
+                        out.extend_from_slice(&c.text_item_indices);
+                    }
+                }
+                out
+            }
+            _ => self.block_indices.clone(),
+        }
+    }
 }
 
 /// Union of the boxes of `lines[start..end]` — the region a table run covers
@@ -302,9 +356,14 @@ fn cell_rect(cell: &TableCell, line: &ProjectedLine) -> Rect {
     }
 }
 
-/// Build a located `Cell` from a `TableCell` and its owning line.
+/// Build a located `Cell` from a `TableCell` and its owning line, carrying
+/// the cell's source-item attribution.
 fn located_cell(cell: &TableCell, line: &ProjectedLine) -> Cell {
-    Cell::located(cell.text.clone(), cell_rect(cell, line))
+    Cell::located_with(
+        cell.text.clone(),
+        cell_rect(cell, line),
+        cell.text_item_indices.clone(),
+    )
 }
 
 /// Split a `ProjectedLine`'s spans into cells. A gap larger than
@@ -312,13 +371,18 @@ fn located_cell(cell: &TableCell, line: &ProjectedLine) -> Cell {
 /// a new cell; otherwise spans join into the same cell with a single space.
 pub(super) fn split_cells(line: &ProjectedLine) -> Vec<TableCell> {
     // Skip whitespace-only spans before computing gaps — leading/trailing
-    // empty items would otherwise add spurious cell boundaries.
-    let mut spans: Vec<&TextItem> = line
+    // empty items would otherwise add spurious cell boundaries. Each span is
+    // paired with its source-item index (positional zip, `.get` so a
+    // misaligned index vector degrades to unattributed spans, never dropped
+    // ones).
+    let mut spans: Vec<(&TextItem, Option<usize>)> = line
         .spans
         .iter()
-        .filter(|s| !s.text.trim().is_empty())
+        .enumerate()
+        .filter(|(_, s)| !s.text.trim().is_empty())
+        .map(|(i, s)| (s, line.span_item_indices.get(i).copied()))
         .collect();
-    spans.sort_by(|a, b| a.x.total_cmp(&b.x));
+    spans.sort_by(|a, b| a.0.x.total_cmp(&b.0.x));
     if spans.is_empty() {
         return Vec::new();
     }
@@ -331,12 +395,13 @@ pub(super) fn split_cells(line: &ProjectedLine) -> Vec<TableCell> {
 
     let mut cells: Vec<TableCell> = Vec::new();
     let mut current_text = String::new();
-    let mut current_start = spans[0].x;
+    let mut current_start = spans[0].0.x;
     let mut current_bold_chars: usize = 0;
     let mut current_total_chars: usize = 0;
-    let mut prev_right = spans[0].x;
+    let mut current_indices: Vec<usize> = Vec::new();
+    let mut prev_right = spans[0].0.x;
 
-    for (i, span) in spans.iter().enumerate() {
+    for (i, (span, source_index)) in spans.iter().enumerate() {
         let gap = span.x - prev_right;
         let break_cell = i > 0 && gap > gap_threshold;
         if break_cell {
@@ -346,6 +411,7 @@ pub(super) fn split_cells(line: &ProjectedLine) -> Vec<TableCell> {
                 end_x: prev_right,
                 text: collapse_whitespace(current_text.trim()),
                 bold,
+                text_item_indices: std::mem::take(&mut current_indices),
             });
             current_text.clear();
             current_start = span.x;
@@ -356,6 +422,9 @@ pub(super) fn split_cells(line: &ProjectedLine) -> Vec<TableCell> {
             current_text.push(' ');
         }
         current_text.push_str(&span.text);
+        if let Some(idx) = source_index {
+            current_indices.push(*idx);
+        }
         let n = span.text.chars().count();
         current_total_chars += n;
         if is_bold_item(span) {
@@ -370,6 +439,7 @@ pub(super) fn split_cells(line: &ProjectedLine) -> Vec<TableCell> {
             end_x: prev_right,
             text: collapse_whitespace(current_text.trim()),
             bold,
+            text_item_indices: current_indices,
         });
     }
     cells
@@ -441,6 +511,10 @@ fn recover_merged_cell(mut cells: Vec<TableCell>, tracks: &[f32]) -> Option<Vec<
                 end_x,
                 text: piece.clone(),
                 bold: cell.bold,
+                // The split position inside a merged span is an estimate, so
+                // each derived cell attributes to the full source set of the
+                // cell it was carved from.
+                text_item_indices: cell.text_item_indices.clone(),
             });
         }
         cells.remove(i);
@@ -677,6 +751,7 @@ fn cells_from_pieces(
             end_x: t,
             text: String::new(),
             bold: false,
+            text_item_indices: Vec::new(),
         })
         .collect();
     let push_text = |dst: &mut String, src: &str| {
@@ -716,6 +791,9 @@ fn cells_from_pieces(
                 let idx = covered[0];
                 push_text(&mut cells[idx].text, &span.text);
                 cells[idx].end_x = cells[idx].end_x.max(x1);
+                if let Some(si) = span.source_index {
+                    cells[idx].text_item_indices.push(si);
+                }
                 if is_bold_item(span.span) {
                     cells[idx].bold = true;
                 }
@@ -733,6 +811,12 @@ fn cells_from_pieces(
                         return None;
                     }
                     push_text(&mut cells[*idx].text, piece);
+                    // A piece split across tracks attributes its source item
+                    // to every receiving cell — word-anchored and
+                    // char-estimate splits alike.
+                    if let Some(si) = span.source_index {
+                        cells[*idx].text_item_indices.push(si);
+                    }
                     if bold {
                         cells[*idx].bold = true;
                     }
@@ -967,6 +1051,7 @@ fn finalize_table_run(
             header,
             rows: body_rows,
         },
+        block_indices: Vec::new(),
     })
 }
 
@@ -1324,6 +1409,7 @@ fn try_detect_table(lines: &[ProjectedLine], start_idx: usize, floor: usize) -> 
                             end_x: tracks[i],
                             text: String::new(),
                             bold: false,
+                            text_item_indices: Vec::new(),
                         })
                         .collect();
                     for (c, &idx) in cells.iter().zip(&mapping) {
@@ -1343,6 +1429,9 @@ fn try_detect_table(lines: &[ProjectedLine], start_idx: usize, floor: usize) -> 
                         prev_cells[idx].text.push(' ');
                     }
                     prev_cells[idx].text.push_str(&c.text);
+                    prev_cells[idx]
+                        .text_item_indices
+                        .extend(c.text_item_indices.iter().copied());
                 }
                 j += 1;
                 continue;
@@ -1413,12 +1502,19 @@ fn try_detect_table(lines: &[ProjectedLine], start_idx: usize, floor: usize) -> 
             .iter()
             .map(|(_, line, _)| line.text.trim_end().to_string())
             .collect();
+        // Block-level provenance only: the fallback renders the raw line
+        // text, so it attributes to exactly the lines it displays.
+        let block_indices: Vec<usize> = rows
+            .iter()
+            .flat_map(|(_, line, _)| line.span_item_indices.iter().copied())
+            .collect();
         return Some(TableRun {
             start: start_idx,
             end,
             body_start: start_idx,
             bbox: lines_bbox(lines, start_idx, end),
             block: Block::GridFallback { lines: raw },
+            block_indices,
         });
     }
 
@@ -1532,6 +1628,7 @@ fn absorb_header_lines(
                 header[idx].text.push(' ');
             }
             header[idx].text.push_str(&c.text);
+            header[idx].add_indices(c.text_item_indices.iter().copied());
             Rect::extend(&mut header[idx].bbox, &cell_rect(c, &lines[*line_idx]));
         }
     }
@@ -2060,8 +2157,9 @@ fn try_detect_description_list(lines: &[ProjectedLine], start_idx: usize) -> Opt
                     tail.text.push_str(&cell.text);
                     // The wrapped continuation is part of the same logical
                     // cell, so it grows that cell's box rather than starting a
-                    // new one.
+                    // new one — and extends its provenance likewise.
                     Rect::extend(&mut tail.bbox, &cell_rect(cell, &lines[j]));
+                    tail.add_indices(cell.text_item_indices.iter().copied());
                     j += 1;
                     continue;
                 }
@@ -2075,8 +2173,13 @@ fn try_detect_description_list(lines: &[ProjectedLine], start_idx: usize) -> Opt
                 {
                     // Split position is a linear estimate inside one merged
                     // span, not an observed boundary — the halves carry text
-                    // only rather than a fabricated rect.
-                    rows.push((j, left.into(), right.into()));
+                    // only rather than a fabricated rect. BOTH halves
+                    // attribute to the single merged span's source items.
+                    let mut lcell: Cell = left.into();
+                    lcell.add_indices(cell.text_item_indices.iter().copied());
+                    let mut rcell: Cell = right.into();
+                    rcell.add_indices(cell.text_item_indices.iter().copied());
+                    rows.push((j, lcell, rcell));
                     j += 1;
                     continue;
                 }
@@ -2141,6 +2244,7 @@ fn try_detect_description_list(lines: &[ProjectedLine], start_idx: usize) -> Opt
             header: None,
             rows: body,
         },
+        block_indices: Vec::new(),
     })
 }
 
@@ -2708,6 +2812,7 @@ fn build_union_table(
         body_start: window_start,
         bbox: lines_bbox(lines, start, window_end),
         block: Block::Table { header, rows },
+        block_indices: Vec::new(),
     })
 }
 
@@ -2944,6 +3049,7 @@ fn try_merge_pair(a: &TableRun, b: &TableRun, lines: &[ProjectedLine]) -> Option
             // between them.
             bbox: lines_bbox(lines, a.start, b.end),
             block: Block::Table { header, rows },
+            block_indices: Vec::new(),
         });
     }
 
@@ -3011,6 +3117,7 @@ fn try_merge_pair(a: &TableRun, b: &TableRun, lines: &[ProjectedLine]) -> Option
                 header: Some(merged_header),
                 rows: merged_rows,
             },
+            block_indices: Vec::new(),
         });
     }
 
@@ -4535,6 +4642,7 @@ fn build_ruled_table_from(
                 header,
                 rows: body_rows,
             },
+            block_indices: Vec::new(),
         },
         consumed_indices,
         straddle_frac,
@@ -5001,10 +5109,12 @@ fn merge_continuation_rows(rows: &mut Vec<Vec<Cell>>) {
                     prev[i].text.push(' ');
                     prev[i].text.push_str(t);
                     // The wrapped line is part of the same logical cell, so it
-                    // grows that cell's box down to cover the continuation.
+                    // grows that cell's box down to cover the continuation —
+                    // and extends its provenance the same way.
                     if let Some(r) = &cell.bbox {
                         Rect::extend(&mut prev[i].bbox, r);
                     }
+                    prev[i].add_indices(cell.text_item_indices.iter().copied());
                 }
                 continue;
             }
@@ -5536,12 +5646,14 @@ mod tests {
                 end_x: 160.0,
                 text: "MEMORYBANK 5.00".into(),
                 bold: false,
+                text_item_indices: vec![],
             },
             TableCell {
                 start_x: 250.0,
                 end_x: 280.0,
                 text: "4.77".into(),
                 bold: false,
+                text_item_indices: vec![],
             },
         ];
         let tracks = vec![50.0, 150.0, 250.0];
@@ -5562,12 +5674,14 @@ mod tests {
                 end_x: 260.0,
                 text: "MEMORYBANK 13.18 10.03".into(),
                 bold: false,
+                text_item_indices: vec![],
             },
             TableCell {
                 start_x: 350.0,
                 end_x: 380.0,
                 text: "7.61".into(),
                 bold: false,
+                text_item_indices: vec![],
             },
         ];
         let tracks = vec![50.0, 150.0, 250.0, 350.0];
@@ -5588,6 +5702,7 @@ mod tests {
             end_x: 200.0,
             text: "ABC-DEF-GHI".into(),
             bold: false,
+                text_item_indices: vec![],
         }];
         let tracks = vec![50.0, 150.0];
         assert!(recover_merged_cell(row, &tracks).is_none());
@@ -5821,6 +5936,110 @@ mod tests {
     }
 
     #[test]
+    fn borderless_table_cells_carry_source_item_indices() {
+        // Same shape as the span-extents test, but every span carries a
+        // globally distinct source-item index: cell (r, c) must attribute to
+        // exactly index r*3 + c.
+        let mut lines = vec![
+            line_with_spans(
+                &[("Name", 50.0), ("Qty", 150.0), ("Cost", 250.0)],
+                100.0,
+                10.0,
+            ),
+            line_with_spans(
+                &[("Bolt", 50.0), ("12", 150.0), ("3.50", 250.0)],
+                115.0,
+                10.0,
+            ),
+            line_with_spans(
+                &[("Nut", 50.0), ("40", 150.0), ("1.25", 250.0)],
+                130.0,
+                10.0,
+            ),
+        ];
+        for (r, l) in lines.iter_mut().enumerate() {
+            l.span_item_indices = (r * 3..r * 3 + 3).collect();
+        }
+        let runs = detect_tables(&lines);
+        assert_eq!(runs.len(), 1, "expected 1 borderless table, got {runs:?}");
+        let Block::Table { header, rows } = &runs[0].block else {
+            panic!("expected Block::Table");
+        };
+        assert!(header.is_none());
+        for (r, row) in rows.iter().enumerate() {
+            for (c, cell) in row.iter().enumerate() {
+                assert_eq!(
+                    cell.text_item_indices,
+                    vec![r * 3 + c],
+                    "cell ({r},{c}) '{}' mis-attributed",
+                    cell.text
+                );
+            }
+        }
+        // The run's block-level indices are the union of the cells'.
+        let mut block = runs[0].block_item_indices();
+        block.sort_unstable();
+        assert_eq!(block, (0..9).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn merged_span_split_duplicates_source_index_into_each_cell() {
+        // One span whose x-extent covers two tracks: the char-estimate split
+        // carves it into two cells, and BOTH cells attribute to the single
+        // source span.
+        let l = line_with_spans(&[("aaaaaaaaaa bbbbbbbbbb", 50.0)], 100.0, 10.0);
+        let pieces = line_pieces(&l);
+        assert_eq!(pieces.len(), 1);
+        assert_eq!(pieces[0].source_index, Some(0));
+        let cells =
+            cells_from_pieces(&pieces, &[50.0, 150.0], true).expect("split should succeed");
+        assert_eq!(cells.len(), 2);
+        assert_eq!(cells[0].text, "aaaaaaaaaa");
+        assert_eq!(cells[1].text, "bbbbbbbbbb");
+        assert_eq!(cells[0].text_item_indices, vec![0]);
+        assert_eq!(cells[1].text_item_indices, vec![0]);
+    }
+
+    #[test]
+    fn track_cells_without_content_carry_no_indices() {
+        // Three tracks, two pieces: the unpopulated track's cell stays empty
+        // of both text and attribution.
+        let l = line_with_spans(&[("alpha", 50.0), ("beta", 150.0)], 100.0, 10.0);
+        let pieces = line_pieces(&l);
+        let cells =
+            cells_from_pieces(&pieces, &[50.0, 150.0, 250.0], false).expect("bin should succeed");
+        assert_eq!(cells.len(), 3);
+        assert_eq!(cells[0].text_item_indices, vec![0]);
+        assert_eq!(cells[1].text_item_indices, vec![1]);
+        assert!(cells[2].text.is_empty());
+        assert!(cells[2].text_item_indices.is_empty());
+    }
+
+    #[test]
+    fn split_cells_groups_indices_with_their_cells() {
+        // Spans 0+1 sit close (one cell); span 2 is across a wide gap.
+        let l = line_with_spans(&[("a", 50.0), ("b", 58.0), ("c", 250.0)], 100.0, 10.0);
+        let cells = split_cells(&l);
+        assert_eq!(cells.len(), 2);
+        assert_eq!(cells[0].text_item_indices, vec![0, 1]);
+        assert_eq!(cells[1].text_item_indices, vec![2]);
+    }
+
+    #[test]
+    fn continuation_row_merge_folds_indices() {
+        let mut r = rows(&[
+            &["Knowledge", "To understand the meaning of reducing"],
+            &["", "and how they connect"],
+        ]);
+        r[0][0].text_item_indices = vec![0];
+        r[0][1].text_item_indices = vec![1];
+        r[1][1].text_item_indices = vec![2];
+        merge_continuation_rows(&mut r);
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0][1].text_item_indices, vec![1, 2]);
+    }
+
+    #[test]
     fn ruled_table_rect_borders_detected() {
         // Same 2×2 table but drawn as 4 individual cell rects (each cell is a
         // stroked rectangle). Each rect contributes 4 strokes via
@@ -5910,6 +6129,7 @@ mod tests {
             start: 5,
             end: 10,
             body_start: 5,
+            block_indices: vec![],
             bbox: None,
             block: Block::Table {
                 header: None,
@@ -5920,6 +6140,7 @@ mod tests {
             start: 6,
             end: 11,
             body_start: 6,
+            block_indices: vec![],
             bbox: None,
             block: Block::GridFallback {
                 lines: vec!["bl".into()],
@@ -5972,6 +6193,7 @@ mod tests {
             start: 0,
             end: 2,
             body_start: 0,
+            block_indices: vec![],
             bbox: None,
             block: Block::Table {
                 header: Some(vec!["A".into(), "B".into(), "C".into()]),
@@ -5982,6 +6204,7 @@ mod tests {
             start: 2,
             end: 5,
             body_start: 2,
+            block_indices: vec![],
             bbox: None,
             block: Block::Table {
                 header: None,
@@ -6022,6 +6245,7 @@ mod tests {
             start: 0,
             end: 2,
             body_start: 0,
+            block_indices: vec![],
             bbox: None,
             block: Block::Table {
                 header: None,
@@ -6035,6 +6259,7 @@ mod tests {
             start: 2,
             end: 5,
             body_start: 2,
+            block_indices: vec![],
             bbox: None,
             block: Block::Table {
                 header: None,
@@ -6076,6 +6301,7 @@ mod tests {
             start: 0,
             end: 2,
             body_start: 0,
+            block_indices: vec![],
             bbox: None,
             block: Block::Table {
                 header: Some(vec!["A".into(), "B".into(), "C".into()]),
@@ -6086,6 +6312,7 @@ mod tests {
             start: 2,
             end: 4,
             body_start: 2,
+            block_indices: vec![],
             bbox: None,
             block: Block::Table {
                 header: None,
@@ -6111,6 +6338,7 @@ mod tests {
             start: 0,
             end: 10,
             body_start: 0,
+            block_indices: vec![],
             bbox: None,
             block: Block::Table {
                 header: None,
@@ -6123,6 +6351,7 @@ mod tests {
             start: 10,
             end: 13,
             body_start: 10,
+            block_indices: vec![],
             bbox: None,
             block: Block::Table {
                 header: None,
@@ -6169,6 +6398,7 @@ mod tests {
             start: 0,
             end: 2,
             body_start: 0,
+            block_indices: vec![],
             bbox: None,
             block: Block::Table {
                 header: None,
@@ -6182,6 +6412,7 @@ mod tests {
             start: 2,
             end: 4,
             body_start: 2,
+            block_indices: vec![],
             bbox: None,
             block: Block::Table {
                 header: None,
@@ -6206,6 +6437,7 @@ mod tests {
             start: 0,
             end: 2,
             body_start: 0,
+            block_indices: vec![],
             bbox: None,
             block: Block::Table {
                 header: None,
@@ -6219,6 +6451,7 @@ mod tests {
             start: 2,
             end: 3,
             body_start: 2,
+            block_indices: vec![],
             bbox: None,
             block: Block::GridFallback {
                 lines: vec!["fallback".into()],
@@ -6252,6 +6485,7 @@ mod tests {
             start: 0,
             end: 2,
             body_start: 0,
+            block_indices: vec![],
             bbox: None,
             block: Block::Table {
                 header: Some(vec!["A".into(), "B".into(), "C".into()]),
@@ -6262,6 +6496,7 @@ mod tests {
             start: 3,
             end: 5,
             body_start: 3,
+            block_indices: vec![],
             bbox: None,
             block: Block::Table {
                 header: None,
@@ -6292,6 +6527,7 @@ mod tests {
             start: 0,
             end: 2,
             body_start: 0,
+            block_indices: vec![],
             bbox: None,
             block: Block::Table {
                 header: None,
@@ -6305,6 +6541,7 @@ mod tests {
             start: 3,
             end: 6,
             body_start: 3,
+            block_indices: vec![],
             bbox: None,
             block: Block::Table {
                 header: None,

--- a/crates/liteparse/src/markdown_layout/tables.rs
+++ b/crates/liteparse/src/markdown_layout/tables.rs
@@ -2604,17 +2604,19 @@ fn union_header_from_above(
         if !table_rows_adjacent(&lines[cand], &lines[j]) {
             break;
         }
-        let spans: Vec<&TextItem> = lines[cand]
+        let spans: Vec<(&TextItem, Option<usize>)> = lines[cand]
             .spans
             .iter()
-            .filter(|s| !s.text.trim().is_empty())
+            .enumerate()
+            .filter(|(_, s)| !s.text.trim().is_empty())
+            .map(|(i, s)| (s, lines[cand].span_item_indices.get(i).copied()))
             .collect();
         if spans.len() < 2 {
             break;
         }
         let mut layer = vec![Cell::default(); tracks.len()];
         let mut ok = true;
-        for s in &spans {
+        for (s, source_index) in &spans {
             let x0 = s.x;
             let x1 = s.x + s.width.max(0.0);
             let covered: Vec<usize> = tracks
@@ -2645,6 +2647,7 @@ fn union_header_from_above(
                     dst.text.push(' ');
                 }
                 dst.text.push_str(s.text.trim());
+                dst.add_indices(source_index.iter().copied());
                 Rect::extend(&mut dst.bbox, &span_rect);
             }
         }
@@ -2661,6 +2664,7 @@ fn union_header_from_above(
     let header: Vec<Cell> = (0..tracks.len())
         .map(|col| {
             let mut parts: Vec<&str> = Vec::new();
+            let mut indices: Vec<usize> = Vec::new();
             let mut bbox: Option<Rect> = None;
             for layer in &layers {
                 let s = layer[col].as_str();
@@ -2671,11 +2675,13 @@ fn union_header_from_above(
                     continue;
                 }
                 parts.push(s);
+                indices.extend(layer[col].text_item_indices.iter().copied());
             }
+            dedup_preserving_order(&mut indices);
             Cell {
                 text: parts.join(" "),
                 bbox,
-                text_item_indices: Vec::new(),
+                text_item_indices: indices,
             }
         })
         .collect();
@@ -2785,7 +2791,11 @@ fn build_union_table(
                 // Unbinnable line kept whole in column 0; it occupies the
                 // entire line, so that is the cell's box.
                 let mut row = vec![Cell::default(); tracks.len()];
-                row[0] = Cell::located(collapse_whitespace(text), line.bbox.clone());
+                row[0] = Cell::located_with(
+                    collapse_whitespace(text),
+                    line.bbox.clone(),
+                    line.span_item_indices.clone(),
+                );
                 rows.push(row);
             }
         }
@@ -2986,7 +2996,13 @@ fn try_merge_pair(a: &TableRun, b: &TableRun, lines: &[ProjectedLine]) -> Option
         }
         slice
             .iter()
-            .map(|l| Cell::located(l.text.trim().to_string(), l.bbox.clone()))
+            .map(|l| {
+                Cell::located_with(
+                    l.text.trim().to_string(),
+                    l.bbox.clone(),
+                    l.span_item_indices.clone(),
+                )
+            })
             .collect()
     };
     let (a_header, a_rows) = match &a.block {
@@ -3074,6 +3090,7 @@ fn try_merge_pair(a: &TableRun, b: &TableRun, lines: &[ProjectedLine]) -> Option
         let merged_header: Vec<Cell> = (0..b_cols)
             .map(|col| {
                 let mut parts: Vec<String> = Vec::new();
+                let mut indices: Vec<usize> = Vec::new();
                 let mut bbox: Option<Rect> = None;
                 for layer in &header_layers {
                     let Some(cell) = layer.get(col) else {
@@ -3090,11 +3107,13 @@ fn try_merge_pair(a: &TableRun, b: &TableRun, lines: &[ProjectedLine]) -> Option
                         continue;
                     }
                     parts.push(s.to_string());
+                    indices.extend(cell.text_item_indices.iter().copied());
                 }
+                dedup_preserving_order(&mut indices);
                 Cell {
                     text: parts.join(" "),
                     bbox,
-                    text_item_indices: Vec::new(),
+                    text_item_indices: indices,
                 }
             })
             .collect();
@@ -3465,6 +3484,11 @@ struct CellGrid {
     /// centered over its sub-columns must replicate, while the same geometry in
     /// a data row is a merged run that should split.
     repl: Vec<Vec<String>>,
+    /// Source-item indices behind each `repl` cell, in the same push order.
+    /// A parallel layer (rather than a Cell) because `repl` is a plain text
+    /// grid; it filters through every retain in lockstep. The `text` layer
+    /// needs no twin — its cells carry their own indices.
+    repl_indices: Vec<Vec<Vec<usize>>>,
     /// Per-row flag: the row contains an alpha-dominant multi-column span (a
     /// group-header label, as opposed to a mostly-digit merged data run).
     row_alpha_spanner: Vec<bool>,
@@ -3508,6 +3532,7 @@ impl CellGrid {
             is_bold: vec![vec![true; n_cols]; n_rows],
             has_text: vec![vec![false; n_cols]; n_rows],
             repl: vec![vec![String::new(); n_cols]; n_rows],
+            repl_indices: vec![vec![Vec::new(); n_cols]; n_rows],
             row_alpha_spanner: vec![false; n_rows],
             spanned: vec![vec![false; n_cols]; n_rows],
             straddle_frac: 0.0,
@@ -3522,9 +3547,10 @@ impl CellGrid {
         self.text.first().map(|r| r.len()).unwrap_or(0)
     }
 
-    /// Append trimmed text to a cell, marking it as text-bearing. No-op for
-    /// blank input.
-    fn push_text(&mut self, row: usize, col: usize, txt: &str) {
+    /// Append trimmed text to a cell, marking it as text-bearing and
+    /// attributing the contributing source items. No-op for blank input (no
+    /// attribution either — provenance follows the text that actually landed).
+    fn push_text(&mut self, row: usize, col: usize, txt: &str, sources: &[usize]) {
         let txt = txt.trim();
         if txt.is_empty() {
             return;
@@ -3533,12 +3559,15 @@ impl CellGrid {
             self.text[row][col].text.push(' ');
         }
         self.text[row][col].text.push_str(txt);
+        self.text[row][col]
+            .text_item_indices
+            .extend_from_slice(sources);
         self.has_text[row][col] = true;
     }
 
     /// Append trimmed text to the colspan-semantics (`repl`) cell. No-op for
     /// blank input.
-    fn push_repl(&mut self, row: usize, col: usize, txt: &str) {
+    fn push_repl(&mut self, row: usize, col: usize, txt: &str, sources: &[usize]) {
         let txt = txt.trim();
         if txt.is_empty() {
             return;
@@ -3548,6 +3577,7 @@ impl CellGrid {
             dst.push(' ');
         }
         dst.push_str(txt);
+        self.repl_indices[row][col].extend_from_slice(sources);
     }
 
     /// Keep only rows `r` where `keep[r]`; every layer filters identically.
@@ -3556,6 +3586,7 @@ impl CellGrid {
         self.is_bold = filter_by(std::mem::take(&mut self.is_bold), keep);
         self.has_text = filter_by(std::mem::take(&mut self.has_text), keep);
         self.repl = filter_by(std::mem::take(&mut self.repl), keep);
+        self.repl_indices = filter_by(std::mem::take(&mut self.repl_indices), keep);
         self.row_alpha_spanner = filter_by(std::mem::take(&mut self.row_alpha_spanner), keep);
         self.spanned = filter_by(std::mem::take(&mut self.spanned), keep);
     }
@@ -3576,6 +3607,10 @@ impl CellGrid {
             .map(|row| filter_by(row, keep))
             .collect();
         self.repl = std::mem::take(&mut self.repl)
+            .into_iter()
+            .map(|row| filter_by(row, keep))
+            .collect();
+        self.repl_indices = std::mem::take(&mut self.repl_indices)
             .into_iter()
             .map(|row| filter_by(row, keep))
             .collect();
@@ -3727,19 +3762,23 @@ fn assign_cells(
             continue;
         }
 
-        let mut text_spans: Vec<&TextItem> = line
+        // Spans paired with their source-item indices (positional zip; `.get`
+        // so a misaligned index vector degrades to unattributed spans).
+        let mut text_spans: Vec<(&TextItem, Option<usize>)> = line
             .spans
             .iter()
-            .filter(|s| !s.text.trim().is_empty())
+            .enumerate()
+            .filter(|(_, s)| !s.text.trim().is_empty())
+            .map(|(i, s)| (s, line.span_item_indices.get(i).copied()))
             .collect();
-        text_spans.sort_by(|a, b| a.x.total_cmp(&b.x));
+        text_spans.sort_by(|a, b| a.0.x.total_cmp(&b.0.x));
 
         if text_spans.is_empty() {
             // No raw text spans (synthetic/OCR lines): old whole-line centroid path.
             let cx = line.bbox.x + line.bbox.width * 0.5;
             if let Some(col) = find_bucket(xs, cx.clamp(xs[0], xs[n_cols])) {
-                grid.push_text(row, col, &line.text);
-                grid.push_repl(row, col, &line.text);
+                grid.push_text(row, col, &line.text, &line.span_item_indices);
+                grid.push_repl(row, col, &line.text, &line.span_item_indices);
                 if !line.all_bold {
                     grid.is_bold[row][col] = false;
                 }
@@ -3748,7 +3787,11 @@ fn assign_cells(
             continue;
         }
 
-        for span in text_spans {
+        for (span, source_index) in text_spans {
+            // One-element source slice for the push helpers; empty when the
+            // span carries no attribution.
+            let src_buf: Vec<usize> = source_index.into_iter().collect();
+            let srcs: &[usize] = &src_buf;
             // Per-span row: a span carries its own baseline y, which may sit
             // in a different ruled row than the line centroid.
             let span_cy = span.y + span.height * 0.5;
@@ -3766,8 +3809,8 @@ fn assign_cells(
                 }
             }
             if c_lo == c_hi {
-                grid.push_text(row, c_lo, &span.text);
-                grid.push_repl(row, c_lo, &span.text);
+                grid.push_text(row, c_lo, &span.text, srcs);
+                grid.push_repl(row, c_lo, &span.text, srcs);
                 if !line.all_bold {
                     grid.is_bold[row][c_lo] = false;
                 }
@@ -3778,7 +3821,7 @@ fn assign_cells(
             // label is alpha-dominant (group headers are words; merged data
             // runs are mostly digits).
             for col in c_lo..=c_hi {
-                grid.push_repl(row, col, &span.text);
+                grid.push_repl(row, col, &span.text, srcs);
             }
             if is_alpha_dominant(&span.text) {
                 grid.row_alpha_spanner[row] = true;
@@ -3793,14 +3836,16 @@ fn assign_cells(
             // font it can cut a word or two off from the true boundary.
             if let Some(by_word) = bucket_words_into_columns(span, xs) {
                 for (col, text) in by_word {
-                    grid.push_text(row, col, &text);
+                    // A straddling span attributes its source item to every
+                    // cell that receives a fragment of it.
+                    grid.push_text(row, col, &text, srcs);
                     if !line.all_bold {
                         grid.is_bold[row][col] = false;
                     }
                 }
             } else if let Some(pieces) = split_span_at_anchors(span, &covered, xs) {
                 for (k, piece) in pieces.iter().enumerate() {
-                    grid.push_text(row, c_lo + k, piece);
+                    grid.push_text(row, c_lo + k, piece, srcs);
                     if !line.all_bold {
                         grid.is_bold[row][c_lo + k] = false;
                     }
@@ -3809,7 +3854,7 @@ fn assign_cells(
                 // No whitespace to split on — assign whole span by center.
                 let cx = (span.x + span.width * 0.5).clamp(xs[0], xs[n_cols]);
                 if let Some(col) = find_bucket(xs, cx) {
-                    grid.push_text(row, col, &span.text);
+                    grid.push_text(row, col, &span.text, srcs);
                     if !line.all_bold {
                         grid.is_bold[row][col] = false;
                     }
@@ -3852,10 +3897,12 @@ fn assign_cells(
 /// top-to-bottom join), so each column carries its full layer chain ("North
 /// America Revenue") — that chain is what header-keyed consumers (and readers)
 /// need. Returns `(header_row, body_start)` or `None`.
+#[allow(clippy::too_many_arguments)]
 fn flatten_header_band(
     cells: &[Vec<Cell>],
     cell_has_text: &[Vec<bool>],
     cells_repl: &[Vec<String>],
+    cells_repl_indices: &[Vec<Vec<usize>>],
     row_alpha_spanner: &[bool],
     n_rows: usize,
     n_cols: usize,
@@ -3892,13 +3939,22 @@ fn flatten_header_band(
             let header: Vec<Cell> = (0..n_cols)
                 .map(|c| {
                     let mut parts: Vec<&str> = Vec::new();
-                    for row in cells_repl.iter().take(b + 1) {
+                    let mut indices: Vec<usize> = Vec::new();
+                    for (row, row_idx) in cells_repl
+                        .iter()
+                        .take(b + 1)
+                        .zip(cells_repl_indices.iter())
+                    {
                         let s = row[c].as_str();
                         if s.is_empty() || parts.last() == Some(&s) {
                             continue;
                         }
                         parts.push(s);
+                        indices.extend(row_idx[c].iter().copied());
                     }
+                    // A spanning header replicated across band rows can repeat
+                    // a source item; a cell never lists one twice.
+                    dedup_preserving_order(&mut indices);
                     let mut bbox: Option<Rect> = None;
                     for row in cells.iter().take(b + 1) {
                         if let Some(r) = &row[c].bbox {
@@ -3908,7 +3964,7 @@ fn flatten_header_band(
                     Cell {
                         text: parts.join(" "),
                         bbox,
-                        text_item_indices: Vec::new(),
+                        text_item_indices: indices,
                     }
                 })
                 .collect();
@@ -3988,6 +4044,7 @@ fn merge_stacked_header(
                     merged_row[c].text.push(' ');
                 }
                 merged_row[c].text.push_str(cells[r][c].as_str());
+                merged_row[c].add_indices(cells[r][c].text_item_indices.iter().copied());
                 merged_has[c] = true;
                 if !cell_is_bold[r][c] {
                     merged_bold[c] = false;
@@ -4558,6 +4615,7 @@ fn build_ruled_table_from(
         is_bold: cell_is_bold,
         has_text: cell_has_text,
         repl: cells_repl,
+        repl_indices: cells_repl_indices,
         row_alpha_spanner,
         spanned,
         straddle_frac: _,
@@ -4567,6 +4625,7 @@ fn build_ruled_table_from(
         &cells,
         &cell_has_text,
         &cells_repl,
+        &cells_repl_indices,
         &row_alpha_spanner,
         n_rows,
         n_cols,
@@ -5165,6 +5224,13 @@ fn cell_continues(prev: &str, cur: &str) -> bool {
         .is_some_and(|c| c.is_uppercase());
     let prev_closed = prev.ends_with(['.', '!', '?']);
     !(starts_new_sentence && prev_closed)
+}
+
+/// Drop repeated source-item indices, keeping first-occurrence order — the
+/// within-cell contract is reading order with no repeats.
+fn dedup_preserving_order(v: &mut Vec<usize>) {
+    let mut seen = std::collections::HashSet::new();
+    v.retain(|i| seen.insert(*i));
 }
 
 /// Escape `|` and `\n` inside a markdown table cell so the pipe-table grammar
@@ -5886,6 +5952,89 @@ mod tests {
         assert_eq!(rect(0, 1), (150.0, 100.0, 100.0, 40.0));
         assert_eq!(rect(1, 0), (50.0, 140.0, 100.0, 40.0));
         assert_eq!(rect(1, 1), (150.0, 140.0, 100.0, 40.0));
+    }
+
+    #[test]
+    fn ruled_table_cells_carry_source_item_indices() {
+        // 2×2 ruled grid; every span carries a globally distinct source-item
+        // index, and each grid cell must attribute to exactly its own span.
+        let mut graphics = Vec::new();
+        for y in [100.0_f32, 140.0, 180.0] {
+            graphics.push(stroke(50.0, y, 250.0, y, 0.5));
+        }
+        for x in [50.0_f32, 150.0, 250.0] {
+            graphics.push(stroke(x, 100.0, x, 180.0, 0.5));
+        }
+        let mut lines = vec![
+            line_with_spans(&[("a", 90.0), ("b", 190.0)], 115.0, 10.0),
+            line_with_spans(&[("c", 90.0), ("d", 190.0)], 155.0, 10.0),
+        ];
+        lines[0].span_item_indices = vec![10, 11];
+        lines[1].span_item_indices = vec![12, 13];
+        let runs = detect_ruled_tables(&lines, &extract_rule_segments(&graphics), 612.0, 792.0);
+        assert_eq!(runs.len(), 1);
+        let Block::Table { rows, .. } = &runs[0].block else {
+            panic!("expected Block::Table");
+        };
+        assert_eq!(rows[0][0].text_item_indices, vec![10]);
+        assert_eq!(rows[0][1].text_item_indices, vec![11]);
+        assert_eq!(rows[1][0].text_item_indices, vec![12]);
+        assert_eq!(rows[1][1].text_item_indices, vec![13]);
+        let mut block = runs[0].block_item_indices();
+        block.sort_unstable();
+        assert_eq!(block, vec![10, 11, 12, 13]);
+    }
+
+    #[test]
+    fn ruled_straddle_split_duplicates_source_index() {
+        // Row 1's single span crosses the interior column boundary at x=150;
+        // the char-estimate split carves it into both cells, and BOTH cells
+        // attribute to that one span.
+        let mut graphics = Vec::new();
+        for y in [100.0_f32, 140.0, 180.0] {
+            graphics.push(stroke(50.0, y, 250.0, y, 0.5));
+        }
+        for x in [50.0_f32, 150.0, 250.0] {
+            graphics.push(stroke(x, 100.0, x, 180.0, 0.5));
+        }
+        let mut lines = vec![
+            line_with_spans(&[("a", 90.0), ("b", 190.0)], 115.0, 10.0),
+            line_with_spans(
+                &[("aaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbb", 55.0)],
+                155.0,
+                10.0,
+            ),
+        ];
+        lines[0].span_item_indices = vec![0, 1];
+        lines[1].span_item_indices = vec![2];
+        let runs = detect_ruled_tables(&lines, &extract_rule_segments(&graphics), 612.0, 792.0);
+        assert_eq!(runs.len(), 1);
+        let Block::Table { rows, .. } = &runs[0].block else {
+            panic!("expected Block::Table");
+        };
+        assert!(!rows[1][0].text.is_empty() && !rows[1][1].text.is_empty());
+        assert_eq!(rows[1][0].text_item_indices, vec![2]);
+        assert_eq!(rows[1][1].text_item_indices, vec![2]);
+    }
+
+    #[test]
+    fn union_header_fold_carries_span_indices() {
+        // A spanning group header ("GroupGroupGroup" covering tracks 1 and 2)
+        // replicates into both columns; each folded header cell must carry
+        // the contributing spans' indices, deduped within the cell.
+        let mut header_line =
+            line_with_spans(&[("Region", 50.0), ("GroupGroupGroup", 145.0)], 100.0, 20.0);
+        header_line.span_item_indices = vec![7, 8];
+        let mut body = line_with_spans(&[("x", 50.0), ("1", 150.0), ("2", 250.0)], 125.0, 10.0);
+        body.span_item_indices = vec![9, 10, 11];
+        let lines = vec![header_line, body];
+        let (start, header) = union_header_from_above(&lines, 1, 0, &[50.0, 150.0, 250.0])
+            .expect("header should absorb");
+        assert_eq!(start, 0);
+        assert_eq!(header.len(), 3);
+        assert_eq!(header[0].text_item_indices, vec![7]);
+        assert_eq!(header[1].text_item_indices, vec![8]);
+        assert_eq!(header[2].text_item_indices, vec![8]);
     }
 
     #[test]

--- a/crates/liteparse/src/markdown_layout/tables.rs
+++ b/crates/liteparse/src/markdown_layout/tables.rs
@@ -2671,11 +2671,16 @@ fn union_header_from_above(
                 if let Some(r) = &layer[col].bbox {
                     Rect::extend(&mut bbox, r);
                 }
-                if s.is_empty() || parts.last() == Some(&s) {
+                if s.is_empty() {
+                    continue;
+                }
+                // Like the bbox union above: a layer whose text de-duplicates
+                // away still contributed real source items — attribute them.
+                indices.extend(layer[col].text_item_indices.iter().copied());
+                if parts.last() == Some(&s) {
                     continue;
                 }
                 parts.push(s);
-                indices.extend(layer[col].text_item_indices.iter().copied());
             }
             dedup_preserving_order(&mut indices);
             Cell {
@@ -3103,11 +3108,16 @@ fn try_merge_pair(a: &TableRun, b: &TableRun, lines: &[ProjectedLine]) -> Option
                         Rect::extend(&mut bbox, r);
                     }
                     let s = cell.as_str();
-                    if s.is_empty() || parts.last().map(|p| p.as_str()) == Some(s) {
+                    if s.is_empty() {
+                        continue;
+                    }
+                    // Same policy as the bbox union: attribute a layer's
+                    // source items even when its text de-duplicates away.
+                    indices.extend(cell.text_item_indices.iter().copied());
+                    if parts.last().map(|p| p.as_str()) == Some(s) {
                         continue;
                     }
                     parts.push(s.to_string());
-                    indices.extend(cell.text_item_indices.iter().copied());
                 }
                 dedup_preserving_order(&mut indices);
                 Cell {
@@ -3946,11 +3956,18 @@ fn flatten_header_band(
                         .zip(cells_repl_indices.iter())
                     {
                         let s = row[c].as_str();
-                        if s.is_empty() || parts.last() == Some(&s) {
+                        if s.is_empty() {
+                            continue;
+                        }
+                        // A band row whose text de-duplicates away still
+                        // contributed real source items (two stacked rows can
+                        // repeat a group label from *different* items) —
+                        // attribute them even when the text is skipped.
+                        indices.extend(row_idx[c].iter().copied());
+                        if parts.last() == Some(&s) {
                             continue;
                         }
                         parts.push(s);
-                        indices.extend(row_idx[c].iter().copied());
                     }
                     // A spanning header replicated across band rows can repeat
                     // a source item; a cell never lists one twice.
@@ -6035,6 +6052,28 @@ mod tests {
         assert_eq!(header[0].text_item_indices, vec![7]);
         assert_eq!(header[1].text_item_indices, vec![8]);
         assert_eq!(header[2].text_item_indices, vec![8]);
+    }
+
+    #[test]
+    fn union_header_fold_attributes_duplicate_text_layers() {
+        // Two stacked header layers repeat the same text in column 0 from
+        // DIFFERENT source items ("Rated" printed on both band rows). The
+        // fold de-duplicates the text but must still attribute both items —
+        // otherwise the second row's item belongs to no block.
+        let mut top = line_with_spans(&[("Rated", 50.0), ("Voltage", 150.0)], 100.0, 10.0);
+        top.span_item_indices = vec![1, 2];
+        let mut bottom = line_with_spans(&[("Rated", 50.0), ("(VDC)", 150.0)], 115.0, 10.0);
+        bottom.span_item_indices = vec![3, 4];
+        let mut body = line_with_spans(&[("x", 50.0), ("1", 150.0)], 130.0, 10.0);
+        body.span_item_indices = vec![5, 6];
+        let lines = vec![top, bottom, body];
+        let (start, header) = union_header_from_above(&lines, 2, 0, &[50.0, 150.0])
+            .expect("header should absorb");
+        assert_eq!(start, 0);
+        assert_eq!(header[0].text, "Rated");
+        assert_eq!(header[0].text_item_indices, vec![1, 3]);
+        assert_eq!(header[1].text, "Voltage (VDC)");
+        assert_eq!(header[1].text_item_indices, vec![2, 4]);
     }
 
     #[test]

--- a/crates/liteparse/src/markdown_layout/tables.rs
+++ b/crates/liteparse/src/markdown_layout/tables.rs
@@ -2571,6 +2571,7 @@ fn union_header_from_above(
             Cell {
                 text: parts.join(" "),
                 bbox,
+                text_item_indices: Vec::new(),
             }
         })
         .collect();
@@ -2987,6 +2988,7 @@ fn try_merge_pair(a: &TableRun, b: &TableRun, lines: &[ProjectedLine]) -> Option
                 Cell {
                     text: parts.join(" "),
                     bbox,
+                    text_item_indices: Vec::new(),
                 }
             })
             .collect();
@@ -3389,6 +3391,7 @@ impl CellGrid {
                             width: xs[c + 1] - xs[c],
                             height: ys[r + 1] - ys[r],
                         }),
+                        text_item_indices: Vec::new(),
                     })
                     .collect()
             })
@@ -3798,6 +3801,7 @@ fn flatten_header_band(
                     Cell {
                         text: parts.join(" "),
                         bbox,
+                        text_item_indices: Vec::new(),
                     }
                 })
                 .collect();

--- a/crates/liteparse/src/markdown_layout/tables.rs
+++ b/crates/liteparse/src/markdown_layout/tables.rs
@@ -3950,10 +3950,8 @@ fn flatten_header_band(
                 .map(|c| {
                     let mut parts: Vec<&str> = Vec::new();
                     let mut indices: Vec<usize> = Vec::new();
-                    for (row, row_idx) in cells_repl
-                        .iter()
-                        .take(b + 1)
-                        .zip(cells_repl_indices.iter())
+                    for (row, row_idx) in
+                        cells_repl.iter().take(b + 1).zip(cells_repl_indices.iter())
                     {
                         let s = row[c].as_str();
                         if s.is_empty() {
@@ -5785,7 +5783,7 @@ mod tests {
             end_x: 200.0,
             text: "ABC-DEF-GHI".into(),
             bold: false,
-                text_item_indices: vec![],
+            text_item_indices: vec![],
         }];
         let tracks = vec![50.0, 150.0];
         assert!(recover_merged_cell(row, &tracks).is_none());
@@ -6067,8 +6065,8 @@ mod tests {
         let mut body = line_with_spans(&[("x", 50.0), ("1", 150.0)], 130.0, 10.0);
         body.span_item_indices = vec![5, 6];
         let lines = vec![top, bottom, body];
-        let (start, header) = union_header_from_above(&lines, 2, 0, &[50.0, 150.0])
-            .expect("header should absorb");
+        let (start, header) =
+            union_header_from_above(&lines, 2, 0, &[50.0, 150.0]).expect("header should absorb");
         assert_eq!(start, 0);
         assert_eq!(header[0].text, "Rated");
         assert_eq!(header[0].text_item_indices, vec![1, 3]);
@@ -6179,8 +6177,7 @@ mod tests {
         let pieces = line_pieces(&l);
         assert_eq!(pieces.len(), 1);
         assert_eq!(pieces[0].source_index, Some(0));
-        let cells =
-            cells_from_pieces(&pieces, &[50.0, 150.0], true).expect("split should succeed");
+        let cells = cells_from_pieces(&pieces, &[50.0, 150.0], true).expect("split should succeed");
         assert_eq!(cells.len(), 2);
         assert_eq!(cells[0].text, "aaaaaaaaaa");
         assert_eq!(cells[1].text, "bbbbbbbbbb");

--- a/crates/liteparse/src/markdown_layout/test_helpers.rs
+++ b/crates/liteparse/src/markdown_layout/test_helpers.rs
@@ -23,6 +23,7 @@ pub(crate) fn line(text: &str, x: f32, y: f32, h: f32, size: f32) -> ProjectedLi
         all_mono: false,
         all_strike: false,
         spans: vec![TextItem::default()],
+        span_item_indices: vec![0],
         region_path: Vec::new(),
         mcid: None,
         in_figure: false,
@@ -80,6 +81,7 @@ pub(crate) fn line_with_spans(cells: &[(&str, f32)], y: f32, size: f32) -> Proje
         .iter()
         .map(|s| s.x + s.width)
         .fold(f32::NEG_INFINITY, f32::max);
+    let span_item_indices = (0..spans.len()).collect();
     ProjectedLine {
         text: cells
             .iter()
@@ -104,6 +106,7 @@ pub(crate) fn line_with_spans(cells: &[(&str, f32)], y: f32, size: f32) -> Proje
         all_mono: false,
         all_strike: false,
         spans,
+        span_item_indices,
         region_path: Vec::new(),
         mcid: None,
         in_figure: false,
@@ -136,6 +139,7 @@ pub(crate) fn styled_line(spans: &[(&str, f32, Option<&str>)], y: f32, size: f32
         .iter()
         .map(|s| s.x + s.width)
         .fold(f32::NEG_INFINITY, f32::max);
+    let span_item_indices = (0..items.len()).collect();
     ProjectedLine {
         rtl: crate::bidi::is_rtl_text(&joined),
         text: joined,
@@ -156,6 +160,7 @@ pub(crate) fn styled_line(spans: &[(&str, f32, Option<&str>)], y: f32, size: f32
         all_mono: false,
         all_strike: false,
         spans: items,
+        span_item_indices,
         region_path: Vec::new(),
         mcid: None,
         in_figure: false,

--- a/crates/liteparse/src/output/markdown.rs
+++ b/crates/liteparse/src/output/markdown.rs
@@ -191,6 +191,7 @@ mod tests {
             all_mono: false,
             all_strike: false,
             spans: vec![TextItem::default()],
+            span_item_indices: vec![0],
             region_path: Vec::new(),
             mcid: None,
             in_figure: false,

--- a/crates/liteparse/src/output/markdown.rs
+++ b/crates/liteparse/src/output/markdown.rs
@@ -162,7 +162,22 @@ fn dedupe_rules(blocks: &mut Vec<crate::markdown_layout::PositionedBlock>) {
     while matches!(blocks.last().map(|b| &b.block), Some(HorizontalRule)) {
         blocks.pop();
     }
-    blocks.dedup_by(|a, b| matches!((&a.block, &b.block), (HorizontalRule, HorizontalRule)));
+    blocks.dedup_by(|a, b| {
+        if !matches!((&a.block, &b.block), (HorizontalRule, HorizontalRule)) {
+            return false;
+        }
+        // The surviving rule stands for the whole collapsed run: union the
+        // removed rule's provenance and geometry into it, so a text-derived
+        // flourish line stays attributed (documented guarantee) even when a
+        // vector-derived rule with no items is the one kept. Markdown output
+        // is unaffected — only the structured blocks view sees these fields.
+        b.text_item_indices
+            .extend(a.text_item_indices.iter().copied());
+        if let Some(r) = &a.bbox {
+            crate::types::Rect::extend(&mut b.bbox, r);
+        }
+        true
+    });
 }
 
 #[cfg(test)]
@@ -253,6 +268,51 @@ mod tests {
             .collect();
         // Leading + trailing rules gone; the doubled interior run collapsed to one.
         assert_eq!(kinds, vec![false, true, false]);
+    }
+
+    #[test]
+    fn dedupe_rules_unions_provenance_into_the_surviving_rule() {
+        use crate::markdown_layout::Block::{HorizontalRule, Paragraph};
+        use crate::markdown_layout::PositionedBlock;
+        let p = |t: &str| {
+            PositionedBlock::unlocated(Paragraph {
+                text: t.into(),
+                bold: false,
+                italic: false,
+            })
+        };
+        // A vector-derived rule (no items) followed by a text-derived
+        // flourish rule (items [4, 7]); the flourish's attribution must
+        // survive the collapse onto the first rule.
+        let vector_rule = PositionedBlock::new(
+            HorizontalRule,
+            Some(Rect {
+                x: 10.0,
+                y: 50.0,
+                width: 100.0,
+                height: 1.0,
+            }),
+            vec![],
+        );
+        let text_rule = PositionedBlock::new(
+            HorizontalRule,
+            Some(Rect {
+                x: 10.0,
+                y: 55.0,
+                width: 120.0,
+                height: 8.0,
+            }),
+            vec![4, 7],
+        );
+        let mut blocks = vec![p("a"), vector_rule, text_rule, p("b")];
+        dedupe_rules(&mut blocks);
+        assert_eq!(blocks.len(), 3);
+        let rule = &blocks[1];
+        assert!(matches!(rule.block, HorizontalRule));
+        assert_eq!(rule.text_item_indices, vec![4, 7]);
+        let bbox = rule.bbox.as_ref().expect("unioned bbox");
+        assert_eq!((bbox.x, bbox.y), (10.0, 50.0));
+        assert_eq!((bbox.width, bbox.height), (120.0, 13.0));
     }
 
     #[test]

--- a/crates/liteparse/src/parser.rs
+++ b/crates/liteparse/src/parser.rs
@@ -258,14 +258,42 @@ fn apply_layout(
             // A page with no structural decomposition reports an empty list,
             // not `None` — extraction *was* enabled, there was just nothing to
             // decompose.
-            page.blocks = Some(
-                blocks
-                    .as_deref()
-                    .unwrap_or_default()
-                    .iter()
-                    .map(crate::layout::LayoutBlock::from)
-                    .collect(),
-            );
+            let mut layout_blocks: Vec<crate::layout::LayoutBlock> = blocks
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .map(crate::layout::LayoutBlock::from)
+                .collect();
+            // Bounds safety at the public boundary: every provenance index
+            // must address this page's returned text_items. Should never
+            // fire (indices are recorded against the same vector the page
+            // returns); in release an out-of-range index is dropped rather
+            // than shipped.
+            let n_items = page.text_items.len();
+            for block in &mut layout_blocks {
+                debug_assert!(
+                    block.text_item_indices.iter().all(|&i| i < n_items),
+                    "block provenance index out of range (page {}: {} items)",
+                    page.page_number,
+                    n_items
+                );
+                block.text_item_indices.retain(|&i| i < n_items);
+                for cell in block
+                    .header
+                    .iter_mut()
+                    .flatten()
+                    .chain(block.rows.iter_mut().flatten().flatten())
+                {
+                    debug_assert!(
+                        cell.text_item_indices.iter().all(|&i| i < n_items),
+                        "cell provenance index out of range (page {}: {} items)",
+                        page.page_number,
+                        n_items
+                    );
+                    cell.text_item_indices.retain(|&i| i < n_items);
+                }
+            }
+            page.blocks = Some(layout_blocks);
         }
     }
     if !wants_markdown {

--- a/crates/liteparse/src/parser.rs
+++ b/crates/liteparse/src/parser.rs
@@ -685,11 +685,20 @@ impl LiteParse {
                     continue_on_page_error: self.config.continue_on_page_error,
                     extract_content_bounds: self.config.extract_content_bounds,
                     extract_images: self.config.effective_extract_images(),
-                    // The markdown table detector splits PDFium's merged
-                    // multi-cell runs on real word geometry, so it needs word
-                    // boxes even when the caller didn't ask for them.
+                    // The table detector splits PDFium's merged multi-cell
+                    // runs on real word geometry, so it needs word boxes even
+                    // when the caller didn't ask for them. Markdown output
+                    // always runs it; `extract_blocks` runs the same
+                    // classifier under any output format, so without the
+                    // forcing a JSON caller would get blocks classified by a
+                    // materially weaker (char-estimate) table splitter than
+                    // the markdown they can see. Detection-only: `self.config`
+                    // is left untouched, so `config()` still reports what the
+                    // caller asked for, and bindings that expose
+                    // `TextItem::words` gate serialization on that request.
                     emit_word_boxes: self.config.emit_word_boxes
-                        || self.config.output_format == crate::config::OutputFormat::Markdown,
+                        || self.config.output_format == crate::config::OutputFormat::Markdown
+                        || self.config.extract_blocks,
                     extract_text_metadata: self.config.extract_text_metadata,
                     extract_vector_graphics: self.config.extract_vector_graphics,
                     extract_annotations: self.config.extract_annotations,

--- a/crates/liteparse/src/projection.rs
+++ b/crates/liteparse/src/projection.rs
@@ -4776,6 +4776,7 @@ fn build_one_line(
     let mut anchor_weights: HashMap<u8, usize> = HashMap::new();
     let mut mcid: Option<i32> = None;
     let mut spans: Vec<TextItem> = Vec::with_capacity(sorted.len());
+    let mut span_item_indices: Vec<usize> = Vec::with_capacity(sorted.len());
 
     for &i in sorted.iter() {
         let proj = &items[i];
@@ -4789,6 +4790,10 @@ fn build_one_line(
         let mut span = it.clone();
         span.rotation = proj.orig_rotation;
         spans.push(span);
+        // `i` indexes the final projected vector, which becomes the page's
+        // returned `text_items` 1:1 in `project_pages_to_grid` — so this is
+        // directly the public source-item index for the span above.
+        span_item_indices.push(i);
 
         // Collect item text. Use existing num_spaces from projection only as
         // a hint — the markdown emitter re-collapses whitespace, so we just
@@ -4986,6 +4991,7 @@ fn build_one_line(
         all_mono: majority(mono_chars),
         all_strike: false,
         spans,
+        span_item_indices,
         region_path,
         mcid,
         in_figure,
@@ -5047,6 +5053,91 @@ mod tests {
         let (_, text) = project_to_grid(&page, projection_boxes);
 
         assert!(text.is_empty());
+    }
+
+    #[test]
+    fn span_item_indices_stay_aligned_with_spans() {
+        // Two-column layout through the line builder: every line must carry
+        // exactly one source index per span, each index in bounds, and each
+        // (span, index) pair must point back at its own source item.
+        let mut items = Vec::new();
+        for row in 0..5 {
+            let y = 100.0 + row as f32 * 14.0;
+            items.push(item_at(&format!("left{row}"), 50.0, y, 200.0, 10.0));
+            items.push(item_at(&format!("right{row}"), 350.0, y, 200.0, 10.0));
+        }
+        let (lines, _region) = build_projected_lines(&items, 612.0, 792.0, &[]);
+        assert_eq!(lines.len(), 10);
+        for line in &lines {
+            assert_eq!(line.spans.len(), line.span_item_indices.len());
+            for (span, &idx) in line.spans.iter().zip(&line.span_item_indices) {
+                assert!(idx < items.len());
+                assert_eq!(items[idx].item.text, span.text);
+                assert_eq!(items[idx].item.x, span.x);
+            }
+        }
+    }
+
+    #[test]
+    fn span_item_indices_index_the_returned_text_items() {
+        // Full projection pipeline on a two-column page: the contract is that
+        // indices address the *returned* `ParsedPage.text_items` array
+        // (post-clean, line-order flattened) — not extraction order. Distinct
+        // texts make each span identify exactly one source item.
+        let mut text_items = Vec::new();
+        for row in 0..5 {
+            let y = 100.0 + row as f32 * 14.0;
+            text_items.push(TextItem {
+                text: format!("left{row}"),
+                x: 50.0,
+                y,
+                width: 200.0,
+                height: 10.0,
+                ..Default::default()
+            });
+            text_items.push(TextItem {
+                text: format!("right{row}"),
+                x: 350.0,
+                y,
+                width: 200.0,
+                height: 10.0,
+                ..Default::default()
+            });
+        }
+        let page = Page {
+            page_number: 1,
+            page_width: 612.0,
+            page_height: 792.0,
+            content_bounds: None,
+            graphics: Vec::new(),
+            vector_graphics: None,
+            text_items,
+            struct_nodes: Vec::new(),
+            image_refs: Vec::new(),
+            annotations: None,
+            form_fields: None,
+            structure_tree: None,
+        };
+        let pages = project_pages_to_grid(vec![page]);
+        let page = &pages[0];
+        assert!(!page.projected_lines.is_empty());
+        for line in &page.projected_lines {
+            assert_eq!(line.spans.len(), line.span_item_indices.len());
+            for (span, &idx) in line.spans.iter().zip(&line.span_item_indices) {
+                assert!(idx < page.text_items.len());
+                assert_eq!(page.text_items[idx].text, span.text);
+            }
+        }
+        // Every returned item survives this clean layout and is referenced by
+        // exactly one span across the page's lines.
+        let mut seen: Vec<usize> = page
+            .projected_lines
+            .iter()
+            .flat_map(|l| l.span_item_indices.iter().copied())
+            .collect();
+        seen.sort_unstable();
+        let expected: Vec<usize> = (0..page.text_items.len()).collect();
+        assert_eq!(seen, expected);
     }
 
     fn item_at(text: &str, x: f32, y: f32, w: f32, h: f32) -> ProjectedTextItem {

--- a/crates/liteparse/src/types.rs
+++ b/crates/liteparse/src/types.rs
@@ -676,6 +676,18 @@ pub struct ProjectedLine {
     pub all_mono: bool,
     pub all_strike: bool,
     pub spans: Vec<TextItem>,
+    /// For each entry in `spans`, the index of its source item in the page's
+    /// *returned* `text_items` vector (post-projection, after
+    /// `clean_projected_items`, line-order flattened — not PDF paint order).
+    /// Positionally aligned with `spans`; any code that reorders or extends
+    /// `spans` must transform this vector in lockstep, preferably by zipping
+    /// the two before sorting. Lets the markdown classifier attribute blocks
+    /// and table cells back to their source items without string matching.
+    ///
+    /// Note this stays aligned with the x-ascending `spans` order even when
+    /// `rtl` is set: RTL reverses only how the line's *text* is rebuilt,
+    /// never the span order itself.
+    pub span_item_indices: Vec<usize>,
     /// True when the line's base direction is right-to-left (strong RTL
     /// characters outnumber strong LTR ones). `spans` is always in x-ascending
     /// order; consumers that rebuild the line's *text* must walk it in reverse

--- a/crates/liteparse/tests/integration_test.rs
+++ b/crates/liteparse/tests/integration_test.rs
@@ -419,6 +419,59 @@ async fn test_extract_blocks_carries_geometry_without_changing_markdown() {
     }
 }
 
+/// `extract_blocks` needs real word geometry for table detection (word-anchored
+/// straddle splits), so it forces word-box extraction internally — under any
+/// output format, exactly like markdown output always has. The forcing is a
+/// detection input only: the parser's reported config still says what the
+/// caller asked for, and with `extract_blocks` off nothing changes.
+#[tokio::test]
+#[serial]
+async fn test_extract_blocks_forces_word_geometry_json_output() {
+    let base = LiteParseConfig {
+        ocr_enabled: false,
+        output_format: OutputFormat::Json,
+        ..LiteParseConfig::default()
+    };
+
+    // Control: JSON output without extract_blocks populates no word boxes.
+    let without = LiteParse::new(base.clone());
+    let parsed = without
+        .parse("../../integration_tests_data/sample.pdf")
+        .await
+        .expect("Should be able to parse");
+    assert!(
+        parsed
+            .pages
+            .iter()
+            .flat_map(|p| &p.text_items)
+            .all(|i| i.words.is_empty()),
+        "no word boxes should be extracted when neither the caller nor a \
+         feature asks for them"
+    );
+
+    let with = LiteParse::new(LiteParseConfig {
+        extract_blocks: true,
+        ..base
+    });
+    let parsed = with
+        .parse("../../integration_tests_data/sample.pdf")
+        .await
+        .expect("Should be able to parse");
+    assert!(
+        parsed
+            .pages
+            .iter()
+            .flat_map(|p| &p.text_items)
+            .any(|i| !i.words.is_empty()),
+        "extract_blocks should force word-box extraction as a table-detection \
+         input even under JSON output"
+    );
+    // The forcing is internal: the resolved config still reports the caller's
+    // own request, which is what binding layers echo and gate `words`
+    // serialization on.
+    assert!(!with.config().emit_word_boxes);
+}
+
 #[tokio::test]
 #[serial]
 async fn test_parse_bytes_pdf_integration() {

--- a/crates/liteparse/tests/integration_test.rs
+++ b/crates/liteparse/tests/integration_test.rs
@@ -387,6 +387,36 @@ async fn test_extract_blocks_carries_geometry_without_changing_markdown() {
         ys.windows(2).all(|w| w[0] <= w[1]),
         "blocks should be in reading order, got {ys:?}"
     );
+
+    // Provenance (fork): every block attributes to the page's returned
+    // text_items — indices in bounds, sorted+deduped, non-empty for
+    // text-bearing kinds, and never shared between two different blocks.
+    let n_items = with.pages[0].text_items.len();
+    let mut seen: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    for b in blocks {
+        assert!(
+            b.text_item_indices.iter().all(|&i| i < n_items),
+            "index out of bounds in {:?}",
+            b.kind
+        );
+        assert!(
+            b.text_item_indices.windows(2).all(|w| w[0] < w[1]),
+            "block indices must be strictly ascending (sorted+deduped)"
+        );
+        if !matches!(b.kind, "rule" | "figure") {
+            assert!(
+                !b.text_item_indices.is_empty(),
+                "text-bearing block {:?} carries no provenance",
+                b.kind
+            );
+        }
+        for &i in &b.text_item_indices {
+            assert!(
+                seen.insert(i),
+                "item {i} attributed to two different blocks"
+            );
+        }
+    }
 }
 
 #[tokio::test]

--- a/packages/node/src/lib.ts
+++ b/packages/node/src/lib.ts
@@ -92,6 +92,8 @@ export interface LiteParseConfig {
    * Emit per-word sub-boxes on each text item ({@link TextItem.words}).
    * Default false. Word boxes roughly double the text-item payload (size + napi
    * marshalling), so enable only when doing word-level bbox attribution.
+   * With `extractBlocks` on, word geometry is always computed internally as a
+   * table-detection input, but `words` is only returned when this is set.
    */
   emitWordBoxes: boolean;
   /** Include rich PDF text metadata on returned text items. Default false. */

--- a/packages/node/src/lib.ts
+++ b/packages/node/src/lib.ts
@@ -271,6 +271,11 @@ export interface LayoutCell {
    * a ragged grid, or halves of a merged run split at an estimated position.
    */
   bbox?: Rect;
+  /**
+   * Indices into the page's returned `textItems`, in reading order, never
+   * repeating within one cell; empty for padding cells.
+   */
+  textItemIndices: number[];
 }
 
 /** A classified block of page content, discriminated by `kind`. */
@@ -284,6 +289,12 @@ export interface LayoutBlock {
     | "grid_fallback"
     | "rule"
     | "figure";
+  /**
+   * Indices into the page's returned `textItems`, sorted and deduped; empty
+   * for text-less blocks. For a `table` block, the union of its cells'
+   * indices.
+   */
+  textItemIndices: number[];
   /** Rendered text for `heading`, `paragraph`, and `list_item`. */
   text?: string;
   /** Heading level (1-6), or list nesting depth for `list_item`. */

--- a/packages/node/src/native.ts
+++ b/packages/node/src/native.ts
@@ -149,10 +149,12 @@ export interface NativeParsedPage {
 export interface NativeLayoutCell {
   text: string;
   bbox?: NativeRect;
+  textItemIndices: number[];
 }
 
 export interface NativeLayoutBlock {
   kind: string;
+  textItemIndices: number[];
   text?: string;
   level?: number;
   bold?: boolean;

--- a/packages/python/liteparse/parser.py
+++ b/packages/python/liteparse/parser.py
@@ -553,7 +553,9 @@ class LiteParse:
             emit_word_boxes: Emit per-word sub-boxes on each text item
                 (``TextItem.words``). Default False. Word boxes roughly double
                 the text-item payload, so enable only for word-level bbox
-                attribution.
+                attribution. With ``extract_blocks=True``, word geometry is
+                always computed internally as a table-detection input, but
+                ``words`` is only returned when this is set.
             extract_text_metadata: Include rich PDF text metadata on returned
                 text items (MCID, glyph width, font metrics/weight/buggy state,
                 colors, raw character codes, and ``trailing_space_generated``). Default False.

--- a/packages/python/liteparse/parser.py
+++ b/packages/python/liteparse/parser.py
@@ -45,12 +45,17 @@ def _convert_rect(rect: Any) -> Optional[AnnotationRect]:
 
 
 def _convert_cell(cell: Any) -> LayoutCell:
-    return LayoutCell(text=cell.text, bbox=_convert_rect(cell.bbox))
+    return LayoutCell(
+        text=cell.text,
+        bbox=_convert_rect(cell.bbox),
+        text_item_indices=list(cell.text_item_indices),
+    )
 
 
 def _convert_block(block: Any) -> LayoutBlock:
     return LayoutBlock(
         kind=block.kind,
+        text_item_indices=list(block.text_item_indices),
         text=block.text,
         level=block.level,
         bold=block.bold,

--- a/packages/python/liteparse/types.py
+++ b/packages/python/liteparse/types.py
@@ -46,7 +46,8 @@ class TextItem:
     confidence: Optional[float] = None
     rotation: float = 0.0
     #: Per-word sub-boxes. Empty unless the parser was configured with
-    #: ``emit_word_boxes=True``.
+    #: ``emit_word_boxes=True`` (``extract_blocks`` computes word geometry
+    #: internally for table detection, but never returns it unrequested).
     words: List[WordBox] = field(default_factory=list)
 
 

--- a/packages/python/liteparse/types.py
+++ b/packages/python/liteparse/types.py
@@ -69,6 +69,9 @@ class LayoutCell:
     """
     text: str
     bbox: Optional[AnnotationRect] = None
+    #: Indices into the page's returned ``text_items``, in reading order,
+    #: never repeating within one cell; empty for padding cells.
+    text_item_indices: List[int] = field(default_factory=list)
 
 
 @dataclass
@@ -80,6 +83,10 @@ class LayoutBlock:
     apply to a block's kind are ``None``.
     """
     kind: str
+    #: Indices into the page's returned ``text_items``, sorted and deduped;
+    #: empty for text-less blocks. For a ``table`` block, the union of its
+    #: cells' indices.
+    text_item_indices: List[int] = field(default_factory=list)
     #: Rendered text for ``heading``, ``paragraph`` and ``list_item``.
     text: Optional[str] = None
     #: Heading level (1-6), or list nesting depth for ``list_item``.


### PR DESCRIPTION
Follow-up to #407 / #403. Adds `text_item_indices` to `LayoutBlock` and `LayoutCell` — indices into the returned page `textItems` — so callers can map blocks back to the items they already have (grounded citations, highlight overlays, layout-aware chunking, document comparison).

- Indices are recorded where blocks are formed: projection keeps a span→item alignment on `ProjectedLine`, and the classifier and table paths carry it through wraps, de-hyphenation, merges, and header folds. Cell indices are in reading order; block indices are the sorted union of their lines/cells.
- All bindings: core (and therefore CLI serde), wasm, napi, and python, including the public DTOs.
- `extract_blocks` now enables word-box extraction in core — the table detector needs real word geometry — and each binding serializes `words` only when the caller asked for them, so payloads are unchanged. (napi `parse_pages()` is untouched; the caller supplies geometry there.)
- With `extract_blocks` off, output is identical to v2.13.1; with it on, the new fields are additive.
