### PR TITLE
fix(node): preserve page boundaries in text output

### DIFF
--- a/packages/node/src/cli-text.ts
+++ b/packages/node/src/cli-text.ts
@@ -1,0 +1,10 @@
+import type { ParsedPage } from "./lib.js";
+
+/** Format parsed pages as plain text with page headers. */
+export function formatText(
+  pages: readonly Pick<ParsedPage, "pageNum" | "text">[],
+): string {
+  return pages
+    .map((page) => `\n--- Page ${page.pageNum} ---\n${page.text}`)
+    .join("\n\n");
+}

--- a/packages/node/src/cli.ts
+++ b/packages/node/src/cli.ts
@@ -3,6 +3,7 @@
 import { program } from "commander";
 import { LiteParse, type LiteParseConfig } from "./lib.js";
 import { parseResultToCliJson } from "./cli-json.js";
+import { formatText } from "./cli-text.js";
 import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import { join, relative, parse as parsePath } from "node:path";
 
@@ -187,7 +188,9 @@ program
               null,
               2,
             )
-          : result.text;
+          : config.outputFormat === "text"
+            ? formatText(result.pages)
+            : result.text;
 
 
       if (opts.output) {
@@ -461,7 +464,9 @@ program
                     null,
                     2,
                   )
-                : result.text;
+                : format === "text"
+                  ? formatText(result.pages)
+                  : result.text;
             writeFileSync(outPath, output, "utf-8");
             success++;
             if (!opts.quiet) {

--- a/packages/node/tests/cli-text.test.mjs
+++ b/packages/node/tests/cli-text.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolve(packageDir, "..", "..");
+const cliPath = join(packageDir, "dist", "cli.js");
+const samplePdf = join(repoRoot, "demo", "docs", "apple-10k-2024.pdf");
+
+function pageHeaders(output) {
+  return output.match(/^--- Page \d+ ---$/gm) ?? [];
+}
+
+test("parse preserves page boundaries in text output", () => {
+  const output = execFileSync(
+    process.execPath,
+    [
+      cliPath,
+      "parse",
+      samplePdf,
+      "--no-ocr",
+      "--max-pages",
+      "2",
+      "--format",
+      "text",
+      "--quiet",
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.deepEqual(pageHeaders(output), ["--- Page 1 ---", "--- Page 2 ---"]);
+});
+
+test("batch-parse preserves page boundaries in text output", () => {
+  const testDir = mkdtempSync(join(tmpdir(), "liteparse-cli-text-"));
+  const inputDir = join(testDir, "input");
+  const outputDir = join(testDir, "output");
+  mkdirSync(inputDir);
+  mkdirSync(outputDir);
+  copyFileSync(samplePdf, join(inputDir, "sample.pdf"));
+
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        cliPath,
+        "batch-parse",
+        inputDir,
+        outputDir,
+        "--no-ocr",
+        "--max-pages",
+        "2",
+        "--format",
+        "text",
+        "--quiet",
+      ],
+      { encoding: "utf8" },
+    );
+    const output = readFileSync(join(outputDir, "sample.txt"), "utf8");
+    assert.deepEqual(pageHeaders(output), [
+      "--- Page 1 ---",
+      "--- Page 2 ---",
+    ]);
+  } finally {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- format Node CLI text output with the same per-page headers as the Rust and Python CLIs
- preserve `result.text` unchanged for Markdown output
- cover both `parse` and `batch-parse` with a two-page end-to-end regression test

## Why

The npm `lit` CLI currently writes `result.text` for both text and Markdown. In text mode, that drops all page boundaries even though the Cargo and pip CLIs emit `--- Page N ---` headers. The shared Node formatter now mirrors the Rust text formatter and uses each parsed page's actual number.

Fixes #391.

## Testing

- `npm run build:ts`
- Node 18: `node --test tests/cli-text.test.mjs`
- Node 20: `node --test tests/`
- Node 22: `node --test tests/*.test.mjs`
- parsed the two-page sample through both `parse` and `batch-parse` (two page headers each)
- verified JSON output parses with two pages
- verified Markdown CLI output remains byte-for-byte equal to `ParseResult.text`
- `npm pack --dry-run`
