### PR TITLE
fix: reject invalid output formats in Node and Python bindings

### DIFF
--- a/crates/liteparse-napi/src/lib.rs
+++ b/crates/liteparse-napi/src/lib.rs
@@ -20,13 +20,16 @@ impl LiteParse {
     /// Create a new LiteParse instance with optional configuration.
     /// Any fields not provided will use defaults.
     #[napi(constructor)]
-    pub fn new(config: Option<JsLiteParseConfig>) -> Self {
-        let rust_config = config.map(|c| c.into_rust()).unwrap_or_default();
+    pub fn new(config: Option<JsLiteParseConfig>) -> Result<Self> {
+        let rust_config = config
+            .map(|c| c.into_rust())
+            .transpose()?
+            .unwrap_or_default();
         let inner = liteparse::parser::LiteParse::new(rust_config.clone());
-        Self {
+        Ok(Self {
             inner,
             config: rust_config,
-        }
+        })
     }
 
     /// Parse a document. Accepts a file path (string) or raw PDF bytes (Buffer).

--- a/crates/liteparse-napi/src/types.rs
+++ b/crates/liteparse-napi/src/types.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use napi::bindgen_prelude::{Error, Result};
 use napi_derive::napi;
 
 use liteparse::config::{CropBox, ImageMode, LiteParseConfig, OutputFormat};
@@ -133,7 +134,7 @@ pub struct JsCropBox {
 }
 
 impl JsLiteParseConfig {
-    pub fn into_rust(self) -> LiteParseConfig {
+    pub fn into_rust(self) -> Result<LiteParseConfig> {
         let mut cfg = LiteParseConfig::default();
         if let Some(v) = self.ocr_language {
             cfg.ocr_language = v;
@@ -166,11 +167,7 @@ impl JsLiteParseConfig {
             cfg.dpi = v as f32;
         }
         if let Some(v) = self.output_format {
-            cfg.output_format = match v.as_str() {
-                "text" => OutputFormat::Text,
-                "markdown" | "md" => OutputFormat::Markdown,
-                _ => OutputFormat::Json,
-            };
+            cfg.output_format = parse_output_format(&v)?;
         }
         if let Some(v) = self.preserve_very_small_text {
             cfg.preserve_very_small_text = v;
@@ -259,7 +256,7 @@ impl JsLiteParseConfig {
         if let Some(v) = self.extract_vector_graphics {
             cfg.extract_vector_graphics = v;
         }
-        cfg
+        Ok(cfg)
     }
 
     pub fn from_rust(cfg: &LiteParseConfig) -> Self {
@@ -324,6 +321,17 @@ impl JsLiteParseConfig {
             include_complexity: Some(cfg.include_complexity),
             extract_vector_graphics: Some(cfg.extract_vector_graphics),
         }
+    }
+}
+
+fn parse_output_format(value: &str) -> Result<OutputFormat> {
+    match value {
+        "json" => Ok(OutputFormat::Json),
+        "text" => Ok(OutputFormat::Text),
+        "markdown" | "md" => Ok(OutputFormat::Markdown),
+        _ => Err(Error::from_reason(format!(
+            "invalid outputFormat: {value} (expected 'json', 'text', or 'markdown')"
+        ))),
     }
 }
 
@@ -1384,7 +1392,23 @@ mod tests {
         let mut js = JsLiteParseConfig::from_rust(&LiteParseConfig::default());
         assert_eq!(js.extract_text_metadata, Some(false));
         js.extract_text_metadata = Some(true);
-        assert!(js.into_rust().extract_text_metadata);
+        assert!(js.into_rust().unwrap().extract_text_metadata);
+    }
+
+    #[test]
+    fn output_format_rejects_invalid_values() {
+        assert_eq!(parse_output_format("json").unwrap(), OutputFormat::Json);
+        assert_eq!(parse_output_format("text").unwrap(), OutputFormat::Text);
+        assert_eq!(
+            parse_output_format("markdown").unwrap(),
+            OutputFormat::Markdown
+        );
+        assert_eq!(parse_output_format("md").unwrap(), OutputFormat::Markdown);
+
+        let mut config = JsLiteParseConfig::from_rust(&LiteParseConfig::default());
+        config.output_format = Some("yaml".to_string());
+        let error = config.into_rust().unwrap_err();
+        assert!(error.reason.contains("invalid outputFormat: yaml"));
     }
 
     #[test]

--- a/crates/liteparse-python/src/lib.rs
+++ b/crates/liteparse-python/src/lib.rs
@@ -8,6 +8,17 @@ use liteparse::types::PdfInput;
 
 mod cli;
 
+fn parse_output_format(value: &str) -> PyResult<OutputFormat> {
+    match value {
+        "json" => Ok(OutputFormat::Json),
+        "text" => Ok(OutputFormat::Text),
+        "markdown" | "md" => Ok(OutputFormat::Markdown),
+        _ => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+            "invalid output_format: {value} (expected 'json', 'text', or 'markdown')"
+        ))),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Python type wrappers
 // ---------------------------------------------------------------------------
@@ -1534,11 +1545,7 @@ impl LiteParse {
             cfg.dpi = v;
         }
         if let Some(v) = output_format {
-            cfg.output_format = match v.as_str() {
-                "text" => OutputFormat::Text,
-                "markdown" | "md" => OutputFormat::Markdown,
-                _ => OutputFormat::Json,
-            };
+            cfg.output_format = parse_output_format(&v)?;
         }
         if let Some(v) = preserve_very_small_text {
             cfg.preserve_very_small_text = v;
@@ -1953,6 +1960,20 @@ mod tests {
         };
         let py = PyLiteParseConfig::from_rust(&config);
         assert!(py.extract_text_metadata);
+    }
+
+    #[test]
+    fn output_format_rejects_invalid_values() {
+        assert_eq!(parse_output_format("json").unwrap(), OutputFormat::Json);
+        assert_eq!(parse_output_format("text").unwrap(), OutputFormat::Text);
+        assert_eq!(
+            parse_output_format("markdown").unwrap(),
+            OutputFormat::Markdown
+        );
+        assert_eq!(parse_output_format("md").unwrap(), OutputFormat::Markdown);
+
+        let error = parse_output_format("yaml").unwrap_err();
+        assert!(error.to_string().contains("invalid output_format: yaml"));
     }
 
     #[test]

--- a/packages/node/tests/exports.test.mjs
+++ b/packages/node/tests/exports.test.mjs
@@ -83,6 +83,15 @@ test("CJS: require by package name loads the native module and parses", async ()
   assert.ok(result.text.length > 0, "expected non-empty extracted text");
 });
 
+test("rejects an invalid outputFormat", async () => {
+  const { LiteParse } = await import(PACKAGE_NAME);
+
+  assert.throws(
+    () => new LiteParse({ outputFormat: "yaml" }),
+    /invalid outputFormat: yaml/,
+  );
+});
+
 // The native .node binary is located relative to the built file's own path.
 // Loading from a working directory outside the package, via an entry script
 // that cannot resolve the package by name, is the case that catches a loader

--- a/packages/python/tests/test_parse_e2e.py
+++ b/packages/python/tests/test_parse_e2e.py
@@ -106,6 +106,10 @@ class TestParsedPageStructure:
 class TestParseOptions:
     """Test that CLI options are correctly forwarded."""
 
+    def test_invalid_output_format(self):
+        with pytest.raises(ValueError, match="invalid output_format: yaml"):
+            LiteParse(output_format="yaml")
+
     def test_target_pages(self, parser: LiteParse, invoice_pdf: Path):
         # invoice.pdf has 2 pages — parse only page 1
         result = parser.parse(invoice_pdf, ocr_enabled=False, target_pages="1")


### PR DESCRIPTION
## Summary

Closes #452

- reject unsupported `outputFormat` values in the Node binding
- reject unsupported `output_format` values with `ValueError` in the Python binding
- preserve the existing `json`, `text`, `markdown`, and `md` values
- add native conversion and public API regression coverage

## Problem

The Node and Python bindings silently mapped every unknown output format to JSON. This differed from the WASM binding and meant configuration typos could produce unexpected output without any error.

## Root cause

Both native binding conversions used a wildcard match arm that selected `OutputFormat::Json` for unsupported strings.

## Solution

Make both conversions fallible and return binding-appropriate errors. The Node constructor now propagates the napi error, while Python returns `ValueError` through its existing `PyResult` constructor.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p liteparse-napi -p liteparse-python --all-targets --no-default-features`
- `cargo test -p liteparse-napi --lib --no-default-features` (4 passed)
- `cargo check -p liteparse-python --lib --no-default-features`
- `cargo test -p liteparse --lib --no-default-features parse_from_blocks` (2 passed)
- `npm run build`
- `node --test tests/exports.test.mjs tests/pool.test.mjs` against the locally built addon (16 passed)
- built and installed the Python package with `maturin develop --release`; verified all accepted formats and invalid-format rejection through the public API
